### PR TITLE
Always clear sky/depth; remove extra SDF bins

### DIFF
--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -63,38 +63,6 @@ path = "rc_benchmark.rs"
 name = "sdf_demo"
 path = "sdf_demo.rs"
 
-[[bin]]
-name = "sdf_move"
-path = "sdf_move.rs"
-
-[[bin]]
-name = "sdf_pulse"
-path = "sdf_pulse.rs"
-
-[[bin]]
-name = "sdf_morph"
-path = "sdf_morph.rs"
-
-[[bin]]
-name = "sdf_boolean"
-path = "sdf_boolean.rs"
-
-[[bin]]
-name = "sdf_blend"
-path = "sdf_blend.rs"
-
-[[bin]]
-name = "sdf_grid"
-path = "sdf_grid.rs"
-
-[[bin]]
-name = "sdf_multi"
-path = "sdf_multi.rs"
-
-[[bin]]
-name = "sdf_terrain"
-path = "sdf_terrain.rs"
-
 [dependencies]
 helio-render-v2 = { path = "../helio-render-v2" }
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/helio-render-v2/src/passes/depth_prepass.rs
+++ b/crates/helio-render-v2/src/passes/depth_prepass.rs
@@ -41,15 +41,14 @@ impl RenderPass for DepthPrepassPass {
     }
 
     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
+        // Always clear the depth buffer to 1.0, even when there are no mesh
+        // draw calls.  Other passes (e.g. SDF ray march) load the depth buffer
+        // with CompareFunction::Less and depend on a clean far-plane value.
         let indirect_buf = self.shared_indirect.lock().unwrap().clone();
-        let Some(indirect_buf) = indirect_buf else { return Ok(()); };
-
-        let draw_count = {
+        let draw_count = indirect_buf.as_ref().map(|_| {
             let ranges = self.shared_material_ranges.lock().unwrap();
-            if ranges.is_empty() { return Ok(()); }
             ranges.iter().map(|r| r.count).sum::<u32>()
-        };
-        if draw_count == 0 { return Ok(()); }
+        }).unwrap_or(0);
 
         let mut pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label: Some("Depth Prepass"),
@@ -67,19 +66,23 @@ impl RenderPass for DepthPrepassPass {
             multiview_mask: None,
         });
 
-        pass.set_pipeline(&self.pipeline);
-        pass.set_bind_group(0, ctx.global_bind_group, &[]);
-        pass.set_bind_group(1, Some(self.default_material_bg.as_ref()), &[]);
-        pass.set_bind_group(2, ctx.lighting_bind_group, &[]);
-        let vb = self.pool_vertex_buffer.lock().unwrap().clone();
-        let ib = self.pool_index_buffer .lock().unwrap().clone();
-        pass.set_vertex_buffer(0, vb.slice(..));
-        pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
-        if self.has_multi_draw {
-            pass.multi_draw_indexed_indirect(&indirect_buf, 0, draw_count);
-        } else {
-            for j in 0..draw_count {
-                pass.draw_indexed_indirect(&indirect_buf, j as u64 * 20);
+        if let Some(indirect_buf) = &indirect_buf {
+            if draw_count > 0 {
+                pass.set_pipeline(&self.pipeline);
+                pass.set_bind_group(0, ctx.global_bind_group, &[]);
+                pass.set_bind_group(1, Some(self.default_material_bg.as_ref()), &[]);
+                pass.set_bind_group(2, ctx.lighting_bind_group, &[]);
+                let vb = self.pool_vertex_buffer.lock().unwrap().clone();
+                let ib = self.pool_index_buffer .lock().unwrap().clone();
+                pass.set_vertex_buffer(0, vb.slice(..));
+                pass.set_index_buffer(ib.slice(..), wgpu::IndexFormat::Uint32);
+                if self.has_multi_draw {
+                    pass.multi_draw_indexed_indirect(indirect_buf, 0, draw_count);
+                } else {
+                    for j in 0..draw_count {
+                        pass.draw_indexed_indirect(indirect_buf, j as u64 * 20);
+                    }
+                }
             }
         }
         Ok(())

--- a/crates/helio-render-v2/src/passes/sky.rs
+++ b/crates/helio-render-v2/src/passes/sky.rs
@@ -35,19 +35,37 @@ impl RenderPass for SkyPass {
     }
 
     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
-        // Skip entirely when no atmosphere is configured this frame
-        if !ctx.has_sky { return Ok(()); }
+        let clear_color = wgpu::Color {
+            r: ctx.sky_color[0] as f64,
+            g: ctx.sky_color[1] as f64,
+            b: ctx.sky_color[2] as f64,
+            a: 1.0,
+        };
 
         let color_attachment = Some(wgpu::RenderPassColorAttachment {
             view:           ctx.target,
             resolve_target: None,
             depth_slice:    None,
             ops: wgpu::Operations {
-                // Sky IS the clear – we write every pixel
-                load:  wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                // Always clear the color target — even without an atmosphere,
+                // downstream passes use LoadOp::Load and expect a cleared surface.
+                load:  wgpu::LoadOp::Clear(clear_color),
                 store: wgpu::StoreOp::Store,
             },
         });
+
+        // When no atmosphere is configured, just clear and return (no sky draw).
+        if !ctx.has_sky {
+            let _pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label:                    Some("Sky Clear"),
+                color_attachments:        &[color_attachment],
+                depth_stencil_attachment: None,
+                timestamp_writes:         None,
+                occlusion_query_set:      None,
+                multiview_mask:           None,
+            });
+            return Ok(());
+        }
 
         let mut pass = ctx.encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
             label:                    Some("Sky Pass"),

--- a/crates/helio-wasm-examples/src/examples/sdf_demo.rs
+++ b/crates/helio-wasm-examples/src/examples/sdf_demo.rs
@@ -7,7 +7,7 @@ use helio_render_v2::features::{
     LightingFeature, BloomFeature, ShadowsFeature,
     BillboardsFeature, BillboardInstance,
     RadianceCascadesFeature,
-    SdfFeature, SdfMode, SdfEdit, SdfShapeType, SdfShapeParams, BooleanOp,
+    SdfFeature, SdfEdit, SdfShapeType, SdfShapeParams, BooleanOp,
     TerrainConfig,
 };
 
@@ -23,7 +23,6 @@ impl WasmScene for SdfDemo {
         let (sprite_rgba, sprite_w, sprite_h) = load_sprite();
 
         let mut sdf = SdfFeature::new()
-            .with_mode(SdfMode::ClipMap)
             .with_grid_dim(128)
             .with_volume_bounds([-3.0, -1.0, -3.0], [3.0, 3.0, 3.0])
             .with_terrain(TerrainConfig::rolling());

--- a/crates/helio-wasm-examples/src/sdf_common.rs
+++ b/crates/helio-wasm-examples/src/sdf_common.rs
@@ -11,7 +11,7 @@ use helio_render_v2::features::{
     LightingFeature, BloomFeature, ShadowsFeature,
     BillboardsFeature, BillboardInstance,
     RadianceCascadesFeature,
-    SdfFeature, SdfMode,
+    SdfFeature,
 };
 
 use crate::harness::{WasmScene, load_sprite};
@@ -35,7 +35,6 @@ pub struct SdfScene<U: SdfUpdater> {
 impl<U: SdfUpdater> SdfScene<U> {
     pub fn new(mut updater: U) -> Self {
         let mut sdf = SdfFeature::new()
-            .with_mode(SdfMode::ClipMap)
             .with_grid_dim(128)
             .with_volume_bounds([-3.0, -1.0, -3.0], [3.0, 3.0, 3.0]);
         updater.init(&mut sdf);


### PR DESCRIPTION
Remove unused example binaries from crates/examples/Cargo.toml. Ensure the depth prepass always clears the depth buffer (far plane = 1.0) and only issues draw calls when an indirect buffer and non-zero draw count are present. Change sky pass to always clear the color target using ctx.sky_color; if no atmosphere is configured, perform a clear-only pass and return. Remove SdfMode usage/imports and .with_mode(...) calls from wasm SDF examples (simplifies SDF feature initialization). These changes ensure downstream passes see a deterministic cleared surface/depth and tighten example configuration.