### PR TITLE
Overhaul renderer implementation in v4

### DIFF
--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -92,11 +92,7 @@ impl VirtualGeometryPass {
                         &format!("binding_array<sampler, {MAX_TEXTURES}>"),
                     );
                 #[cfg(target_arch = "wasm32")]
-                let s = {
-                    let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
-                    s.replace("enable wgpu_binding_array;\n", "")
-                     .replace("enable wgpu_binding_array;\r\n", "")
-                };
+                let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
                 s.into()
             }),
         });

--- a/crates/helio-voxel-core/src/octree.rs
+++ b/crates/helio-voxel-core/src/octree.rs
@@ -1,4 +1,37 @@
 use crate::constants::*;
+use std::fmt;
+
+/// Six complete octree subdivisions produce 8^6 = 262,144 terminal bricks,
+/// exactly the existing per-volume brick limit. A deeper complete tree cannot
+/// be represented by the retained voxel path's GPU budget.
+pub const MAX_OCTREE_DEPTH: u32 = max_complete_depth(MAX_BRICKS_PER_VOLUME);
+
+const fn max_complete_depth(mut leaf_budget: u32) -> u32 {
+    let mut depth = 0;
+    while leaf_budget >= 8 {
+        leaf_budget /= 8;
+        depth += 1;
+    }
+    depth
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OctreeDepthError {
+    pub requested: u32,
+    pub maximum: u32,
+}
+
+impl fmt::Display for OctreeDepthError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "requested voxel octree depth {} exceeds the supported maximum {}",
+            self.requested, self.maximum
+        )
+    }
+}
+
+impl std::error::Error for OctreeDepthError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeState {
@@ -62,7 +95,7 @@ impl OctreeNode {
             (self.aabb_min[2] + self.aabb_max[2]) * 0.5,
         ];
         let mut children: [Option<Box<OctreeNode>>; 8] = Default::default();
-        for i in 0..8 {
+        for (i, child) in children.iter_mut().enumerate() {
             let (lx, ly, lz) = ((i & 1) != 0, (i & 2) != 0, (i & 4) != 0);
             let min = [
                 if lx { mid[0] } else { self.aabb_min[0] },
@@ -74,31 +107,27 @@ impl OctreeNode {
                 if ly { self.aabb_max[1] } else { mid[1] },
                 if lz { self.aabb_max[2] } else { mid[2] },
             ];
-            children[i] = Some(Box::new(OctreeNode::new_empty(min, max)));
+            *child = Some(Box::new(OctreeNode::new_empty(min, max)));
         }
         self.children = Some(Box::new(children));
         self.state = NodeState::Branch;
     }
 
     pub fn collect_leaves<'a>(&'a self, leaves: &mut Vec<&'a OctreeNode>) {
-        match self.state {
-            NodeState::Leaf => leaves.push(self),
-            NodeState::Branch => {
-                if let Some(ref children) = self.children {
-                    for child in children.iter().flatten() {
-                        child.collect_leaves(leaves);
-                    }
-                }
+        if let Some(ref children) = self.children {
+            for child in children.iter().flatten() {
+                child.collect_leaves(leaves);
             }
-            _ => {}
+        } else {
+            // "Leaf" here is structural: constant Empty/Solid regions and
+            // allocated GPU Leaf nodes are all terminal octree nodes.
+            leaves.push(self);
         }
     }
 
     pub fn collect_dirty_leaves<'a>(&'a self, leaves: &mut Vec<&'a OctreeNode>) {
-        if self.dirty {
-            if matches!(self.state, NodeState::Leaf) {
-                leaves.push(self);
-            }
+        if self.dirty && matches!(self.state, NodeState::Leaf) {
+            leaves.push(self);
         }
         if let Some(ref children) = self.children {
             for child in children.iter().flatten() {
@@ -131,11 +160,45 @@ impl OctreeNode {
                     for child in children.iter_mut().flatten() {
                         any |= child.mark_sphere_dirty(center, radius);
                     }
-                    if any { self.dirty = true; }
+                    if any {
+                        self.dirty = true;
+                    }
                     any
-                } else { false }
+                } else {
+                    false
+                }
             }
             NodeState::Empty | NodeState::Solid(_) => false,
+        }
+    }
+
+    pub fn node_count(&self) -> usize {
+        1 + self
+            .children
+            .iter()
+            .flat_map(|children| children.iter().flatten())
+            .map(|child| child.node_count())
+            .sum::<usize>()
+    }
+
+    fn ensure_empty_depth(&mut self, remaining_depth: u32) {
+        if remaining_depth == 0 {
+            return;
+        }
+
+        match self.state {
+            NodeState::Empty => self.subdivide(),
+            NodeState::Branch => {}
+            // Constant solid regions and materialized GPU leaves are already
+            // valid sparse terminals. Expanding them as Empty would destroy
+            // terrain or discard their GPU slot.
+            NodeState::Solid(_) | NodeState::Leaf => return,
+        }
+
+        if let Some(children) = self.children.as_mut() {
+            for child in children.iter_mut().flatten() {
+                child.ensure_empty_depth(remaining_depth - 1);
+            }
         }
     }
 }
@@ -160,7 +223,18 @@ impl VoxelOctree {
     }
 
     pub fn needed_depth(world_size: f32, voxel_size: f32, brick_size: u32) -> u32 {
+        if !world_size.is_finite()
+            || !voxel_size.is_finite()
+            || world_size <= 0.0
+            || voxel_size <= 0.0
+            || brick_size == 0
+        {
+            return 0;
+        }
         let brick_world = brick_size as f32 * voxel_size;
+        if !brick_world.is_finite() || world_size <= brick_world {
+            return 0;
+        }
         let mut depth = 0;
         let mut size = world_size;
         while size > brick_world {
@@ -170,17 +244,33 @@ impl VoxelOctree {
         depth
     }
 
+    /// Ensure `target_depth` subdivision levels below the root.
+    ///
+    /// The retained voxel path can represent at most `MAX_OCTREE_DEPTH`
+    /// complete levels. Call [`Self::try_ensure_depth`] when the requested
+    /// depth is derived from untrusted or runtime data.
     pub fn ensure_depth(&mut self, target_depth: u32) {
-        while self.level_count < target_depth {
-            self.subdivide_root();
-        }
+        self.try_ensure_depth(target_depth)
+            .unwrap_or_else(|error| panic!("{error}"));
     }
 
-    fn subdivide_root(&mut self) {
-        if !matches!(self.root.state, NodeState::Branch) {
-            self.root.subdivide();
-            self.level_count += 1;
+    pub fn try_ensure_depth(&mut self, target_depth: u32) -> Result<(), OctreeDepthError> {
+        if target_depth > MAX_OCTREE_DEPTH {
+            return Err(OctreeDepthError {
+                requested: target_depth,
+                maximum: MAX_OCTREE_DEPTH,
+            });
         }
+        let current_depth = self.level_count.saturating_sub(1);
+        if target_depth > current_depth {
+            self.root.ensure_empty_depth(target_depth);
+            self.level_count = target_depth + 1;
+        }
+        Ok(())
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.root.node_count()
     }
 }
 
@@ -190,17 +280,20 @@ mod tests {
 
     #[test]
     fn test_octree_basic() {
-        let mut octree = VoxelOctree::new(1.0, 256.0);
+        let octree = VoxelOctree::new(1.0, 256.0);
         assert_eq!(octree.level_count, 1);
         assert!(matches!(octree.root.state, NodeState::Empty));
+        assert_eq!(octree.node_count(), 1);
     }
 
     #[test]
-    fn test_subdivide() {
-        let mut octree = VoxelOctree::new(1.0, 256.0);
-        octree.ensure_depth(4);
-        assert!(octree.level_count >= 4);
-        assert!(matches!(octree.root.state, NodeState::Branch));
+    fn needed_depth_is_exact_and_rejects_invalid_sizes_without_looping() {
+        assert_eq!(VoxelOctree::needed_depth(256.0, 1.0, 8), 5);
+        assert_eq!(VoxelOctree::needed_depth(8.0, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(7.0, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(f32::INFINITY, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(256.0, -1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(256.0, 1.0, 0), 0);
     }
 
     #[test]
@@ -215,10 +308,73 @@ mod tests {
 
     #[test]
     fn test_collect_leaves() {
+        for depth in 0..=4 {
+            let mut octree = VoxelOctree::new(1.0, 256.0);
+            octree.ensure_depth(depth);
+            let mut leaves = vec![];
+            octree.root.collect_leaves(&mut leaves);
+            assert_eq!(leaves.len(), 8_usize.pow(depth));
+            assert_eq!(octree.level_count, depth + 1);
+        }
+    }
+
+    #[test]
+    fn ensure_depth_is_idempotent() {
         let mut octree = VoxelOctree::new(1.0, 256.0);
         octree.ensure_depth(3);
-        let mut leaves = vec![];
-        octree.root.collect_leaves(&mut leaves);
-        assert_eq!(leaves.len(), 512);
+        let node_count = octree.node_count();
+        octree.ensure_depth(3);
+        octree.ensure_depth(2);
+        assert_eq!(octree.node_count(), node_count);
+        assert_eq!(octree.level_count, 4);
+    }
+
+    #[test]
+    fn ensure_depth_preserves_sparse_solid_and_gpu_leaf_terminals() {
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        octree.root.subdivide();
+        let children = octree.root.children.as_mut().unwrap();
+        children[0] = Some(Box::new(OctreeNode::new_solid(7, [-128.0; 3], [0.0; 3])));
+        children[1] = Some(Box::new(OctreeNode::new_leaf(
+            42,
+            [0.0, -128.0, -128.0],
+            [128.0, 0.0, 0.0],
+        )));
+
+        octree.try_ensure_depth(3).unwrap();
+
+        let children = octree.root.children.as_ref().unwrap();
+        assert!(matches!(
+            children[0].as_deref().unwrap().state,
+            NodeState::Solid(7)
+        ));
+        assert!(children[0].as_deref().unwrap().children.is_none());
+        assert!(matches!(
+            children[1].as_deref().unwrap().state,
+            NodeState::Leaf
+        ));
+        assert_eq!(children[1].as_deref().unwrap().gpu_slot, 42);
+        assert!(children[1].as_deref().unwrap().children.is_none());
+    }
+
+    #[test]
+    fn checked_depth_rejects_exponential_over_budget_growth() {
+        assert_eq!(8_u32.pow(MAX_OCTREE_DEPTH), MAX_BRICKS_PER_VOLUME);
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        assert_eq!(
+            octree.try_ensure_depth(MAX_OCTREE_DEPTH + 1),
+            Err(OctreeDepthError {
+                requested: MAX_OCTREE_DEPTH + 1,
+                maximum: MAX_OCTREE_DEPTH,
+            })
+        );
+        assert_eq!(octree.node_count(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the supported maximum")]
+    fn compatibility_depth_api_panics_before_over_budget_allocation() {
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        octree.ensure_depth(MAX_OCTREE_DEPTH + 1);
     }
 }

--- a/crates/helio/src/scene/lifecycle.rs
+++ b/crates/helio/src/scene/lifecycle.rs
@@ -295,7 +295,7 @@ mod tests {
 
     fn create_test_device() -> (std::sync::Arc<wgpu::Device>, std::sync::Arc<wgpu::Queue>) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::BROWSER_WEBGPU,
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/helio/src/scene/virtual_geometry/objects.rs
+++ b/crates/helio/src/scene/virtual_geometry/objects.rs
@@ -233,7 +233,7 @@ mod tests {
 
     fn create_test_scene() -> Scene {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::BROWSER_WEBGPU,
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/libhelio/src/shader.rs
+++ b/crates/libhelio/src/shader.rs
@@ -2,7 +2,8 @@
 ///
 /// Browser WebGPU does not expose wgpu's `binding_array` WGSL extension. The
 /// fixed bindings and switch preserve every material texture slot without
-/// requiring a native-only feature.
+/// requiring a native-only feature. The native-only extension directive is
+/// removed together with the binding-array declarations.
 pub fn apply_webgpu_material_bindings(src: &str, max_textures: usize) -> String {
     let mut declarations = String::new();
     for index in 0..max_textures {
@@ -20,7 +21,9 @@ pub fn apply_webgpu_material_bindings(src: &str, max_textures: usize) -> String 
 
     let mut source = String::with_capacity(src.len() + declarations.len());
     for line in src.lines() {
-        if line.contains("scene_textures:") && line.contains("binding_array<texture_2d") {
+        if line.trim() == "enable wgpu_binding_array;" {
+            // The rewritten shader no longer uses this native-only extension.
+        } else if line.contains("scene_textures:") && line.contains("binding_array<texture_2d") {
             source.push_str(&declarations);
         } else if line.contains("scene_samplers:") && line.contains("binding_array<sampler") {
             // Both binding tables were emitted in place of scene_textures.
@@ -51,6 +54,7 @@ mod tests {
     #[test]
     fn expands_material_binding_arrays() {
         let source = r#"
+enable wgpu_binding_array;
 @group(1) @binding(2) var scene_textures: binding_array<texture_2d<f32>, 2>;
 @group(1) @binding(3) var scene_samplers: binding_array<sampler, 2>;
 fn sample_texture(slot: MaterialTextureSlot, uv: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {


### PR DESCRIPTION
This pull request refactors the workspace and example projects to use a new `helio-core` and `helio-default-graphs` structure, and updates all example applications to use a unified render graph construction flow. It also simplifies the workspace configuration and cleans up deprecated code.

**Workspace and crate structure:**
* The workspace member list in `Cargo.toml` is replaced with a glob pattern (`crates/*`), simplifying crate management and making it easier to add or remove crates. (`[Cargo.tomlL3-R3](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3)`)
* All references to `helio-v3` are replaced with `helio-core`, and `helio-default-graphs` is introduced as a new dependency for constructing render graphs. (`[[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L77-R30)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R166)`)

**Examples and render graph initialization:**
* All example applications are updated to use the new `build_default_graph` function from `helio_default_graphs`, and to explicitly create and pass `Scene`, `DebugDrawState`, debug camera and cull stats buffers, and the render graph to the `Renderer::new` constructor. This unifies and modernizes renderer initialization. (`[[1]](diffhunk://#diff-5f8095f8015965bf93b4f7e7d9df8a0521c8e9bcab21332e75f26915020a52c5L14-R15)`, `[[2]](diffhunk://#diff-5f8095f8015965bf93b4f7e7d9df8a0521c8e9bcab21332e75f26915020a52c5L126-R147)`, `[[3]](diffhunk://#diff-385674391bd4311c94696d33dc7c51dd93efe707df118e2dbe5d7b654fc25f77L22-R25)`, `[[4]](diffhunk://#diff-385674391bd4311c94696d33dc7c51dd93efe707df118e2dbe5d7b654fc25f77L233-R253)`, `[[5]](diffhunk://#diff-1cb7b9f07b7c816a48ffcb919811b2e527c5623047bf6a86dcb2bce7c92d6884L14-R15)`, `[[6]](diffhunk://#diff-1cb7b9f07b7c816a48ffcb919811b2e527c5623047bf6a86dcb2bce7c92d6884R116-R135)`, `[[7]](diffhunk://#diff-21c8f2a4d3da1b124b726b3072ae8232599048cfd96bbf63e4e505bef7a3b204L30-R33)`, `[[8]](diffhunk://#diff-21c8f2a4d3da1b124b726b3072ae8232599048cfd96bbf63e4e505bef7a3b204R162-R181)`, `[[9]](diffhunk://#diff-efc4fd2d9c701b506dc2ab01e26866e25c0c714d5174704b35b4145306dfcc29L30-R34)`, `[[10]](diffhunk://#diff-efc4fd2d9c701b506dc2ab01e26866e25c0c714d5174704b35b4145306dfcc29R161-R181)`, `[[11]](diffhunk://#diff-f97cb9ff1168f29751df779023721531e4934ed50721f122ff4a2cce5bce4cdfL26-R28)`, `[[12]](diffhunk://#diff-f97cb9ff1168f29751df779023721531e4934ed50721f122ff4a2cce5bce4cdfR219-R239)`, `[[13]](diffhunk://#diff-7de04b043674761f48a225b5ea711d93da270b4a91741047de0875d68e46a903L23-R27)`)
* The `README.md` and crate documentation are updated to reflect the new API and crate names, ensuring that users see up-to-date usage examples and crate structure. (`[[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L72-R106)`, `[[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L140-R166)`)

**Cleanup:**
* Removes the deprecated `enable_live_dashboard` helper from `demo_portal.rs`, as the live performance dashboard feature has been removed. (`[crates/examples/demo_portal.rsL1-L4](diffhunk://#diff-acc25f6b195b611c94e6793e969613fdce00a08349993861ddde9d98c3aa73e5L1-L4)`)

**Dependency updates:**
* Updates dependencies in examples to use the new `helio-default-graphs` crate where appropriate. (`[crates/examples/Cargo.tomlR164](diffhunk://#diff-04d80c541556b06d72062686dc56a02b82e82be07ea2805106a63412b58ba14fR164)`)

These changes modernize the project structure, simplify example initialization, and prepare the codebase for further development with the new render graph and core crate architecture.