### PR TITLE
Update transparent tests

### DIFF
--- a/crates/helio-pass-transparent/tests/transparent_tests.rs
+++ b/crates/helio-pass-transparent/tests/transparent_tests.rs
@@ -121,14 +121,15 @@ fn blend_result_stays_in_0_1_for_valid_inputs() {
 }
 
 #[test]
-fn blend_commutative_when_alpha_0_dot_5() {
-    // Over is NOT commutative; verify different order gives different result
-    let a = [1.0f32, 0.0, 0.0, 0.5]; // red
-    let b = [0.0f32, 0.0, 1.0, 0.5]; // blue
+fn blend_not_commutative_for_different_alpha() {
+    // Over is NOT commutative in general; choose different source alpha values.
+    let a = [1.0f32, 0.0, 0.0, 0.5]; // red, 50% alpha
+    let b = [0.0f32, 0.0, 1.0, 0.25]; // blue, 25% alpha
     let ab = blend_over(a, [b[0], b[1], b[2]]);
     let ba = blend_over(b, [a[0], a[1], a[2]]);
-    // Red channel should differ: a-over-b vs b-over-a
-    assert!((ab[0] - ba[0]).abs() > 0.1f32, "blend should be order-dependent");
+    // Color channels should differ due asymmetric alpha.
+    assert!((ab[0] - ba[0]).abs() > 0.1f32, "red channel should differ for order-dependent blend");
+    assert!((ab[2] - ba[2]).abs() > 0.1f32, "blue channel should differ for order-dependent blend");
 }
 
 #[test]


### PR DESCRIPTION
This pull request updates the test for the commutativity of the `blend_over` function in `transparent_tests.rs`. The revised test now uses source colors with different alpha values to more accurately demonstrate that the blending operation is not commutative in general, and it expands the assertions to check both the red and blue channels for order dependence.

Test improvements:

* Renamed the test from `blend_commutative_when_alpha_0_dot_5` to `blend_not_commutative_for_different_alpha` to clarify its purpose and updated the test to use source colors with different alpha values (0.5 and 0.25) instead of both being 0.5.
* Enhanced the assertions to check that both the red and blue channels differ when blending in different orders, reflecting the non-commutative nature of the operation for different alpha values.