### PR TITLE
Repair meshlet construction and culling for production use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2104,6 +2104,7 @@ dependencies = [
  "helio-pass-perf-overlay",
  "helio-pass-postprocess",
  "helio-pass-taa",
+ "helio-pass-virtual-geometry",
  "helio-pass-voxel-mesh",
  "helio-pass-voxel-raymarch",
  "helio-voxel-core",

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -140,6 +140,10 @@ name = "editor_demo_mini"
 path = "editor_demo_mini.rs"
 
 [[bin]]
+name = "meshlet_cull_benchmark"
+path = "meshlet_cull_benchmark.rs"
+
+[[bin]]
 name = "corona_demo"
 path = "corona_demo.rs"
 

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -176,6 +176,7 @@ helio-pass-perf-overlay = { path = "../helio-pass-perf-overlay" }
 helio-pass-postprocess = { path = "../helio-pass-postprocess" }
 helio-pass-voxel-raymarch = { path = "../helio-pass-voxel-raymarch" }
 helio-pass-voxel-mesh = { path = "../helio-pass-voxel-mesh" }
+helio-pass-virtual-geometry = { path = "../helio-pass-virtual-geometry" }
 helio-voxel-core = { path = "../helio-voxel-core" }
 helio-default-graphs = { path = "../helio-default-graphs" }
 rapier3d = "0.24"

--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -90,7 +90,9 @@ struct AppState {
     is_fullscreen: bool,
     /// Index into the debug views list (0 = off).
     debug_view_index: usize,
+    active_debug_mode: u32,
     debug_overlay_enabled: bool,
+    debug_overlay: Arc<std::sync::Mutex<helio_pass_debug_overlay::DebugOverlayState>>,
 }
 
 impl ApplicationHandler for App {
@@ -777,7 +779,9 @@ impl ApplicationHandler for App {
             grid_enabled: true,
             is_fullscreen: false,
             debug_view_index: 0,
+            active_debug_mode: 0,
             debug_overlay_enabled: false,
+            debug_overlay,
         });
     }
 
@@ -881,11 +885,11 @@ impl ApplicationHandler for App {
                             } else {
                                 state.debug_view_index = (state.debug_view_index + 1) % (views.len() + 1);
                                 if state.debug_view_index == 0 {
-                                    state.renderer.set_debug_mode(0);
+                                    state.apply_debug_mode(0);
                                     eprintln!("[debug] Debug view: OFF");
                                 } else {
                                     let view = &views[state.debug_view_index - 1];
-                                    state.renderer.set_debug_mode(view.debug_mode);
+                                    state.apply_debug_mode(view.debug_mode);
                                     eprintln!("[debug] Debug view: {} — {}", view.name, view.description);
                                 }
                             }
@@ -901,11 +905,11 @@ impl ApplicationHandler for App {
                                     state.debug_view_index -= 1;
                                 }
                                 if state.debug_view_index == 0 {
-                                    state.renderer.set_debug_mode(0);
+                                    state.apply_debug_mode(0);
                                     eprintln!("[debug] Debug view: OFF");
                                 } else {
                                     let view = &views[state.debug_view_index - 1];
-                                    state.renderer.set_debug_mode(view.debug_mode);
+                                    state.apply_debug_mode(view.debug_mode);
                                     eprintln!("[debug] Debug view: {} — {}", view.name, view.description);
                                 }
                             }
@@ -913,7 +917,7 @@ impl ApplicationHandler for App {
                         KeyCode::F2 | KeyCode::F5 => {
                             state.debug_overlay_enabled = !state.debug_overlay_enabled;
                             if let Some(pass) = state.renderer.find_pass_mut::<helio_pass_debug_overlay::DebugOverlayPass>() {
-                                pass.set_enabled(state.debug_overlay_enabled);
+                                pass.set_enabled(state.debug_overlay_enabled || state.active_debug_mode == 21);
                             }
                         }
                         KeyCode::KeyL if !state.right_mouse_held => {
@@ -1031,6 +1035,45 @@ impl ApplicationHandler for App {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl AppState {
+    fn apply_debug_mode(&mut self, mode: u32) {
+        const LOD_COLORS: [[f32; 3]; 8] = [
+            [0.10, 0.95, 0.10],
+            [0.50, 0.95, 0.10],
+            [0.85, 0.90, 0.10],
+            [1.00, 0.70, 0.10],
+            [1.00, 0.45, 0.05],
+            [1.00, 0.25, 0.05],
+            [0.90, 0.10, 0.05],
+            [0.60, 0.05, 0.30],
+        ];
+
+        self.active_debug_mode = mode;
+        self.renderer.set_debug_mode(mode);
+
+        let show_lod_legend = mode == 21;
+        {
+            let mut overlay = self.debug_overlay.lock().unwrap();
+            overlay.populate = show_lod_legend.then(|| {
+                Box::new(|overlay: &mut helio_pass_debug_overlay::DebugOverlayState| {
+                    overlay.write_text(0, 2, "VG LOD HEATMAP");
+                    for (lod, color) in LOD_COLORS.iter().enumerate() {
+                        let x = 8.0 + lod as f32 * 68.0;
+                        overlay.add_bar(x, 76.0, 20.0, 14.0, color[0], color[1], color[2], 1.0);
+                        overlay.write_small((x / 8.0) as u32 + 3, 6, &format!("LOD{lod}"));
+                    }
+                    overlay.write_text(0, 5, "LOD0 = full detail                     LOD7 = coarsest");
+                }) as Box<dyn Fn(&mut helio_pass_debug_overlay::DebugOverlayState) + Send + Sync>
+            });
+        }
+
+        if let Some(pass) = self
+            .renderer
+            .find_pass_mut::<helio_pass_debug_overlay::DebugOverlayPass>()
+        {
+            pass.set_enabled(self.debug_overlay_enabled || show_lod_legend);
+        }
+    }
+
     fn build_ray(&self) -> (glam::Vec3, glam::Vec3) {
         let sz = self.window.inner_size();
         let width = sz.width as f32;

--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -33,6 +33,7 @@ use helio::{
 };
 use helio_default_graphs::{build_default_graph, build_fxaa_graph};
 use helio_asset_compat::{load_scene_bytes_with_config, upload_scene_materials, LoadConfig};
+use helio_pass_virtual_geometry::{VirtualGeometryDebugStats, VirtualGeometryPass};
 use v3_demo_common::{
     box_mesh, insert_object_with_movability, make_material, plane_mesh, point_light, sphere_mesh,
 };
@@ -93,6 +94,7 @@ struct AppState {
     active_debug_mode: u32,
     debug_overlay_enabled: bool,
     debug_overlay: Arc<std::sync::Mutex<helio_pass_debug_overlay::DebugOverlayState>>,
+    lod_debug_stats: Arc<std::sync::Mutex<VirtualGeometryDebugStats>>,
 }
 
 impl ApplicationHandler for App {
@@ -514,6 +516,35 @@ impl ApplicationHandler for App {
             }
         }
 
+        // ── Radar dome — dense single-material VG LOD validation asset ──
+        // The container is intentionally split by material and many sections
+        // are too small to have eight distinct simplification levels. This
+        // dense dome gives the debug heatmap a truthful deep LOD chain.
+        {
+            let radius = 6.0;
+            let position = glam::Vec3::new(-55.0, 8.0, -42.0);
+            let upload = sphere_mesh([0.0; 3], radius);
+            let virtual_mesh = renderer
+                .scene_mut()
+                .insert_actor(SceneActor::virtual_mesh(VirtualMeshUpload {
+                    vertices: upload.vertices,
+                    indices: upload.indices,
+                }))
+                .as_virtual_mesh()
+                .unwrap();
+            let _ = renderer.scene_mut().insert_actor(SceneActor::virtual_object(
+                VirtualObjectDescriptor {
+                    virtual_mesh,
+                    material_id: mat_steel.slot(),
+                    transform: glam::Mat4::from_translation(position),
+                    bounds: [position.x, position.y, position.z, radius],
+                    flags: 0,
+                    groups: helio::GroupMask::NONE,
+                    movability: Some(helio::Movability::Static),
+                },
+            ));
+        }
+
         // ── Shipping containers — 10 total, using Virtual Geometry ─────
         // Load with merge_meshes so sections share one vertex buffer (correct
         // spatial relationships). Upload the FBX textures+materials, then
@@ -746,6 +777,9 @@ impl ApplicationHandler for App {
         let fxaa_config = RendererConfig::new(sz.width, sz.height, format)
             .with_render_scale(1.0);
         let debug_overlay = helio_pass_debug_overlay::DebugOverlayState::new();
+        let lod_debug_stats = Arc::new(std::sync::Mutex::new(
+            VirtualGeometryDebugStats::default(),
+        ));
         let fxaa_graph = build_fxaa_graph(
             &device,
             &queue,
@@ -782,6 +816,7 @@ impl ApplicationHandler for App {
             active_debug_mode: 0,
             debug_overlay_enabled: false,
             debug_overlay,
+            lod_debug_stats,
         });
     }
 
@@ -1053,15 +1088,41 @@ impl AppState {
         let show_lod_legend = mode == 21;
         {
             let mut overlay = self.debug_overlay.lock().unwrap();
-            overlay.populate = show_lod_legend.then(|| {
-                Box::new(|overlay: &mut helio_pass_debug_overlay::DebugOverlayState| {
+            let shared_stats = Arc::clone(&self.lod_debug_stats);
+            overlay.populate = show_lod_legend.then(move || {
+                Box::new(move |overlay: &mut helio_pass_debug_overlay::DebugOverlayState| {
+                    let stats = *shared_stats.lock().unwrap();
                     overlay.write_text(0, 2, "VG LOD HEATMAP");
+                    if let Some((first, last)) = stats.selected_lod_range() {
+                        overlay.write_text(
+                            0,
+                            3,
+                            &format!(
+                                "GPU objects: {}  selected: LOD{}..LOD{}  asset max: LOD{}",
+                                stats.visible_objects(), first, last, stats.max_available_lod,
+                            ),
+                        );
+                        overlay.write_text(
+                            0,
+                            4,
+                            &format!(
+                                "Meshlets: {} visible  {} rejected",
+                                stats.visible_meshlets, stats.rejected_meshlets,
+                            ),
+                        );
+                    } else {
+                        overlay.write_text(0, 3, "GPU LOD sample pending / no VG objects visible");
+                    }
                     for (lod, color) in LOD_COLORS.iter().enumerate() {
                         let x = 8.0 + lod as f32 * 68.0;
-                        overlay.add_bar(x, 76.0, 20.0, 14.0, color[0], color[1], color[2], 1.0);
-                        overlay.write_small((x / 8.0) as u32 + 3, 6, &format!("LOD{lod}"));
+                        overlay.add_bar(x, 128.0, 20.0, 14.0, color[0], color[1], color[2], 1.0);
+                        overlay.write_small(
+                            (x / 8.0) as u32 + 3,
+                            11,
+                            &format!("L{lod}:{}", stats.lod_object_counts[lod]),
+                        );
                     }
-                    overlay.write_text(0, 5, "LOD0 = full detail                     LOD7 = coarsest");
+                    overlay.write_text(0, 6, "LOD0 = full detail; asset max can be below LOD7");
                 }) as Box<dyn Fn(&mut helio_pass_debug_overlay::DebugOverlayState) + Send + Sync>
             });
         }
@@ -1176,6 +1237,12 @@ impl AppState {
             0.1,
             800.0,
         );
+
+        if self.active_debug_mode == 21 {
+            if let Some(pass) = self.renderer.find_pass::<VirtualGeometryPass>() {
+                *self.lod_debug_stats.lock().unwrap() = pass.debug_stats();
+            }
+        }
 
         self.renderer.debug_clear();
         self.renderer.set_gizmo_camera(&camera, self.renderer.output_height() as f32);

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -1,8 +1,9 @@
 //! Headless virtual-geometry culling benchmark.
 //!
 //! Holds total visible meshlet work constant while changing how that work is
-//! distributed across objects. This exposes occupancy problems in the current
-//! one-workgroup-per-object publication path.
+//! distributed across objects. It also measures pre-rasterization indirect-draw
+//! amplification against one conventional indexed draw and reports the explicit
+//! scheduling/publication memory reserved by both approaches.
 //!
 //! Run with:
 //! `cargo run --release -p examples --bin meshlet_cull_benchmark`
@@ -17,9 +18,22 @@ use std::sync::mpsc;
 use wgpu::util::DeviceExt;
 
 const CULL_SHADER: &str = include_str!("../helio-pass-virtual-geometry/shaders/vg_cull.wgsl");
+const DRAW_BENCH_SHADER: &str = r#"
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> @builtin(position) vec4<f32> {
+    let x = 2.0 + f32(vertex_index) * 0.001;
+    return vec4<f32>(x, 2.0, 0.0, 1.0);
+}
+
+@fragment
+fn fs_main() -> @location(0) vec4<f32> {
+    return vec4<f32>(0.0);
+}
+"#;
 const TOTAL_MESHLETS: u32 = 1_048_576;
 const DEFAULT_WARMUP: u32 = 5;
 const DEFAULT_SAMPLES: u32 = 20;
+const DEFAULT_RENDER_SAMPLES: u32 = 3;
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
@@ -57,6 +71,7 @@ struct Case {
 struct CaseBuffers {
     select_bind_group: wgpu::BindGroup,
     cull_bind_group: wgpu::BindGroup,
+    indirect: wgpu::Buffer,
     draw_count: wgpu::Buffer,
     draw_count_readback: wgpu::Buffer,
     object_dispatch_width: u32,
@@ -87,17 +102,19 @@ async fn run() {
         .await
         .expect("no GPU adapter available");
 
-    let timestamp_features =
-        wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+    let benchmark_features = wgpu::Features::TIMESTAMP_QUERY
+        | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS
+        | wgpu::Features::INDIRECT_FIRST_INSTANCE
+        | wgpu::Features::MULTI_DRAW_INDIRECT_COUNT;
     assert!(
-        adapter.features().contains(timestamp_features),
-        "meshlet benchmark requires encoder timestamp queries"
+        adapter.features().contains(benchmark_features),
+        "meshlet benchmark requires timestamp, indirect-first-instance, and indirect-count support"
     );
     let limits = adapter.limits();
     let (device, queue) = adapter
         .request_device(&wgpu::DeviceDescriptor {
             label: Some("Meshlet Cull Benchmark Device"),
-            required_features: timestamp_features,
+            required_features: benchmark_features,
             required_limits: limits.clone(),
             ..Default::default()
         })
@@ -110,6 +127,7 @@ async fn run() {
     let info = adapter.get_info();
     let warmup = env_u32("HELIO_BENCH_WARMUP", DEFAULT_WARMUP);
     let samples = env_u32("HELIO_BENCH_SAMPLES", DEFAULT_SAMPLES).max(1);
+    let render_samples = env_u32("HELIO_BENCH_RENDER_SAMPLES", DEFAULT_RENDER_SAMPLES).max(1);
     println!("adapter,{},backend,{:?}", info.name, info.backend);
     println!("warmup,{warmup},samples,{samples},total_meshlets,{TOTAL_MESHLETS}");
     println!("case,objects,meshlets_per_object,median_ms,p95_ms,meshlets_per_second");
@@ -134,6 +152,64 @@ async fn run() {
         compilation_options: Default::default(),
         cache: None,
     });
+    let draw_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Meshlet Draw Benchmark Shader"),
+        source: wgpu::ShaderSource::Wgsl(DRAW_BENCH_SHADER.into()),
+    });
+    let draw_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Meshlet Draw Benchmark Layout"),
+        bind_group_layouts: &[],
+        immediate_size: 0,
+    });
+    let draw_pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("Meshlet Draw Benchmark Pipeline"),
+        layout: Some(&draw_layout),
+        vertex: wgpu::VertexState {
+            module: &draw_shader,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: Default::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &draw_shader,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                blend: None,
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: Default::default(),
+        }),
+        primitive: wgpu::PrimitiveState {
+            cull_mode: None,
+            ..Default::default()
+        },
+        depth_stencil: None,
+        multisample: Default::default(),
+        multiview_mask: None,
+        cache: None,
+    });
+    let draw_target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Meshlet Draw Benchmark Target"),
+        size: wgpu::Extent3d {
+            width: 1,
+            height: 1,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let draw_target_view = draw_target.create_view(&wgpu::TextureViewDescriptor::default());
+    let draw_index_buffer = init_buffer(
+        &device,
+        "Meshlet Draw Benchmark Indices",
+        bytemuck::cast_slice(&[0_u32, 1, 2]),
+        wgpu::BufferUsages::INDEX,
+    );
     let select_bind_group_layout = select_pipeline.get_bind_group_layout(0);
     let cull_bind_group_layout = cull_pipeline.get_bind_group_layout(0);
     let query_set = device.create_query_set(&wgpu::QuerySetDescriptor {
@@ -161,7 +237,7 @@ async fn run() {
         Case { name: "many_small", object_count: 65_536, meshlets_per_object: TOTAL_MESHLETS / 65_536 },
     ];
 
-    for case in cases {
+    for &case in &cases {
         if !case_fits_limits(case, &limits) {
             println!("{},SKIPPED,storage_binding_limit", case.name);
             continue;
@@ -229,6 +305,40 @@ async fn run() {
         );
     }
 
+    // These rows isolate scheduling/publication overhead. Each shape shares one
+    // unique mesh, while publication reserves the exact worst-case visible draw
+    // capacity, so this is not a complete scene-memory comparison.
+    println!("memory_probe,case,meshlet_descriptors_bytes,object_metadata_bytes,instance_and_cull_bytes,work_span_bytes,publication_bytes,vg_total_bytes,conventional_object_draw_bytes");
+    for &case in &cases {
+        let meshlet_descriptors = u64::from(case.meshlets_per_object)
+            * std::mem::size_of::<GpuMeshletEntry>() as u64;
+        let object_metadata = u64::from(case.object_count)
+            * std::mem::size_of::<GpuVgObject>() as u64;
+        let instance_and_cull = u64::from(case.object_count)
+            * (std::mem::size_of::<GpuInstanceData>()
+                + std::mem::size_of::<InstanceCullData>()) as u64;
+        let work_spans = u64::from(case.object_count)
+            * u64::from(
+                case.meshlets_per_object
+                    .div_ceil(VG_CULL_MESHLETS_PER_WORK_ITEM),
+            )
+            * std::mem::size_of::<GpuVgWorkItem>() as u64;
+        let publication = u64::from(TOTAL_MESHLETS)
+            * (20 + std::mem::size_of::<GpuVgDraw>() as u64)
+            + 8;
+        let vg_total = meshlet_descriptors
+            + object_metadata
+            + instance_and_cull
+            + work_spans
+            + publication;
+        let conventional = u64::from(case.object_count)
+            * (std::mem::size_of::<GpuInstanceData>() as u64 + 20);
+        println!(
+            "memory_probe,{},{meshlet_descriptors},{object_metadata},{instance_and_cull},{work_spans},{publication},{vg_total},{conventional}",
+            case.name,
+        );
+    }
+
     let overflow_probe = create_case_buffers(
         &device,
         &queue,
@@ -255,6 +365,72 @@ async fn run() {
     let counters = read_draw_counters(&device, &queue, &overflow_probe);
     assert_eq!(counters, [TOTAL_MESHLETS, 17]);
     eprintln!("overflow_probe,attempted={},rejected={}", counters[0], counters[1]);
+
+    let render_probe = create_case_buffers(
+        &device,
+        &queue,
+        &select_bind_group_layout,
+        &cull_bind_group_layout,
+        Case {
+            name: "render_probe",
+            object_count: 4096,
+            meshlets_per_object: TOTAL_MESHLETS / 4096,
+        },
+        &limits,
+        TOTAL_MESHLETS,
+    );
+    let _ = dispatch_and_time(
+        &device,
+        &queue,
+        &select_pipeline,
+        &cull_pipeline,
+        &render_probe,
+        &query_set,
+        &query_resolve,
+        &query_readback,
+    );
+    // Keep rasterization offscreen and submit the same triangle invocation count.
+    // This measures front-end draw amplification, not a complete material or
+    // raster workload; the indexed path is the best-case single-draw baseline.
+    println!("render_probe,triangles,meshlet_draws,meshlet_median_ms,indexed_draws,indexed_median_ms,meshlet_overhead_ms");
+    for draw_count in [1024, 16_384, 65_536, 262_144, TOTAL_MESHLETS] {
+        let mut meshlet_draw_ms = Vec::with_capacity(render_samples as usize);
+        let mut indexed_draw_ms = Vec::with_capacity(render_samples as usize);
+        for _ in 0..render_samples {
+            meshlet_draw_ms.push(draw_and_time(
+                &device,
+                &queue,
+                &draw_pipeline,
+                &draw_target_view,
+                &draw_index_buffer,
+                Some(&render_probe),
+                draw_count,
+                &query_set,
+                &query_resolve,
+                &query_readback,
+            ));
+            indexed_draw_ms.push(draw_and_time(
+                &device,
+                &queue,
+                &draw_pipeline,
+                &draw_target_view,
+                &draw_index_buffer,
+                None,
+                draw_count,
+                &query_set,
+                &query_resolve,
+                &query_readback,
+            ));
+        }
+        meshlet_draw_ms.sort_by(f64::total_cmp);
+        indexed_draw_ms.sort_by(f64::total_cmp);
+        let meshlet_median = percentile(&meshlet_draw_ms, 0.5);
+        let indexed_median = percentile(&indexed_draw_ms, 0.5);
+        println!(
+            "render_probe,{draw_count},{draw_count},{meshlet_median:.4},1,{indexed_median:.4},{:.4}",
+            meshlet_median - indexed_median,
+        );
+    }
 }
 
 fn case_fits_limits(case: Case, limits: &wgpu::Limits) -> bool {
@@ -388,9 +564,24 @@ fn create_case_buffers(
     let instance_buffer = init_buffer(device, "Benchmark Instances", bytemuck::cast_slice(&instances), wgpu::BufferUsages::STORAGE);
     let instance_cull_buffer = init_buffer(device, "Benchmark Instance Cull", bytemuck::cast_slice(&instance_cull), wgpu::BufferUsages::STORAGE);
     let work_item_buffer = init_buffer(device, "Benchmark Work Items", bytemuck::cast_slice(&work_items), wgpu::BufferUsages::STORAGE);
-    let indirect_buffer = output_buffer(device, "Benchmark Indirect", u64::from(TOTAL_MESHLETS) * 20);
-    let metadata_buffer = output_buffer(device, "Benchmark Draw Metadata", u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64);
-    let draw_count = output_buffer(device, "Benchmark Draw And Overflow Counters", 8);
+    let indirect_buffer = output_buffer(
+        device,
+        "Benchmark Indirect",
+        u64::from(TOTAL_MESHLETS) * 20,
+        wgpu::BufferUsages::INDIRECT,
+    );
+    let metadata_buffer = output_buffer(
+        device,
+        "Benchmark Draw Metadata",
+        u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64,
+        wgpu::BufferUsages::empty(),
+    );
+    let draw_count = output_buffer(
+        device,
+        "Benchmark Draw And Overflow Counters",
+        8,
+        wgpu::BufferUsages::INDIRECT,
+    );
     let draw_count_readback = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("Benchmark Draw Count Readback"),
         size: 8,
@@ -461,6 +652,7 @@ fn create_case_buffers(
     CaseBuffers {
         select_bind_group,
         cull_bind_group,
+        indirect: indirect_buffer,
         draw_count,
         draw_count_readback,
         object_dispatch_width,
@@ -536,6 +728,65 @@ fn read_draw_counters(
     [values[0], values[1]]
 }
 
+#[allow(clippy::too_many_arguments)]
+fn draw_and_time(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    pipeline: &wgpu::RenderPipeline,
+    target: &wgpu::TextureView,
+    index_buffer: &wgpu::Buffer,
+    meshlet_draws: Option<&CaseBuffers>,
+    draw_count: u32,
+    query_set: &wgpu::QuerySet,
+    query_resolve: &wgpu::Buffer,
+    query_readback: &wgpu::Buffer,
+) -> f64 {
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Meshlet Draw Benchmark Encoder"),
+    });
+    encoder.write_timestamp(query_set, 0);
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Meshlet Draw Benchmark Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                resolve_target: None,
+                depth_slice: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+        if let Some(buffers) = meshlet_draws {
+            pass.multi_draw_indexed_indirect_count(
+                &buffers.indirect,
+                0,
+                &buffers.draw_count,
+                0,
+                draw_count,
+            );
+        } else {
+            pass.draw_indexed(0..3, 0, 0..draw_count);
+        }
+    }
+    encoder.write_timestamp(query_set, 1);
+    encoder.resolve_query_set(query_set, 0..2, query_resolve, 0);
+    encoder.copy_buffer_to_buffer(query_resolve, 0, query_readback, 0, 16);
+    queue.submit([encoder.finish()]);
+
+    let ticks = read_mapped::<u64>(device, query_readback, 2);
+    ticks[1].saturating_sub(ticks[0]) as f64
+        * f64::from(queue.get_timestamp_period())
+        / 1_000_000.0
+}
+
 fn read_mapped<T: Pod + Copy>(device: &wgpu::Device, buffer: &wgpu::Buffer, count: usize) -> Vec<T> {
     let slice = buffer.slice(..);
     let (tx, rx) = mpsc::channel();
@@ -564,13 +815,19 @@ fn init_buffer(
     })
 }
 
-fn output_buffer(device: &wgpu::Device, label: &'static str, size: u64) -> wgpu::Buffer {
+fn output_buffer(
+    device: &wgpu::Device,
+    label: &'static str,
+    size: u64,
+    extra_usage: wgpu::BufferUsages,
+) -> wgpu::Buffer {
     device.create_buffer(&wgpu::BufferDescriptor {
         label: Some(label),
         size,
         usage: wgpu::BufferUsages::STORAGE
             | wgpu::BufferUsages::COPY_SRC
-            | wgpu::BufferUsages::COPY_DST,
+            | wgpu::BufferUsages::COPY_DST
+            | extra_usage,
         mapped_at_creation: false,
     })
 }

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -11,6 +11,7 @@ use bytemuck::{Pod, Zeroable};
 use glam::{Mat4, Vec3};
 use libhelio::{
     GpuCameraUniforms, GpuInstanceData, GpuMeshletEntry, GpuVgDraw, GpuVgObject,
+    GpuVgWorkItem, VG_CULL_MESHLETS_PER_WORK_ITEM,
 };
 use std::sync::mpsc;
 use wgpu::util::DeviceExt;
@@ -29,8 +30,12 @@ struct CullUniforms {
     hiz_mip_count: u32,
     draw_capacity: u32,
     lod_error_threshold_px: f32,
-    dispatch_width: u32,
+    object_dispatch_width: u32,
+    work_item_count: u32,
+    work_dispatch_width: u32,
     _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
 }
 
 #[repr(C)]
@@ -50,11 +55,14 @@ struct Case {
 }
 
 struct CaseBuffers {
-    bind_group: wgpu::BindGroup,
+    select_bind_group: wgpu::BindGroup,
+    cull_bind_group: wgpu::BindGroup,
     draw_count: wgpu::Buffer,
     draw_count_readback: wgpu::Buffer,
-    dispatch_width: u32,
-    dispatch_height: u32,
+    object_dispatch_width: u32,
+    object_dispatch_height: u32,
+    work_dispatch_width: u32,
+    work_dispatch_height: u32,
     expected_draws: u32,
 }
 
@@ -109,15 +117,24 @@ async fn run() {
         label: Some("VG Cull Benchmark Shader"),
         source: wgpu::ShaderSource::Wgsl(CULL_SHADER.into()),
     });
-    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-        label: Some("VG Cull Benchmark Pipeline"),
+    let select_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("VG Object Select Benchmark Pipeline"),
         layout: None,
         module: &shader,
-        entry_point: Some("cs_cull"),
+        entry_point: Some("cs_select_objects"),
         compilation_options: Default::default(),
         cache: None,
     });
-    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let cull_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("VG Meshlet Cull Benchmark Pipeline"),
+        layout: None,
+        module: &shader,
+        entry_point: Some("cs_cull_meshlets"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let select_bind_group_layout = select_pipeline.get_bind_group_layout(0);
+    let cull_bind_group_layout = cull_pipeline.get_bind_group_layout(0);
     let query_set = device.create_query_set(&wgpu::QuerySetDescriptor {
         label: Some("VG Cull Benchmark Timestamps"),
         ty: wgpu::QueryType::Timestamp,
@@ -148,13 +165,21 @@ async fn run() {
             println!("{},SKIPPED,storage_binding_limit", case.name);
             continue;
         }
-        let buffers = create_case_buffers(&device, &queue, &bind_group_layout, case, &limits);
+        let buffers = create_case_buffers(
+            &device,
+            &queue,
+            &select_bind_group_layout,
+            &cull_bind_group_layout,
+            case,
+            &limits,
+        );
 
         for _ in 0..warmup {
             let _ = dispatch_and_time(
                 &device,
                 &queue,
-                &pipeline,
+                &select_pipeline,
+                &cull_pipeline,
                 &buffers,
                 &query_set,
                 &query_resolve,
@@ -167,7 +192,8 @@ async fn run() {
             timings_ms.push(dispatch_and_time(
                 &device,
                 &queue,
-                &pipeline,
+                &select_pipeline,
+                &cull_pipeline,
                 &buffers,
                 &query_set,
                 &query_resolve,
@@ -206,18 +232,23 @@ fn case_fits_limits(case: Case, limits: &wgpu::Limits) -> bool {
     let indirect_bytes = u64::from(TOTAL_MESHLETS) * 20;
     let metadata_bytes =
         u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64;
+    let work_item_count = u64::from(case.object_count)
+        * u64::from(case.meshlets_per_object.div_ceil(VG_CULL_MESHLETS_PER_WORK_ITEM));
+    let work_item_bytes = work_item_count * std::mem::size_of::<GpuVgWorkItem>() as u64;
     let largest = meshlet_bytes
         .max(object_bytes)
         .max(instance_bytes)
         .max(indirect_bytes)
-        .max(metadata_bytes);
+        .max(metadata_bytes)
+        .max(work_item_bytes);
     largest <= u64::from(limits.max_storage_buffer_binding_size)
 }
 
 fn create_case_buffers(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
-    layout: &wgpu::BindGroupLayout,
+    select_layout: &wgpu::BindGroupLayout,
+    cull_layout: &wgpu::BindGroupLayout,
     case: Case,
     limits: &wgpu::Limits,
 ) -> CaseBuffers {
@@ -280,11 +311,26 @@ fn create_case_buffers(
         })
         .collect();
 
-    let dispatch_width = case
-        .object_count
+    let object_workgroups = case.object_count.div_ceil(VG_CULL_MESHLETS_PER_WORK_ITEM);
+    let object_dispatch_width = object_workgroups
         .min(limits.max_compute_workgroups_per_dimension)
         .max(1);
-    let dispatch_height = case.object_count.div_ceil(dispatch_width);
+    let object_dispatch_height = object_workgroups.div_ceil(object_dispatch_width);
+    let work_items: Vec<_> = (0..case.object_count)
+        .flat_map(|object_index| {
+            (0..case.meshlets_per_object)
+                .step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
+                .map(move |local_meshlet_base| GpuVgWorkItem {
+                    object_index,
+                    local_meshlet_base,
+                })
+        })
+        .collect();
+    let work_item_count = u32::try_from(work_items.len()).expect("benchmark work items exceed u32");
+    let work_dispatch_width = work_item_count
+        .min(limits.max_compute_workgroups_per_dimension)
+        .max(1);
+    let work_dispatch_height = work_item_count.div_ceil(work_dispatch_width);
     let cull_uniforms = CullUniforms {
         object_count: case.object_count,
         screen_width: 1920,
@@ -292,8 +338,12 @@ fn create_case_buffers(
         hiz_mip_count: 1,
         draw_capacity: TOTAL_MESHLETS,
         lod_error_threshold_px: 2.0,
-        dispatch_width,
+        object_dispatch_width,
+        work_item_count,
+        work_dispatch_width,
         _pad0: 0,
+        _pad1: 0,
+        _pad2: 0,
     };
 
     let camera_buffer = init_buffer(device, "Benchmark Camera", bytemuck::bytes_of(&camera), wgpu::BufferUsages::UNIFORM);
@@ -302,6 +352,7 @@ fn create_case_buffers(
     let object_buffer = init_buffer(device, "Benchmark Objects", bytemuck::cast_slice(&objects), wgpu::BufferUsages::STORAGE);
     let instance_buffer = init_buffer(device, "Benchmark Instances", bytemuck::cast_slice(&instances), wgpu::BufferUsages::STORAGE);
     let instance_cull_buffer = init_buffer(device, "Benchmark Instance Cull", bytemuck::cast_slice(&instance_cull), wgpu::BufferUsages::STORAGE);
+    let work_item_buffer = init_buffer(device, "Benchmark Work Items", bytemuck::cast_slice(&work_items), wgpu::BufferUsages::STORAGE);
     let indirect_buffer = output_buffer(device, "Benchmark Indirect", u64::from(TOTAL_MESHLETS) * 20);
     let metadata_buffer = output_buffer(device, "Benchmark Draw Metadata", u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64);
     let draw_count = output_buffer(device, "Benchmark Draw Count", 4);
@@ -342,9 +393,20 @@ fn create_case_buffers(
         ..Default::default()
     });
 
-    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+    let select_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("VG Object Select Benchmark Bind Group"),
+        layout: select_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
+        ],
+    });
+    let cull_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("VG Cull Benchmark Bind Group"),
-        layout,
+        layout: cull_layout,
         entries: &[
             wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
             wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
@@ -357,15 +419,19 @@ fn create_case_buffers(
             wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(&hiz_view) },
             wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(&hiz_sampler) },
             wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 11, resource: work_item_buffer.as_entire_binding() },
         ],
     });
 
     CaseBuffers {
-        bind_group,
+        select_bind_group,
+        cull_bind_group,
         draw_count,
         draw_count_readback,
-        dispatch_width,
-        dispatch_height,
+        object_dispatch_width,
+        object_dispatch_height,
+        work_dispatch_width,
+        work_dispatch_height,
         expected_draws: TOTAL_MESHLETS,
     }
 }
@@ -373,7 +439,8 @@ fn create_case_buffers(
 fn dispatch_and_time(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
-    pipeline: &wgpu::ComputePipeline,
+    select_pipeline: &wgpu::ComputePipeline,
+    cull_pipeline: &wgpu::ComputePipeline,
     buffers: &CaseBuffers,
     query_set: &wgpu::QuerySet,
     query_resolve: &wgpu::Buffer,
@@ -389,9 +456,26 @@ fn dispatch_and_time(
             label: Some("VG Cull Benchmark Dispatch"),
             timestamp_writes: None,
         });
-        pass.set_pipeline(pipeline);
-        pass.set_bind_group(0, &buffers.bind_group, &[]);
-        pass.dispatch_workgroups(buffers.dispatch_width, buffers.dispatch_height, 1);
+        pass.set_pipeline(select_pipeline);
+        pass.set_bind_group(0, &buffers.select_bind_group, &[]);
+        pass.dispatch_workgroups(
+            buffers.object_dispatch_width,
+            buffers.object_dispatch_height,
+            1,
+        );
+    }
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("VG Meshlet Cull Benchmark Dispatch"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(cull_pipeline);
+        pass.set_bind_group(0, &buffers.cull_bind_group, &[]);
+        pass.dispatch_workgroups(
+            buffers.work_dispatch_width,
+            buffers.work_dispatch_height,
+            1,
+        );
     }
     encoder.write_timestamp(query_set, 1);
     encoder.resolve_query_set(query_set, 0..2, query_resolve, 0);

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -7,6 +7,8 @@
 //!
 //! Run with:
 //! `cargo run --release -p examples --bin meshlet_cull_benchmark`
+//! Set `HELIO_BENCH_BACKEND=dx12` (or `vulkan`, `metal`, `gl`, `browser`)
+//! to force one backend for cross-backend verification.
 
 use bytemuck::{Pod, Zeroable};
 use glam::{Mat4, Vec3};
@@ -89,7 +91,7 @@ fn main() {
 
 async fn run() {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-        backends: wgpu::Backends::all(),
+        backends: benchmark_backends(),
         flags: wgpu::InstanceFlags::empty(),
         ..Default::default()
     });
@@ -842,4 +844,21 @@ fn env_u32(name: &str, fallback: u32) -> u32 {
         .ok()
         .and_then(|value| value.parse().ok())
         .unwrap_or(fallback)
+}
+
+fn benchmark_backends() -> wgpu::Backends {
+    let Ok(value) = std::env::var("HELIO_BENCH_BACKEND") else {
+        return wgpu::Backends::all();
+    };
+    match value.to_ascii_lowercase().as_str() {
+        "dx12" => wgpu::Backends::DX12,
+        "vulkan" => wgpu::Backends::VULKAN,
+        "metal" => wgpu::Backends::METAL,
+        "gl" => wgpu::Backends::GL,
+        "browser" => wgpu::Backends::BROWSER_WEBGPU,
+        "all" => wgpu::Backends::all(),
+        other => panic!(
+            "unknown HELIO_BENCH_BACKEND '{other}'; expected dx12, vulkan, metal, gl, browser, or all"
+        ),
+    }
 }

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -1,0 +1,463 @@
+//! Headless virtual-geometry culling benchmark.
+//!
+//! Holds total visible meshlet work constant while changing how that work is
+//! distributed across objects. This exposes occupancy problems in the current
+//! one-workgroup-per-object publication path.
+//!
+//! Run with:
+//! `cargo run --release -p examples --bin meshlet_cull_benchmark`
+
+use bytemuck::{Pod, Zeroable};
+use glam::{Mat4, Vec3};
+use libhelio::{
+    GpuCameraUniforms, GpuInstanceData, GpuMeshletEntry, GpuVgDraw, GpuVgObject,
+};
+use std::sync::mpsc;
+use wgpu::util::DeviceExt;
+
+const CULL_SHADER: &str = include_str!("../helio-pass-virtual-geometry/shaders/vg_cull.wgsl");
+const TOTAL_MESHLETS: u32 = 1_048_576;
+const DEFAULT_WARMUP: u32 = 5;
+const DEFAULT_SAMPLES: u32 = 20;
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct CullUniforms {
+    object_count: u32,
+    screen_width: u32,
+    screen_height: u32,
+    hiz_mip_count: u32,
+    draw_capacity: u32,
+    lod_error_threshold_px: f32,
+    dispatch_width: u32,
+    _pad0: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+struct InstanceCullData {
+    max_scale: f32,
+    min_scale: f32,
+    cone_cull_enabled: u32,
+    valid_transform: u32,
+}
+
+#[derive(Clone, Copy)]
+struct Case {
+    name: &'static str,
+    object_count: u32,
+    meshlets_per_object: u32,
+}
+
+struct CaseBuffers {
+    bind_group: wgpu::BindGroup,
+    draw_count: wgpu::Buffer,
+    draw_count_readback: wgpu::Buffer,
+    dispatch_width: u32,
+    dispatch_height: u32,
+    expected_draws: u32,
+}
+
+fn main() {
+    env_logger::init();
+    pollster::block_on(run());
+}
+
+async fn run() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+        backends: wgpu::Backends::all(),
+        flags: wgpu::InstanceFlags::empty(),
+        ..Default::default()
+    });
+    let adapter = instance
+        .request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        })
+        .await
+        .expect("no GPU adapter available");
+
+    let timestamp_features =
+        wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+    assert!(
+        adapter.features().contains(timestamp_features),
+        "meshlet benchmark requires encoder timestamp queries"
+    );
+    let limits = adapter.limits();
+    let (device, queue) = adapter
+        .request_device(&wgpu::DeviceDescriptor {
+            label: Some("Meshlet Cull Benchmark Device"),
+            required_features: timestamp_features,
+            required_limits: limits.clone(),
+            ..Default::default()
+        })
+        .await
+        .expect("failed to create benchmark device");
+    device.on_uncaptured_error(std::sync::Arc::new(|error| {
+        panic!("[GPU] {error:?}");
+    }));
+
+    let info = adapter.get_info();
+    let warmup = env_u32("HELIO_BENCH_WARMUP", DEFAULT_WARMUP);
+    let samples = env_u32("HELIO_BENCH_SAMPLES", DEFAULT_SAMPLES).max(1);
+    println!("adapter,{},backend,{:?}", info.name, info.backend);
+    println!("warmup,{warmup},samples,{samples},total_meshlets,{TOTAL_MESHLETS}");
+    println!("case,objects,meshlets_per_object,median_ms,p95_ms,meshlets_per_second");
+
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("VG Cull Benchmark Shader"),
+        source: wgpu::ShaderSource::Wgsl(CULL_SHADER.into()),
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("VG Cull Benchmark Pipeline"),
+        layout: None,
+        module: &shader,
+        entry_point: Some("cs_cull"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let bind_group_layout = pipeline.get_bind_group_layout(0);
+    let query_set = device.create_query_set(&wgpu::QuerySetDescriptor {
+        label: Some("VG Cull Benchmark Timestamps"),
+        ty: wgpu::QueryType::Timestamp,
+        count: 2,
+    });
+    let query_resolve = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("VG Cull Benchmark Query Resolve"),
+        size: 16,
+        usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let query_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("VG Cull Benchmark Query Readback"),
+        size: 16,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let cases = [
+        Case { name: "single_huge", object_count: 1, meshlets_per_object: TOTAL_MESHLETS },
+        Case { name: "few_huge", object_count: 16, meshlets_per_object: TOTAL_MESHLETS / 16 },
+        Case { name: "balanced", object_count: 4096, meshlets_per_object: TOTAL_MESHLETS / 4096 },
+        Case { name: "many_small", object_count: 65_536, meshlets_per_object: TOTAL_MESHLETS / 65_536 },
+    ];
+
+    for case in cases {
+        if !case_fits_limits(case, &limits) {
+            println!("{},SKIPPED,storage_binding_limit", case.name);
+            continue;
+        }
+        let buffers = create_case_buffers(&device, &queue, &bind_group_layout, case, &limits);
+
+        for _ in 0..warmup {
+            let _ = dispatch_and_time(
+                &device,
+                &queue,
+                &pipeline,
+                &buffers,
+                &query_set,
+                &query_resolve,
+                &query_readback,
+            );
+        }
+
+        let mut timings_ms = Vec::with_capacity(samples as usize);
+        for _ in 0..samples {
+            timings_ms.push(dispatch_and_time(
+                &device,
+                &queue,
+                &pipeline,
+                &buffers,
+                &query_set,
+                &query_resolve,
+                &query_readback,
+            ));
+        }
+
+        let published = read_draw_count(&device, &queue, &buffers);
+        assert_eq!(
+            published, buffers.expected_draws,
+            "{} did not publish every visible meshlet",
+            case.name
+        );
+        timings_ms.sort_by(f64::total_cmp);
+        let median_ms = percentile(&timings_ms, 0.50);
+        let p95_ms = percentile(&timings_ms, 0.95);
+        let meshlets_per_second = f64::from(TOTAL_MESHLETS) / (median_ms / 1000.0);
+        println!(
+            "{},{},{},{:.4},{:.4},{:.0}",
+            case.name,
+            case.object_count,
+            case.meshlets_per_object,
+            median_ms,
+            p95_ms,
+            meshlets_per_second,
+        );
+    }
+}
+
+fn case_fits_limits(case: Case, limits: &wgpu::Limits) -> bool {
+    let meshlet_bytes = u64::from(case.meshlets_per_object)
+        * std::mem::size_of::<GpuMeshletEntry>() as u64;
+    let object_bytes = u64::from(case.object_count) * std::mem::size_of::<GpuVgObject>() as u64;
+    let instance_bytes =
+        u64::from(case.object_count) * std::mem::size_of::<GpuInstanceData>() as u64;
+    let indirect_bytes = u64::from(TOTAL_MESHLETS) * 20;
+    let metadata_bytes =
+        u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64;
+    let largest = meshlet_bytes
+        .max(object_bytes)
+        .max(instance_bytes)
+        .max(indirect_bytes)
+        .max(metadata_bytes);
+    largest <= u64::from(limits.max_storage_buffer_binding_size)
+}
+
+fn create_case_buffers(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    layout: &wgpu::BindGroupLayout,
+    case: Case,
+    limits: &wgpu::Limits,
+) -> CaseBuffers {
+    let identity = Mat4::IDENTITY.to_cols_array();
+    let camera = GpuCameraUniforms::new(
+        Mat4::IDENTITY,
+        Mat4::perspective_rh(60.0_f32.to_radians(), 16.0 / 9.0, 0.1, 1000.0),
+        Vec3::ZERO,
+        0.1,
+        1000.0,
+        0,
+        [0.0; 2],
+        Mat4::IDENTITY,
+    );
+    let instances = vec![GpuInstanceData {
+        model: identity,
+        normal_mat: [
+            1.0, 0.0, 0.0, 0.0,
+            0.0, 1.0, 0.0, 0.0,
+            0.0, 0.0, 1.0, 0.0,
+        ],
+        bounds: [0.0, 0.0, -10.0, 1.0],
+        mesh_id: 0,
+        material_id: 0,
+        flags: 0,
+        lightmap_index: u32::MAX,
+    }; case.object_count as usize];
+    let instance_cull = vec![InstanceCullData {
+        max_scale: 1.0,
+        min_scale: 1.0,
+        cone_cull_enabled: 0,
+        valid_transform: 1,
+    }; case.object_count as usize];
+    let meshlets = vec![GpuMeshletEntry {
+        center: [0.0, 0.0, -10.0],
+        radius: 0.25,
+        cone_apex: [0.0, 0.0, -10.0],
+        cone_cutoff: 2.0,
+        cone_axis: [0.0, 0.0, 1.0],
+        lod_error: 0.0,
+        first_index: 0,
+        index_count: 3,
+        vertex_offset: 0,
+        instance_index: 0,
+    }; case.meshlets_per_object as usize];
+    let objects: Vec<_> = (0..case.object_count)
+        .map(|instance_index| {
+            let mut lod_meshlet_counts = [0; 8];
+            lod_meshlet_counts[0] = case.meshlets_per_object;
+            GpuVgObject {
+                instance_index,
+                lod_count: 1,
+                max_meshlet_count: case.meshlets_per_object,
+                reserved: 0,
+                local_bounds: [0.0, 0.0, -10.0, 1.0],
+                lod_errors: [0.0; 8],
+                lod_first_meshlets: [0; 8],
+                lod_meshlet_counts,
+            }
+        })
+        .collect();
+
+    let dispatch_width = case
+        .object_count
+        .min(limits.max_compute_workgroups_per_dimension)
+        .max(1);
+    let dispatch_height = case.object_count.div_ceil(dispatch_width);
+    let cull_uniforms = CullUniforms {
+        object_count: case.object_count,
+        screen_width: 1920,
+        screen_height: 1080,
+        hiz_mip_count: 1,
+        draw_capacity: TOTAL_MESHLETS,
+        lod_error_threshold_px: 2.0,
+        dispatch_width,
+        _pad0: 0,
+    };
+
+    let camera_buffer = init_buffer(device, "Benchmark Camera", bytemuck::bytes_of(&camera), wgpu::BufferUsages::UNIFORM);
+    let cull_buffer = init_buffer(device, "Benchmark Cull Uniforms", bytemuck::bytes_of(&cull_uniforms), wgpu::BufferUsages::UNIFORM);
+    let meshlet_buffer = init_buffer(device, "Benchmark Meshlets", bytemuck::cast_slice(&meshlets), wgpu::BufferUsages::STORAGE);
+    let object_buffer = init_buffer(device, "Benchmark Objects", bytemuck::cast_slice(&objects), wgpu::BufferUsages::STORAGE);
+    let instance_buffer = init_buffer(device, "Benchmark Instances", bytemuck::cast_slice(&instances), wgpu::BufferUsages::STORAGE);
+    let instance_cull_buffer = init_buffer(device, "Benchmark Instance Cull", bytemuck::cast_slice(&instance_cull), wgpu::BufferUsages::STORAGE);
+    let indirect_buffer = output_buffer(device, "Benchmark Indirect", u64::from(TOTAL_MESHLETS) * 20);
+    let metadata_buffer = output_buffer(device, "Benchmark Draw Metadata", u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64);
+    let draw_count = output_buffer(device, "Benchmark Draw Count", 4);
+    let draw_count_readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Benchmark Draw Count Readback"),
+        size: 4,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+
+    let hiz = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Benchmark Far HiZ"),
+        size: wgpu::Extent3d { width: 1, height: 1, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &hiz,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        &[255, 255, 255, 255],
+        wgpu::TexelCopyBufferLayout { offset: 0, bytes_per_row: Some(4), rows_per_image: Some(1) },
+        wgpu::Extent3d { width: 1, height: 1, depth_or_array_layers: 1 },
+    );
+    let hiz_view = hiz.create_view(&wgpu::TextureViewDescriptor::default());
+    let hiz_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+        label: Some("Benchmark HiZ Sampler"),
+        mag_filter: wgpu::FilterMode::Linear,
+        min_filter: wgpu::FilterMode::Linear,
+        mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+        ..Default::default()
+    });
+
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("VG Cull Benchmark Bind Group"),
+        layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 2, resource: meshlet_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 5, resource: indirect_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 6, resource: metadata_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 7, resource: draw_count.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(&hiz_view) },
+            wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(&hiz_sampler) },
+            wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
+        ],
+    });
+
+    CaseBuffers {
+        bind_group,
+        draw_count,
+        draw_count_readback,
+        dispatch_width,
+        dispatch_height,
+        expected_draws: TOTAL_MESHLETS,
+    }
+}
+
+fn dispatch_and_time(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    pipeline: &wgpu::ComputePipeline,
+    buffers: &CaseBuffers,
+    query_set: &wgpu::QuerySet,
+    query_resolve: &wgpu::Buffer,
+    query_readback: &wgpu::Buffer,
+) -> f64 {
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("VG Cull Benchmark Encoder"),
+    });
+    encoder.clear_buffer(&buffers.draw_count, 0, None);
+    encoder.write_timestamp(query_set, 0);
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("VG Cull Benchmark Dispatch"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(pipeline);
+        pass.set_bind_group(0, &buffers.bind_group, &[]);
+        pass.dispatch_workgroups(buffers.dispatch_width, buffers.dispatch_height, 1);
+    }
+    encoder.write_timestamp(query_set, 1);
+    encoder.resolve_query_set(query_set, 0..2, query_resolve, 0);
+    encoder.copy_buffer_to_buffer(query_resolve, 0, query_readback, 0, 16);
+    queue.submit([encoder.finish()]);
+
+    let ticks = read_mapped::<u64>(device, query_readback, 2);
+    ticks[1].saturating_sub(ticks[0]) as f64 * f64::from(queue.get_timestamp_period()) / 1_000_000.0
+}
+
+fn read_draw_count(device: &wgpu::Device, queue: &wgpu::Queue, buffers: &CaseBuffers) -> u32 {
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("VG Cull Count Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(&buffers.draw_count, 0, &buffers.draw_count_readback, 0, 4);
+    queue.submit([encoder.finish()]);
+    read_mapped::<u32>(device, &buffers.draw_count_readback, 1)[0]
+}
+
+fn read_mapped<T: Pod + Copy>(device: &wgpu::Device, buffer: &wgpu::Buffer, count: usize) -> Vec<T> {
+    let slice = buffer.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv().expect("map callback dropped").expect("readback mapping failed");
+    let data = slice.get_mapped_range();
+    let values = bytemuck::cast_slice::<u8, T>(&data)[..count].to_vec();
+    drop(data);
+    buffer.unmap();
+    values
+}
+
+fn init_buffer(
+    device: &wgpu::Device,
+    label: &'static str,
+    contents: &[u8],
+    usage: wgpu::BufferUsages,
+) -> wgpu::Buffer {
+    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some(label),
+        contents,
+        usage,
+    })
+}
+
+fn output_buffer(device: &wgpu::Device, label: &'static str, size: u64) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    })
+}
+
+fn percentile(sorted: &[f64], percentile: f64) -> f64 {
+    let index = ((sorted.len() - 1) as f64 * percentile).round() as usize;
+    sorted[index]
+}
+
+fn env_u32(name: &str, fallback: u32) -> u32 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(fallback)
+}

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -327,7 +327,7 @@ async fn run() {
             * std::mem::size_of::<GpuVgWorkItem>() as u64;
         let publication = u64::from(TOTAL_MESHLETS)
             * (20 + std::mem::size_of::<GpuVgDraw>() as u64)
-            + 8;
+            + 44;
         let vg_total = meshlet_descriptors
             + object_metadata
             + instance_and_cull
@@ -629,6 +629,7 @@ fn create_case_buffers(
             wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
             wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
             wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 7, resource: draw_count.as_entire_binding() },
             wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
         ],
     });

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -63,7 +63,8 @@ struct CaseBuffers {
     object_dispatch_height: u32,
     work_dispatch_width: u32,
     work_dispatch_height: u32,
-    expected_draws: u32,
+    expected_attempts: u32,
+    expected_overflow: u32,
 }
 
 fn main() {
@@ -172,6 +173,7 @@ async fn run() {
             &cull_bind_group_layout,
             case,
             &limits,
+            TOTAL_MESHLETS,
         );
 
         for _ in 0..warmup {
@@ -201,10 +203,15 @@ async fn run() {
             ));
         }
 
-        let published = read_draw_count(&device, &queue, &buffers);
+        let counters = read_draw_counters(&device, &queue, &buffers);
         assert_eq!(
-            published, buffers.expected_draws,
-            "{} did not publish every visible meshlet",
+            counters[0], buffers.expected_attempts,
+            "{} did not attempt every visible meshlet",
+            case.name
+        );
+        assert_eq!(
+            counters[1], buffers.expected_overflow,
+            "{} reported an unexpected capacity overflow",
             case.name
         );
         timings_ms.sort_by(f64::total_cmp);
@@ -221,6 +228,33 @@ async fn run() {
             meshlets_per_second,
         );
     }
+
+    let overflow_probe = create_case_buffers(
+        &device,
+        &queue,
+        &select_bind_group_layout,
+        &cull_bind_group_layout,
+        Case {
+            name: "overflow_probe",
+            object_count: 4096,
+            meshlets_per_object: TOTAL_MESHLETS / 4096,
+        },
+        &limits,
+        TOTAL_MESHLETS - 17,
+    );
+    let _ = dispatch_and_time(
+        &device,
+        &queue,
+        &select_pipeline,
+        &cull_pipeline,
+        &overflow_probe,
+        &query_set,
+        &query_resolve,
+        &query_readback,
+    );
+    let counters = read_draw_counters(&device, &queue, &overflow_probe);
+    assert_eq!(counters, [TOTAL_MESHLETS, 17]);
+    eprintln!("overflow_probe,attempted={},rejected={}", counters[0], counters[1]);
 }
 
 fn case_fits_limits(case: Case, limits: &wgpu::Limits) -> bool {
@@ -251,6 +285,7 @@ fn create_case_buffers(
     cull_layout: &wgpu::BindGroupLayout,
     case: Case,
     limits: &wgpu::Limits,
+    draw_capacity: u32,
 ) -> CaseBuffers {
     let identity = Mat4::IDENTITY.to_cols_array();
     let camera = GpuCameraUniforms::new(
@@ -336,7 +371,7 @@ fn create_case_buffers(
         screen_width: 1920,
         screen_height: 1080,
         hiz_mip_count: 1,
-        draw_capacity: TOTAL_MESHLETS,
+        draw_capacity,
         lod_error_threshold_px: 2.0,
         object_dispatch_width,
         work_item_count,
@@ -355,10 +390,10 @@ fn create_case_buffers(
     let work_item_buffer = init_buffer(device, "Benchmark Work Items", bytemuck::cast_slice(&work_items), wgpu::BufferUsages::STORAGE);
     let indirect_buffer = output_buffer(device, "Benchmark Indirect", u64::from(TOTAL_MESHLETS) * 20);
     let metadata_buffer = output_buffer(device, "Benchmark Draw Metadata", u64::from(TOTAL_MESHLETS) * std::mem::size_of::<GpuVgDraw>() as u64);
-    let draw_count = output_buffer(device, "Benchmark Draw Count", 4);
+    let draw_count = output_buffer(device, "Benchmark Draw And Overflow Counters", 8);
     let draw_count_readback = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("Benchmark Draw Count Readback"),
-        size: 4,
+        size: 8,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -432,7 +467,8 @@ fn create_case_buffers(
         object_dispatch_height,
         work_dispatch_width,
         work_dispatch_height,
-        expected_draws: TOTAL_MESHLETS,
+        expected_attempts: TOTAL_MESHLETS,
+        expected_overflow: TOTAL_MESHLETS.saturating_sub(draw_capacity),
     }
 }
 
@@ -486,13 +522,18 @@ fn dispatch_and_time(
     ticks[1].saturating_sub(ticks[0]) as f64 * f64::from(queue.get_timestamp_period()) / 1_000_000.0
 }
 
-fn read_draw_count(device: &wgpu::Device, queue: &wgpu::Queue, buffers: &CaseBuffers) -> u32 {
+fn read_draw_counters(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    buffers: &CaseBuffers,
+) -> [u32; 2] {
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("VG Cull Count Readback Encoder"),
     });
-    encoder.copy_buffer_to_buffer(&buffers.draw_count, 0, &buffers.draw_count_readback, 0, 4);
+    encoder.copy_buffer_to_buffer(&buffers.draw_count, 0, &buffers.draw_count_readback, 0, 8);
     queue.submit([encoder.finish()]);
-    read_mapped::<u32>(device, &buffers.draw_count_readback, 1)[0]
+    let values = read_mapped::<u32>(device, &buffers.draw_count_readback, 2);
+    [values[0], values[1]]
 }
 
 fn read_mapped<T: Pod + Copy>(device: &wgpu::Device, buffer: &wgpu::Buffer, count: usize) -> Vec<T> {

--- a/crates/helio-core/src/graph/execution.rs
+++ b/crates/helio-core/src/graph/execution.rs
@@ -178,6 +178,13 @@ impl RenderGraph {
             .collect()
     }
 
+    /// Propagate a renderer-wide debug mode change to every pass.
+    pub fn set_debug_mode(&mut self, mode: u32) {
+        for pass in &mut self.passes {
+            pass.set_debug_mode(mode);
+        }
+    }
+
     pub fn validate_dependencies(&self) -> std::result::Result<(), String> {
         use std::collections::HashSet;
         let mut available: HashSet<&str> = HashSet::new();

--- a/crates/helio-core/src/traits.rs
+++ b/crates/helio-core/src/traits.rs
@@ -422,6 +422,13 @@ pub trait RenderPass: AsAny + MaybeSend + MaybeSync {
     /// The default is a no-op, so passes that don't need resize handling can ignore it.
     fn on_resize(&mut self, _device: &wgpu::Device, _width: u32, _height: u32) {}
 
+    /// Updates the renderer-wide debug visualisation mode.
+    ///
+    /// Passes that expose [`debug_views`](Self::debug_views) must override this
+    /// hook and update the state consumed by their next `prepare`/`execute`.
+    /// The default keeps passes without debug visualisations source-compatible.
+    fn set_debug_mode(&mut self, _mode: u32) {}
+
     /// Returns the debug visualisation modes this pass provides.
     ///
     /// The renderer aggregates these from all passes to build a discoverable

--- a/crates/helio-pass-deferred-light/src/lib.rs
+++ b/crates/helio-pass-deferred-light/src/lib.rs
@@ -770,6 +770,10 @@ impl RenderPass for DeferredLightPass {
         Ok(())
     }
 
+    fn set_debug_mode(&mut self, mode: u32) {
+        self.debug_mode = mode;
+    }
+
     fn debug_views(&self) -> &'static [DebugViewDescriptor] {
         static VIEWS: &[DebugViewDescriptor] = &[
             DebugViewDescriptor {

--- a/crates/helio-pass-gbuffer/src/lib.rs
+++ b/crates/helio-pass-gbuffer/src/lib.rs
@@ -561,6 +561,10 @@ impl RenderPass for GBufferPass {
         Ok(())
     }
 
+    fn set_debug_mode(&mut self, mode: u32) {
+        self.debug_mode = mode;
+    }
+
     fn debug_views(&self) -> &'static [DebugViewDescriptor] {
         static VIEWS: &[DebugViewDescriptor] = &[
             DebugViewDescriptor {

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -1,15 +1,9 @@
 // Virtual geometry culling compute shader.
 //
-// One thread per meshlet. Tests each meshlet against the view frustum,
-// backface cone, and Hi-Z occlusion buffer.
-// Visible meshlets are atomically appended to a compact indirect draw list:
-//
-//   slot = atomicAdd(&draw_count, 1u);
-//   indirect[slot] = cmd;
-//
-// The GPU-written draw_count is passed to multi_draw_indexed_indirect_count so
-// the hardware only reads the N_visible compact commands — never stale zero-
-// instance_count entries (Nanite / DOTS style compaction).
+// One workgroup owns one virtual object. Lane zero conservatively culls the
+// object's transformed local-space sphere and selects exactly one LOD from the
+// measured meshoptimizer error. The 64 lanes then cooperatively cull only that
+// LOD's immutable meshlet range and append bounded indirect draw commands.
 
 struct Camera {
     view:           mat4x4<f32>,
@@ -36,6 +30,18 @@ struct MeshletEntry {
     instance_index: u32,
 }
 
+/// Mirrors GpuVgObject (Rust, 128 bytes).
+struct VgObjectData {
+    instance_index:       u32,
+    lod_count:            u32,
+    max_meshlet_count:    u32,
+    reserved:             u32,
+    local_bounds:         vec4<f32>,
+    lod_errors:           array<f32, 8>,
+    lod_first_meshlets:   array<u32, 8>,
+    lod_meshlet_counts:   array<u32, 8>,
+}
+
 /// Mirrors GpuInstanceData (Rust, 144 bytes).
 struct InstanceData {
     transform:    mat4x4<f32>,
@@ -49,7 +55,14 @@ struct InstanceData {
     _pad:         u32,
 }
 
-/// Mirrors wgpu::util::DrawIndexedIndirectArgs (20 bytes, but aligned to 4).
+struct InstanceCullData {
+    max_scale:          f32,
+    min_scale:          f32,
+    cone_cull_enabled:  u32,
+    valid_transform:    u32,
+}
+
+/// Mirrors wgpu::util::DrawIndexedIndirectArgs (20 bytes).
 struct DrawIndexedIndirect {
     index_count:    u32,
     instance_count: u32,
@@ -58,148 +71,81 @@ struct DrawIndexedIndirect {
     first_instance: u32,
 }
 
+/// Mirrors GpuVgDraw (Rust, 16 bytes).
+struct VgDrawMetadata {
+    instance_index: u32,
+    meshlet_index:  u32,
+    lod_level:      u32,
+    reserved:       u32,
+}
+
+/// Mirrors CullUniforms (Rust, 32 bytes).
 struct CullUniforms {
-    meshlet_count: u32,
-    screen_width:  u32,
-    screen_height: u32,
-    hiz_mip_count: u32,
-    // 7 screen-radius LOD thresholds: s[i] = transition LOD i → i+1.
-    // 8 LOD levels total (0–7), matching UE5's traditional mesh LOD system.
-    lod_s0: f32,
-    lod_s1: f32,
-    lod_s2: f32,
-    lod_s3: f32,
-    lod_s4: f32,
-    lod_s5: f32,
-    lod_s6: f32,
-    _pad3:  f32,
+    object_count:          u32,
+    screen_width:          u32,
+    screen_height:         u32,
+    hiz_mip_count:         u32,
+    draw_capacity:         u32,
+    lod_error_threshold_px: f32,
+    dispatch_width:        u32,
+    _pad0:                 u32,
 }
 
-@group(0) @binding(0) var<uniform>             camera:     Camera;
-@group(0) @binding(1) var<uniform>             cull_uni:   CullUniforms;
-@group(0) @binding(2) var<storage, read>       meshlets:   array<MeshletEntry>;
-@group(0) @binding(3) var<storage, read>       instances:  array<InstanceData>;
-@group(0) @binding(4) var<storage, read_write> indirect:   array<DrawIndexedIndirect>;
-/// Atomic counter: cull shader increments once per visible meshlet.
-/// CPU passes this buffer to multi_draw_indexed_indirect_count as the count arg.
-@group(0) @binding(5) var<storage, read_write> draw_count: atomic<u32>;
+@group(0) @binding(0) var<uniform> camera: Camera;
+@group(0) @binding(1) var<uniform> cull_uni: CullUniforms;
+@group(0) @binding(2) var<storage, read> meshlets: array<MeshletEntry>;
+@group(0) @binding(3) var<storage, read> objects: array<VgObjectData>;
+@group(0) @binding(4) var<storage, read> instances: array<InstanceData>;
+@group(0) @binding(5) var<storage, read_write> indirect: array<DrawIndexedIndirect>;
+@group(0) @binding(6) var<storage, read_write> draw_metadata: array<VgDrawMetadata>;
+@group(0) @binding(7) var<storage, read_write> draw_count: atomic<u32>;
+@group(0) @binding(8) var hiz_tex: texture_2d<f32>;
+@group(0) @binding(9) var hiz_samp: sampler;
+@group(0) @binding(10) var<storage, read> instance_cull: array<InstanceCullData>;
 
-@group(0) @binding(6) var hiz_tex:  texture_2d<f32>;
-@group(0) @binding(7) var hiz_samp: sampler;
-struct InstanceCullData {
-    max_scale:          f32,
-    min_scale:          f32,
-    cone_cull_enabled:  u32,
-    valid_transform:    u32,
-}
-
-/// Values derived from the model matrix once when instance data changes.
-@group(0) @binding(8) var<storage, read> instance_cull: array<InstanceCullData>;
-
-// ─── LOD selection ───────────────────────────────────────────────────────────
-
-fn select_lod_level(screen_size: f32) -> u32 {
-    if screen_size >= cull_uni.lod_s0 { return 0u; }
-    if screen_size >= cull_uni.lod_s1 { return 1u; }
-    if screen_size >= cull_uni.lod_s2 { return 2u; }
-    if screen_size >= cull_uni.lod_s3 { return 3u; }
-    if screen_size >= cull_uni.lod_s4 { return 4u; }
-    if screen_size >= cull_uni.lod_s5 { return 5u; }
-    if screen_size >= cull_uni.lod_s6 { return 6u; }
-    return 7u;
-}
-
-// ─── Main ────────────────────────────────────────────────────────────────────
-
-/// Pre-normalised frustum planes (left, right, bottom, top, near, far), shared
-/// across the whole workgroup. Planes depend only on `camera.view_proj` — the
-/// same for every thread in the entire dispatch, not just within one workgroup
-/// — so computing them (and the length() normalisation) separately per meshlet
-/// thread bought nothing. One thread per workgroup computes them into workgroup
-/// memory instead of all 64 redoing the same math.
 var<workgroup> wg_planes: array<vec4<f32>, 6>;
+var<workgroup> wg_first_meshlet: u32;
+var<workgroup> wg_meshlet_count: u32;
+var<workgroup> wg_instance_index: u32;
+var<workgroup> wg_selected_lod: u32;
+var<workgroup> wg_object_visible: u32;
 
-@compute @workgroup_size(64)
-fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocation_index) lid: u32) {
-    // Must run before any thread can `return` below, so the barrier stays in
-    // uniform control flow (reached by every invocation in the workgroup).
-    if lid == 0u {
-        let vp = camera.view_proj;
-        // Gribb/Hartmann (column-major, depth ∈ [0,1]); normalised so the
-        // per-meshlet test is a plain dot product (no per-thread length()).
-        let p0 = vec4<f32>(vp[0][3] + vp[0][0], vp[1][3] + vp[1][0], vp[2][3] + vp[2][0], vp[3][3] + vp[3][0]); // left
-        let p1 = vec4<f32>(vp[0][3] - vp[0][0], vp[1][3] - vp[1][0], vp[2][3] - vp[2][0], vp[3][3] - vp[3][0]); // right
-        let p2 = vec4<f32>(vp[0][3] + vp[0][1], vp[1][3] + vp[1][1], vp[2][3] + vp[2][1], vp[3][3] + vp[3][1]); // bottom
-        let p3 = vec4<f32>(vp[0][3] - vp[0][1], vp[1][3] - vp[1][1], vp[2][3] - vp[2][1], vp[3][3] - vp[3][1]); // top
-        let p4 = vec4<f32>(vp[0][2], vp[1][2], vp[2][2], vp[3][2]);                                               // near
-        let p5 = vec4<f32>(vp[0][3] - vp[0][2], vp[1][3] - vp[1][2], vp[2][3] - vp[2][2], vp[3][3] - vp[3][2]); // far
-        wg_planes[0] = p0 / length(p0.xyz);
-        wg_planes[1] = p1 / length(p1.xyz);
-        wg_planes[2] = p2 / length(p2.xyz);
-        wg_planes[3] = p3 / length(p3.xyz);
-        wg_planes[4] = p4 / length(p4.xyz);
-        wg_planes[5] = p5 / length(p5.xyz);
-    }
-    workgroupBarrier();
+fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
+    return (dot(wg_planes[0].xyz, center) + wg_planes[0].w >= -radius)
+        && (dot(wg_planes[1].xyz, center) + wg_planes[1].w >= -radius)
+        && (dot(wg_planes[2].xyz, center) + wg_planes[2].w >= -radius)
+        && (dot(wg_planes[3].xyz, center) + wg_planes[3].w >= -radius)
+        && (dot(wg_planes[4].xyz, center) + wg_planes[4].w >= -radius)
+        && (dot(wg_planes[5].xyz, center) + wg_planes[5].w >= -radius);
+}
 
-    let idx = gid.x;
-    if idx >= cull_uni.meshlet_count {
+fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
+    if meshlet_index >= arrayLength(&meshlets)
+        || instance_index >= arrayLength(&instances)
+        || instance_index >= arrayLength(&instance_cull)
+    {
         return;
     }
 
-    let m    = meshlets[idx];
-    let inst = instances[m.instance_index];
-    let inst_cull = instance_cull[m.instance_index];
+    let m = meshlets[meshlet_index];
+    let inst = instances[instance_index];
+    let inst_cull = instance_cull[instance_index];
     if inst_cull.valid_transform == 0u {
         return;
     }
 
-    let model     = inst.transform;
+    let model = inst.transform;
     let center_ws = (model * vec4<f32>(m.center, 1.0)).xyz;
-
     let world_radius = max(m.radius * inst_cull.max_scale, 0.0);
-
-    // ── LOD selection — Nanite-style projected screen coverage ──────────────
-    // Done first and cheaply (distance + radius only) so the ~7/8 of meshlets
-    // whose baked LOD isn't the one currently wanted bail out here, instead of
-    // paying for frustum planes, cone culling, and a Hi-Z texture sample only
-    // to be discarded at the end.
     let cam_to_center = center_ws - camera.position_near.xyz;
-    let cluster_dist  = max(length(cam_to_center), 0.001);
-    let obj_radius    = max(world_radius, 0.001);
-    let focal_len     = camera.proj[1][1];
-    let screen_size   = (obj_radius * focal_len) / cluster_dist;
-    let lod_level     = u32(m.lod_error + 0.5);
-    let desired_lod   = select_lod_level(screen_size);
 
-    if lod_level != desired_lod {
+    if !sphere_visible(center_ws, world_radius) {
         return;
     }
 
-    // ── Frustum cull ──────────────────────────────────────────────────────────
-    // Planes were pre-normalised once per workgroup above (see wg_planes) —
-    // just dot-product against them here, no per-thread length() needed.
-    let pl0 = wg_planes[0];
-    let pl1 = wg_planes[1];
-    let pl2 = wg_planes[2];
-    let pl3 = wg_planes[3];
-    let pl4 = wg_planes[4];
-    let pl5 = wg_planes[5];
-
-    let visible = (dot(pl0.xyz, center_ws) + pl0.w >= -world_radius)
-               && (dot(pl1.xyz, center_ws) + pl1.w >= -world_radius)
-               && (dot(pl2.xyz, center_ws) + pl2.w >= -world_radius)
-               && (dot(pl3.xyz, center_ws) + pl3.w >= -world_radius)
-               && (dot(pl4.xyz, center_ws) + pl4.w >= -world_radius)
-               && (dot(pl5.xyz, center_ws) + pl5.w >= -world_radius);
-
-    if !visible {
-        return;
-    }
-
-    // ── Backface cone cull (guarded) ─────────────────────────────────────────
-    // Skip when the camera is inside or close to the meshlet's bounding sphere
-    // to avoid false culls on nearby geometry.
+    // Exact meshoptimizer perspective-cone test. The normal matrix is safe
+    // only for angle-preserving, non-reflected transforms; CPU precomputes the
+    // conservative enable bit once per changed instance.
     let cam_dist_sq = dot(cam_to_center, cam_to_center);
     let guard_radius = world_radius * 1.5;
     if cam_dist_sq > guard_radius * guard_radius
@@ -222,84 +168,180 @@ fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocat
         }
     }
 
-    // ── Hi-Z occlusion cull ──────────────────────────────────────────────────
+    // Conservative max-depth Hi-Z test. Reject only when the complete
+    // projected sphere is on-screen and all four footprint corners are behind
+    // existing depth at the chosen mip.
     let cull_clip = camera.view_proj * vec4<f32>(center_ws, 1.0);
     if cull_clip.w > 0.0 {
         let cull_ndc = cull_clip.xyz / cull_clip.w;
-        let cull_uv_x = cull_ndc.x * 0.5 + 0.5;
-        let cull_uv_y = cull_ndc.y * -0.5 + 0.5;
-        let cull_uv = vec2<f32>(cull_uv_x, cull_uv_y);
-
-        // Dividing by the sphere center depth underestimates its projected
-        // footprint. Use the nearest possible depth for a conservative bound.
+        let cull_uv = vec2<f32>(cull_ndc.x * 0.5 + 0.5, cull_ndc.y * -0.5 + 0.5);
         let nearest_view_depth = cull_clip.w - world_radius;
         if nearest_view_depth > camera.position_near.w {
             let ndc_r = max(
-            abs(world_radius * camera.proj[0][0] / nearest_view_depth),
-            abs(world_radius * camera.proj[1][1] / nearest_view_depth),
+                abs(world_radius * camera.proj[0][0] / nearest_view_depth),
+                abs(world_radius * camera.proj[1][1] / nearest_view_depth),
             );
+            let uv_radius = ndc_r * 0.5;
+            let uv_min = cull_uv - vec2<f32>(uv_radius);
+            let uv_max = cull_uv + vec2<f32>(uv_radius);
 
-        let uv_radius = ndc_r * 0.5;
-        let uv_min = cull_uv - vec2<f32>(uv_radius);
-        let uv_max = cull_uv + vec2<f32>(uv_radius);
+            if all(uv_min >= vec2<f32>(0.0)) && all(uv_max <= vec2<f32>(1.0)) {
+                let dist_sq = dot(cam_to_center, cam_to_center);
+                var near_z = 0.0;
+                if dist_sq > world_radius * world_radius {
+                    let direction = cam_to_center / sqrt(dist_sq);
+                    let near_ws = center_ws - direction * world_radius;
+                    let near_clip = camera.view_proj * vec4<f32>(near_ws, 1.0);
+                    if near_clip.w > 0.0 {
+                        near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
+                    }
+                }
 
-        // Only reject when the complete projected bound is on screen. Clamped
-        // edge samples can otherwise claim occlusion for geometry entering the
-        // viewport.
-        if all(uv_min >= vec2<f32>(0.0)) && all(uv_max <= vec2<f32>(1.0)) {
-            let cam_pos = camera.position_near.xyz;
-            let to_meshlet = center_ws - cam_pos;
-            let dist_sq = dot(to_meshlet, to_meshlet);
-            var near_z = 0.0;
-            if dist_sq > world_radius * world_radius {
-                let dir = to_meshlet * (1.0 / sqrt(dist_sq));
-                let near_ws = center_ws - dir * world_radius;
-                let near_clip = camera.view_proj * vec4<f32>(near_ws, 1.0);
-                if near_clip.w > 0.0 {
-                    near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
+                let half_height = f32(cull_uni.screen_height) * 0.5;
+                let diameter_px = max(ndc_r * half_height * 2.0, 1.0);
+                let mip = clamp(
+                    u32(ceil(log2(diameter_px))),
+                    0u,
+                    cull_uni.hiz_mip_count - 1u,
+                );
+                let hiz_00 = textureSampleLevel(hiz_tex, hiz_samp, uv_min, f32(mip)).r;
+                let hiz_01 = textureSampleLevel(
+                    hiz_tex,
+                    hiz_samp,
+                    vec2<f32>(uv_max.x, uv_min.y),
+                    f32(mip),
+                ).r;
+                let hiz_10 = textureSampleLevel(
+                    hiz_tex,
+                    hiz_samp,
+                    vec2<f32>(uv_min.x, uv_max.y),
+                    f32(mip),
+                ).r;
+                let hiz_11 = textureSampleLevel(hiz_tex, hiz_samp, uv_max, f32(mip)).r;
+                let hiz_depth = max(max(hiz_00, hiz_01), max(hiz_10, hiz_11));
+                if near_z > hiz_depth + 1.0 / 65536.0 {
+                    return;
                 }
             }
-
-            let half_h = f32(cull_uni.screen_height) * 0.5;
-            let r_px = ndc_r * half_h;
-            let diameter = max(r_px * 2.0, 1.0);
-            let mip = clamp(u32(ceil(log2(diameter))), 0u, cull_uni.hiz_mip_count - 1u);
-
-            // A single center texel is not conservative when the projected
-            // sphere crosses multiple texels at the chosen mip. Sample all
-            // four corners and keep the farthest depth in the max-depth Hi-Z.
-            let hiz_00 = textureSampleLevel(hiz_tex, hiz_samp, uv_min, f32(mip)).r;
-            let hiz_01 = textureSampleLevel(
-                hiz_tex,
-                hiz_samp,
-                vec2<f32>(uv_max.x, uv_min.y),
-                f32(mip),
-            ).r;
-            let hiz_10 = textureSampleLevel(
-                hiz_tex,
-                hiz_samp,
-                vec2<f32>(uv_min.x, uv_max.y),
-                f32(mip),
-            ).r;
-            let hiz_11 = textureSampleLevel(hiz_tex, hiz_samp, uv_max, f32(mip)).r;
-            let hiz_depth = max(max(hiz_00, hiz_01), max(hiz_10, hiz_11));
-
-            let depth_bias = 1.0 / 65536.0;
-            if near_z > hiz_depth + depth_bias {
-                return;
-            }
-        }
         }
     }
 
-    var cmd: DrawIndexedIndirect;
-    cmd.index_count    = m.index_count;
-    cmd.instance_count = 1u;
-    cmd.first_index    = m.first_index;
-    cmd.base_vertex    = m.vertex_offset;
-    // Pack LOD level into upper 8 bits of first_instance so the draw shader
-    // can extract it for debug visualisation (LOD heatmap mode 21).
-    cmd.first_instance = m.instance_index | (lod_level << 24u);
+    var command: DrawIndexedIndirect;
+    command.index_count = m.index_count;
+    command.instance_count = 1u;
+    command.first_index = m.first_index;
+    command.base_vertex = m.vertex_offset;
     let slot = atomicAdd(&draw_count, 1u);
-    indirect[slot] = cmd;
+    let capacity = min(
+        cull_uni.draw_capacity,
+        min(arrayLength(&indirect), arrayLength(&draw_metadata)),
+    );
+    if slot < capacity {
+        command.first_instance = slot;
+        indirect[slot] = command;
+        draw_metadata[slot] = VgDrawMetadata(
+            instance_index,
+            meshlet_index,
+            lod_level,
+            0u,
+        );
+    }
+}
+
+@compute @workgroup_size(64)
+fn cs_cull(
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+    @builtin(local_invocation_index) lane: u32,
+) {
+    let object_index = workgroup_id.x + workgroup_id.y * cull_uni.dispatch_width;
+
+    // Every lane must reach the barrier, so lane zero publishes validity and
+    // range state instead of returning early.
+    if lane == 0u {
+        let vp = camera.view_proj;
+        let p0 = vec4<f32>(vp[0][3] + vp[0][0], vp[1][3] + vp[1][0], vp[2][3] + vp[2][0], vp[3][3] + vp[3][0]);
+        let p1 = vec4<f32>(vp[0][3] - vp[0][0], vp[1][3] - vp[1][0], vp[2][3] - vp[2][0], vp[3][3] - vp[3][0]);
+        let p2 = vec4<f32>(vp[0][3] + vp[0][1], vp[1][3] + vp[1][1], vp[2][3] + vp[2][1], vp[3][3] + vp[3][1]);
+        let p3 = vec4<f32>(vp[0][3] - vp[0][1], vp[1][3] - vp[1][1], vp[2][3] - vp[2][1], vp[3][3] - vp[3][1]);
+        let p4 = vec4<f32>(vp[0][2], vp[1][2], vp[2][2], vp[3][2]);
+        let p5 = vec4<f32>(vp[0][3] - vp[0][2], vp[1][3] - vp[1][2], vp[2][3] - vp[2][2], vp[3][3] - vp[3][2]);
+        wg_planes[0] = p0 / length(p0.xyz);
+        wg_planes[1] = p1 / length(p1.xyz);
+        wg_planes[2] = p2 / length(p2.xyz);
+        wg_planes[3] = p3 / length(p3.xyz);
+        wg_planes[4] = p4 / length(p4.xyz);
+        wg_planes[5] = p5 / length(p5.xyz);
+
+        wg_first_meshlet = 0u;
+        wg_meshlet_count = 0u;
+        wg_instance_index = 0u;
+        wg_selected_lod = 0u;
+        wg_object_visible = 0u;
+
+        if object_index < cull_uni.object_count && object_index < arrayLength(&objects) {
+            let object = objects[object_index];
+            let lod_count = min(object.lod_count, 8u);
+            if lod_count > 0u
+                && object.instance_index < arrayLength(&instances)
+                && object.instance_index < arrayLength(&instance_cull)
+            {
+                let inst = instances[object.instance_index];
+                let derived = instance_cull[object.instance_index];
+                if derived.valid_transform != 0u {
+                    let center_ws = (
+                        inst.transform * vec4<f32>(object.local_bounds.xyz, 1.0)
+                    ).xyz;
+                    let world_radius = max(object.local_bounds.w * derived.max_scale, 0.0);
+                    if sphere_visible(center_ws, world_radius) {
+                        let camera_distance = length(center_ws - camera.position_near.xyz);
+                        let closest_distance = max(
+                            camera_distance - world_radius,
+                            max(camera.position_near.w, 1.0e-4),
+                        );
+                        let focal_pixels = abs(camera.proj[1][1])
+                            * f32(cull_uni.screen_height) * 0.5;
+                        var selected_lod = 0u;
+                        var level = 1u;
+                        loop {
+                            if level >= lod_count {
+                                break;
+                            }
+                            let error_px = object.lod_errors[level]
+                                * derived.max_scale * focal_pixels / closest_distance;
+                            if error_px <= cull_uni.lod_error_threshold_px {
+                                selected_lod = level;
+                                level += 1u;
+                            } else {
+                                break;
+                            }
+                        }
+
+                        wg_first_meshlet = object.lod_first_meshlets[selected_lod];
+                        wg_meshlet_count = object.lod_meshlet_counts[selected_lod];
+                        wg_instance_index = object.instance_index;
+                        wg_selected_lod = selected_lod;
+                        wg_object_visible = 1u;
+                    }
+                }
+            }
+        }
+    }
+    workgroupBarrier();
+
+    if wg_object_visible == 0u {
+        return;
+    }
+
+    var local_meshlet = lane;
+    loop {
+        if local_meshlet >= wg_meshlet_count {
+            break;
+        }
+        cull_meshlet(
+            wg_first_meshlet + local_meshlet,
+            wg_instance_index,
+            wg_selected_lod,
+        );
+        local_meshlet += 64u;
+    }
 }

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -107,7 +107,9 @@ struct CullUniforms {
 @group(0) @binding(4) var<storage, read> instances: array<InstanceData>;
 @group(0) @binding(5) var<storage, read_write> indirect: array<DrawIndexedIndirect>;
 @group(0) @binding(6) var<storage, read_write> draw_metadata: array<VgDrawMetadata>;
-@group(0) @binding(7) var<storage, read_write> draw_count: atomic<u32>;
+// Counter 0 is the attempted visible-draw count consumed by indirect-count
+// rendering. Counter 1 records attempts rejected by the bounded output arrays.
+@group(0) @binding(7) var<storage, read_write> draw_counters: array<atomic<u32>>;
 @group(0) @binding(8) var hiz_tex: texture_2d<f32>;
 @group(0) @binding(9) var hiz_samp: sampler;
 @group(0) @binding(10) var<storage, read> instance_cull: array<InstanceCullData>;
@@ -242,7 +244,7 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
     command.instance_count = 1u;
     command.first_index = m.first_index;
     command.base_vertex = m.vertex_offset;
-    let slot = atomicAdd(&draw_count, 1u);
+    let slot = atomicAdd(&draw_counters[0], 1u);
     let capacity = min(
         cull_uni.draw_capacity,
         min(arrayLength(&indirect), arrayLength(&draw_metadata)),
@@ -256,6 +258,8 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
             lod_level,
             0u,
         );
+    } else {
+        atomicAdd(&draw_counters[1], 1u);
     }
 }
 

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -1,9 +1,9 @@
 // Virtual geometry culling compute shader.
 //
-// One workgroup owns one virtual object. Lane zero conservatively culls the
-// object's transformed local-space sphere and selects exactly one LOD from the
-// measured meshoptimizer error. The 64 lanes then cooperatively cull only that
-// LOD's immutable meshlet range and append bounded indirect draw commands.
+// Stage one assigns one lane per object for conservative object culling and a
+// whole-object LOD decision. Stage two assigns one 64-lane workgroup to each
+// immutable meshlet span, so very large objects scale across the GPU instead of
+// serialising all their meshlets through one workgroup.
 
 struct Camera {
     view:           mat4x4<f32>,
@@ -35,7 +35,7 @@ struct VgObjectData {
     instance_index:       u32,
     lod_count:            u32,
     max_meshlet_count:    u32,
-    reserved:             u32,
+    selected_lod_plus_one: u32,
     local_bounds:         vec4<f32>,
     lod_errors:           array<f32, 8>,
     lod_first_meshlets:   array<u32, 8>,
@@ -79,7 +79,12 @@ struct VgDrawMetadata {
     reserved:       u32,
 }
 
-/// Mirrors CullUniforms (Rust, 32 bytes).
+struct VgWorkItem {
+    object_index:       u32,
+    local_meshlet_base: u32,
+}
+
+/// Mirrors CullUniforms (Rust, 48 bytes).
 struct CullUniforms {
     object_count:          u32,
     screen_width:          u32,
@@ -87,14 +92,18 @@ struct CullUniforms {
     hiz_mip_count:         u32,
     draw_capacity:         u32,
     lod_error_threshold_px: f32,
-    dispatch_width:        u32,
+    object_dispatch_width: u32,
+    work_item_count:       u32,
+    work_dispatch_width:   u32,
     _pad0:                 u32,
+    _pad1:                 u32,
+    _pad2:                 u32,
 }
 
 @group(0) @binding(0) var<uniform> camera: Camera;
 @group(0) @binding(1) var<uniform> cull_uni: CullUniforms;
 @group(0) @binding(2) var<storage, read> meshlets: array<MeshletEntry>;
-@group(0) @binding(3) var<storage, read> objects: array<VgObjectData>;
+@group(0) @binding(3) var<storage, read_write> objects: array<VgObjectData>;
 @group(0) @binding(4) var<storage, read> instances: array<InstanceData>;
 @group(0) @binding(5) var<storage, read_write> indirect: array<DrawIndexedIndirect>;
 @group(0) @binding(6) var<storage, read_write> draw_metadata: array<VgDrawMetadata>;
@@ -102,6 +111,7 @@ struct CullUniforms {
 @group(0) @binding(8) var hiz_tex: texture_2d<f32>;
 @group(0) @binding(9) var hiz_samp: sampler;
 @group(0) @binding(10) var<storage, read> instance_cull: array<InstanceCullData>;
+@group(0) @binding(11) var<storage, read> work_items: array<VgWorkItem>;
 
 var<workgroup> wg_planes: array<vec4<f32>, 6>;
 var<workgroup> wg_first_meshlet: u32;
@@ -109,6 +119,7 @@ var<workgroup> wg_meshlet_count: u32;
 var<workgroup> wg_instance_index: u32;
 var<workgroup> wg_selected_lod: u32;
 var<workgroup> wg_object_visible: u32;
+var<workgroup> wg_local_meshlet_base: u32;
 
 fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
     return (dot(wg_planes[0].xyz, center) + wg_planes[0].w >= -radius)
@@ -248,78 +259,117 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
     }
 }
 
+fn publish_frustum_planes() {
+    let vp = camera.view_proj;
+    let p0 = vec4<f32>(vp[0][3] + vp[0][0], vp[1][3] + vp[1][0], vp[2][3] + vp[2][0], vp[3][3] + vp[3][0]);
+    let p1 = vec4<f32>(vp[0][3] - vp[0][0], vp[1][3] - vp[1][0], vp[2][3] - vp[2][0], vp[3][3] - vp[3][0]);
+    let p2 = vec4<f32>(vp[0][3] + vp[0][1], vp[1][3] + vp[1][1], vp[2][3] + vp[2][1], vp[3][3] + vp[3][1]);
+    let p3 = vec4<f32>(vp[0][3] - vp[0][1], vp[1][3] - vp[1][1], vp[2][3] - vp[2][1], vp[3][3] - vp[3][1]);
+    let p4 = vec4<f32>(vp[0][2], vp[1][2], vp[2][2], vp[3][2]);
+    let p5 = vec4<f32>(vp[0][3] - vp[0][2], vp[1][3] - vp[1][2], vp[2][3] - vp[2][2], vp[3][3] - vp[3][2]);
+    wg_planes[0] = p0 / length(p0.xyz);
+    wg_planes[1] = p1 / length(p1.xyz);
+    wg_planes[2] = p2 / length(p2.xyz);
+    wg_planes[3] = p3 / length(p3.xyz);
+    wg_planes[4] = p4 / length(p4.xyz);
+    wg_planes[5] = p5 / length(p5.xyz);
+}
+
 @compute @workgroup_size(64)
-fn cs_cull(
+fn cs_select_objects(
     @builtin(workgroup_id) workgroup_id: vec3<u32>,
     @builtin(local_invocation_index) lane: u32,
 ) {
-    let object_index = workgroup_id.x + workgroup_id.y * cull_uni.dispatch_width;
-
-    // Every lane must reach the barrier, so lane zero publishes validity and
-    // range state instead of returning early.
     if lane == 0u {
-        let vp = camera.view_proj;
-        let p0 = vec4<f32>(vp[0][3] + vp[0][0], vp[1][3] + vp[1][0], vp[2][3] + vp[2][0], vp[3][3] + vp[3][0]);
-        let p1 = vec4<f32>(vp[0][3] - vp[0][0], vp[1][3] - vp[1][0], vp[2][3] - vp[2][0], vp[3][3] - vp[3][0]);
-        let p2 = vec4<f32>(vp[0][3] + vp[0][1], vp[1][3] + vp[1][1], vp[2][3] + vp[2][1], vp[3][3] + vp[3][1]);
-        let p3 = vec4<f32>(vp[0][3] - vp[0][1], vp[1][3] - vp[1][1], vp[2][3] - vp[2][1], vp[3][3] - vp[3][1]);
-        let p4 = vec4<f32>(vp[0][2], vp[1][2], vp[2][2], vp[3][2]);
-        let p5 = vec4<f32>(vp[0][3] - vp[0][2], vp[1][3] - vp[1][2], vp[2][3] - vp[2][2], vp[3][3] - vp[3][2]);
-        wg_planes[0] = p0 / length(p0.xyz);
-        wg_planes[1] = p1 / length(p1.xyz);
-        wg_planes[2] = p2 / length(p2.xyz);
-        wg_planes[3] = p3 / length(p3.xyz);
-        wg_planes[4] = p4 / length(p4.xyz);
-        wg_planes[5] = p5 / length(p5.xyz);
+        publish_frustum_planes();
+    }
+    workgroupBarrier();
 
+    let group_index = workgroup_id.x
+        + workgroup_id.y * cull_uni.object_dispatch_width;
+    let object_index = group_index * 64u + lane;
+    if object_index >= cull_uni.object_count
+        || object_index >= arrayLength(&objects)
+    {
+        return;
+    }
+
+    var selected_lod_plus_one = 0u;
+    let object = objects[object_index];
+    let lod_count = min(object.lod_count, 8u);
+    if lod_count > 0u
+        && object.instance_index < arrayLength(&instances)
+        && object.instance_index < arrayLength(&instance_cull)
+    {
+        let inst = instances[object.instance_index];
+        let derived = instance_cull[object.instance_index];
+        if derived.valid_transform != 0u {
+            let center_ws = (
+                inst.transform * vec4<f32>(object.local_bounds.xyz, 1.0)
+            ).xyz;
+            let world_radius = max(object.local_bounds.w * derived.max_scale, 0.0);
+            if sphere_visible(center_ws, world_radius) {
+                let camera_distance = length(center_ws - camera.position_near.xyz);
+                let closest_distance = max(
+                    camera_distance - world_radius,
+                    max(camera.position_near.w, 1.0e-4),
+                );
+                let focal_pixels = abs(camera.proj[1][1])
+                    * f32(cull_uni.screen_height) * 0.5;
+                var selected_lod = 0u;
+                var level = 1u;
+                loop {
+                    if level >= lod_count {
+                        break;
+                    }
+                    let error_px = object.lod_errors[level]
+                        * derived.max_scale * focal_pixels / closest_distance;
+                    if error_px <= cull_uni.lod_error_threshold_px {
+                        selected_lod = level;
+                        level += 1u;
+                    } else {
+                        break;
+                    }
+                }
+                selected_lod_plus_one = selected_lod + 1u;
+            }
+        }
+    }
+    objects[object_index].selected_lod_plus_one = selected_lod_plus_one;
+}
+
+@compute @workgroup_size(64)
+fn cs_cull_meshlets(
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+    @builtin(local_invocation_index) lane: u32,
+) {
+    let work_index = workgroup_id.x
+        + workgroup_id.y * cull_uni.work_dispatch_width;
+
+    if lane == 0u {
+        publish_frustum_planes();
         wg_first_meshlet = 0u;
         wg_meshlet_count = 0u;
         wg_instance_index = 0u;
         wg_selected_lod = 0u;
         wg_object_visible = 0u;
+        wg_local_meshlet_base = 0u;
 
-        if object_index < cull_uni.object_count && object_index < arrayLength(&objects) {
-            let object = objects[object_index];
-            let lod_count = min(object.lod_count, 8u);
-            if lod_count > 0u
-                && object.instance_index < arrayLength(&instances)
-                && object.instance_index < arrayLength(&instance_cull)
-            {
-                let inst = instances[object.instance_index];
-                let derived = instance_cull[object.instance_index];
-                if derived.valid_transform != 0u {
-                    let center_ws = (
-                        inst.transform * vec4<f32>(object.local_bounds.xyz, 1.0)
-                    ).xyz;
-                    let world_radius = max(object.local_bounds.w * derived.max_scale, 0.0);
-                    if sphere_visible(center_ws, world_radius) {
-                        let camera_distance = length(center_ws - camera.position_near.xyz);
-                        let closest_distance = max(
-                            camera_distance - world_radius,
-                            max(camera.position_near.w, 1.0e-4),
-                        );
-                        let focal_pixels = abs(camera.proj[1][1])
-                            * f32(cull_uni.screen_height) * 0.5;
-                        var selected_lod = 0u;
-                        var level = 1u;
-                        loop {
-                            if level >= lod_count {
-                                break;
-                            }
-                            let error_px = object.lod_errors[level]
-                                * derived.max_scale * focal_pixels / closest_distance;
-                            if error_px <= cull_uni.lod_error_threshold_px {
-                                selected_lod = level;
-                                level += 1u;
-                            } else {
-                                break;
-                            }
-                        }
-
+        if work_index < cull_uni.work_item_count
+            && work_index < arrayLength(&work_items)
+        {
+            let item = work_items[work_index];
+            if item.object_index < arrayLength(&objects) {
+                let object = objects[item.object_index];
+                if object.selected_lod_plus_one != 0u {
+                    let selected_lod = object.selected_lod_plus_one - 1u;
+                    let selected_count = object.lod_meshlet_counts[selected_lod];
+                    if item.local_meshlet_base < selected_count {
                         wg_first_meshlet = object.lod_first_meshlets[selected_lod];
-                        wg_meshlet_count = object.lod_meshlet_counts[selected_lod];
+                        wg_meshlet_count = selected_count;
                         wg_instance_index = object.instance_index;
                         wg_selected_lod = selected_lod;
+                        wg_local_meshlet_base = item.local_meshlet_base;
                         wg_object_visible = 1u;
                     }
                 }
@@ -331,17 +381,12 @@ fn cs_cull(
     if wg_object_visible == 0u {
         return;
     }
-
-    var local_meshlet = lane;
-    loop {
-        if local_meshlet >= wg_meshlet_count {
-            break;
-        }
+    let local_meshlet = wg_local_meshlet_base + lane;
+    if local_meshlet < wg_meshlet_count {
         cull_meshlet(
             wg_first_meshlet + local_meshlet,
             wg_instance_index,
             wg_selected_lod,
         );
-        local_meshlet += 64u;
     }
 }

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -336,6 +336,15 @@ fn cs_select_objects(
                     }
                 }
                 selected_lod_plus_one = selected_lod + 1u;
+                // The first two counters remain the indirect draw count and
+                // publication-overflow count. Larger production buffers also
+                // expose a selected-object histogram and the deepest LOD that
+                // the visible assets actually contain. The length guard keeps
+                // the same shader compatible with minimal benchmark buffers.
+                if arrayLength(&draw_counters) >= 11u {
+                    atomicAdd(&draw_counters[2u + selected_lod], 1u);
+                    atomicMax(&draw_counters[10], lod_count - 1u);
+                }
             }
         }
     }

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -86,11 +86,15 @@ struct CullUniforms {
 
 @group(0) @binding(6) var hiz_tex:  texture_2d<f32>;
 @group(0) @binding(7) var hiz_samp: sampler;
-/// One entry per instance: max(|col0|, |col1|, |col2|) of its transform.
-/// Precomputed CPU-side once per instance (see instance_scale_buf in lib.rs) —
-/// identical for every meshlet of a given instance, so there's no reason for
-/// every meshlet thread to redo the 3 sqrt()s that produced it.
-@group(0) @binding(8) var<storage, read> instance_scale: array<f32>;
+struct InstanceCullData {
+    max_scale:          f32,
+    min_scale:          f32,
+    cone_cull_enabled:  u32,
+    valid_transform:    u32,
+}
+
+/// Values derived from the model matrix once when instance data changes.
+@group(0) @binding(8) var<storage, read> instance_cull: array<InstanceCullData>;
 
 // ─── LOD selection ───────────────────────────────────────────────────────────
 
@@ -145,11 +149,15 @@ fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocat
 
     let m    = meshlets[idx];
     let inst = instances[m.instance_index];
+    let inst_cull = instance_cull[m.instance_index];
+    if inst_cull.valid_transform == 0u {
+        return;
+    }
 
     let model     = inst.transform;
     let center_ws = (model * vec4<f32>(m.center, 1.0)).xyz;
 
-    let world_radius = m.radius * instance_scale[m.instance_index];
+    let world_radius = max(m.radius * inst_cull.max_scale, 0.0);
 
     // ── LOD selection — Nanite-style projected screen coverage ──────────────
     // Done first and cheaply (distance + radius only) so the ~7/8 of meshlets
@@ -194,11 +202,22 @@ fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocat
     // to avoid false culls on nearby geometry.
     let cam_dist_sq = dot(cam_to_center, cam_to_center);
     let guard_radius = world_radius * 1.5;
-    if cam_dist_sq > guard_radius * guard_radius && m.cone_cutoff <= 1.0 {
-        let model_mat3 = mat3x3<f32>(model[0].xyz, model[1].xyz, model[2].xyz);
-        let cone_axis_ws = normalize(model_mat3 * m.cone_axis);
-        let view_dir = normalize(cam_to_center);
-        if dot(view_dir, cone_axis_ws) >= m.cone_cutoff {
+    if cam_dist_sq > guard_radius * guard_radius
+        && m.cone_cutoff <= 1.0
+        && inst_cull.cone_cull_enabled != 0u
+    {
+        let normal_mat = mat3x3<f32>(
+            inst.normal_mat_0.xyz,
+            inst.normal_mat_1.xyz,
+            inst.normal_mat_2.xyz,
+        );
+        let cone_axis_ws = normalize(normal_mat * m.cone_axis);
+        let cone_apex_ws = (model * vec4<f32>(m.cone_apex, 1.0)).xyz;
+        let camera_to_apex = cone_apex_ws - camera.position_near.xyz;
+        let apex_distance_sq = dot(camera_to_apex, camera_to_apex);
+        if apex_distance_sq > 1.0e-12
+            && dot(camera_to_apex / sqrt(apex_distance_sq), cone_axis_ws) >= m.cone_cutoff
+        {
             return;
         }
     }
@@ -211,13 +230,23 @@ fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocat
         let cull_uv_y = cull_ndc.y * -0.5 + 0.5;
         let cull_uv = vec2<f32>(cull_uv_x, cull_uv_y);
 
-        let ndc_r = max(
-            abs(world_radius * camera.proj[0][0] / cull_clip.w),
-            abs(world_radius * camera.proj[1][1] / cull_clip.w),
-        );
+        // Dividing by the sphere center depth underestimates its projected
+        // footprint. Use the nearest possible depth for a conservative bound.
+        let nearest_view_depth = cull_clip.w - world_radius;
+        if nearest_view_depth > camera.position_near.w {
+            let ndc_r = max(
+            abs(world_radius * camera.proj[0][0] / nearest_view_depth),
+            abs(world_radius * camera.proj[1][1] / nearest_view_depth),
+            );
 
-        if cull_uv.x + ndc_r > -1.0 && cull_uv.x - ndc_r < 1.0 &&
-           cull_uv.y + ndc_r > -1.0 && cull_uv.y - ndc_r < 1.0 {
+        let uv_radius = ndc_r * 0.5;
+        let uv_min = cull_uv - vec2<f32>(uv_radius);
+        let uv_max = cull_uv + vec2<f32>(uv_radius);
+
+        // Only reject when the complete projected bound is on screen. Clamped
+        // edge samples can otherwise claim occlusion for geometry entering the
+        // viewport.
+        if all(uv_min >= vec2<f32>(0.0)) && all(uv_max <= vec2<f32>(1.0)) {
             let cam_pos = camera.position_near.xyz;
             let to_meshlet = center_ws - cam_pos;
             let dist_sq = dot(to_meshlet, to_meshlet);
@@ -226,21 +255,40 @@ fn cs_cull(@builtin(global_invocation_id) gid: vec3<u32>, @builtin(local_invocat
                 let dir = to_meshlet * (1.0 / sqrt(dist_sq));
                 let near_ws = center_ws - dir * world_radius;
                 let near_clip = camera.view_proj * vec4<f32>(near_ws, 1.0);
-                near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
+                if near_clip.w > 0.0 {
+                    near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
+                }
             }
 
             let half_h = f32(cull_uni.screen_height) * 0.5;
-            let r_px = abs(world_radius / cull_clip.w * camera.proj[1][1] * half_h);
+            let r_px = ndc_r * half_h;
             let diameter = max(r_px * 2.0, 1.0);
             let mip = clamp(u32(ceil(log2(diameter))), 0u, cull_uni.hiz_mip_count - 1u);
 
-            let sample_uv = clamp(cull_uv, vec2<f32>(0.0), vec2<f32>(1.0));
-            let hiz_depth = textureSampleLevel(hiz_tex, hiz_samp, sample_uv, f32(mip)).r;
+            // A single center texel is not conservative when the projected
+            // sphere crosses multiple texels at the chosen mip. Sample all
+            // four corners and keep the farthest depth in the max-depth Hi-Z.
+            let hiz_00 = textureSampleLevel(hiz_tex, hiz_samp, uv_min, f32(mip)).r;
+            let hiz_01 = textureSampleLevel(
+                hiz_tex,
+                hiz_samp,
+                vec2<f32>(uv_max.x, uv_min.y),
+                f32(mip),
+            ).r;
+            let hiz_10 = textureSampleLevel(
+                hiz_tex,
+                hiz_samp,
+                vec2<f32>(uv_min.x, uv_max.y),
+                f32(mip),
+            ).r;
+            let hiz_11 = textureSampleLevel(hiz_tex, hiz_samp, uv_max, f32(mip)).r;
+            let hiz_depth = max(max(hiz_00, hiz_01), max(hiz_10, hiz_11));
 
             let depth_bias = 1.0 / 65536.0;
             if near_z > hiz_depth + depth_bias {
                 return;
             }
+        }
         }
     }
 

--- a/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
@@ -7,8 +7,6 @@
 // This shader is compiled into `helio-pass-virtual-geometry` and draws only
 // VG meshlets that survived the cull compute shader.
 
-// (primitive_index extension removed: not supported by WebGPU in browsers)
-
 struct Camera {
     view:           mat4x4<f32>,
     proj:           mat4x4<f32>,
@@ -81,9 +79,18 @@ struct GpuInstanceData {
     _pad:         u32,
 }
 
+/// Mirrors GpuVgDraw (Rust, 16 bytes).
+struct VgDrawMetadata {
+    instance_index: u32,
+    meshlet_index:  u32,
+    lod_level:      u32,
+    reserved:       u32,
+}
+
 @group(0) @binding(0) var<uniform>       camera:        Camera;
 @group(0) @binding(1) var<uniform>       globals:       Globals;
 @group(0) @binding(2) var<storage, read> instance_data: array<GpuInstanceData>;
+@group(0) @binding(3) var<storage, read> draw_metadata: array<VgDrawMetadata>;
 
 @group(1) @binding(0) var<storage, read> materials:          array<GpuMaterial>;
 @group(1) @binding(1) var<storage, read> material_textures:  array<MaterialTextureData>;
@@ -106,6 +113,7 @@ struct VertexOutput {
     @location(3) world_tangent:  vec3<f32>,
     @location(4) bitangent_sign: f32,
     @location(5) @interpolate(flat) material_id:    u32,
+    @location(6) @interpolate(flat) meshlet_id:     u32,
 }
 
 fn decode_snorm8x4(packed: u32) -> vec3<f32> {
@@ -113,10 +121,9 @@ fn decode_snorm8x4(packed: u32) -> vec3<f32> {
 }
 
 @vertex
-fn vs_main(v: Vertex, @builtin(instance_index) packed_slot: u32) -> VertexOutput {
-    // LOD level is packed in upper 8 bits by the cull shader.
-    let slot = packed_slot & 0x00FFFFFFu;
-    let inst      = instance_data[slot];
+fn vs_main(v: Vertex, @builtin(instance_index) draw_slot: u32) -> VertexOutput {
+    let draw      = draw_metadata[draw_slot];
+    let inst      = instance_data[draw.instance_index];
     let world_pos = inst.transform * vec4<f32>(v.position, 1.0);
 
     let normal_mat = mat3x3<f32>(
@@ -138,6 +145,7 @@ fn vs_main(v: Vertex, @builtin(instance_index) packed_slot: u32) -> VertexOutput
     out.bitangent_sign = v.bitangent_sign;
     out.tex_coords     = v.tex_coords;
     out.material_id    = inst.material_id;
+    out.meshlet_id     = draw.meshlet_index;
     return out;
 }
 
@@ -238,22 +246,12 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
     return out;
 }
 
-// ── Deterministic per-triangle hash for debug colouring ─────────────────────
-// Uses world-space face centroid to generate a stable per-triangle seed.
-fn tri_hash(world_pos: vec3<f32>) -> u32 {
-    let centroid = floor(world_pos * 1000.0);
-    var h = u32(centroid.x) * 73856093u ^ u32(centroid.y) * 19349663u ^ u32(centroid.z) * 83492791u;
-    h ^= h >> 13u;
-    h *= 2654435769u;
-    h ^= h >> 16u;
-    return h;
-}
-
-// ── VG triangle debug (mode 20): unlit solid colour per meshlet + per-tri variation
+// ── VG meshlet debug (mode 20): one unlit solid colour per meshlet ──────────
 @fragment
 fn fs_debug(input: VertexOutput) -> GBufferOutput {
-    // Meshlet-level base colour from material_id hash.
-    var h = (input.material_id * 2747636419u);
+    // `meshlet_id` is flat-interpolated draw metadata emitted by the cull
+    // shader, so every triangle in one meshlet receives exactly one color.
+    var h = (input.meshlet_id * 2747636419u);
     h ^= h >> 16u;
     h *= 2654435769u;
     h ^= h >> 16u;
@@ -273,11 +271,7 @@ fn fs_debug(input: VertexOutput) -> GBufferOutput {
     pal[10] = vec3<f32>(0.00, 0.65, 0.65);
     pal[11] = vec3<f32>(1.00, 0.70, 0.10);
 
-    // Per-triangle variation: slight brightness shift so individual triangles are visible.
-    let face_centroid = input.world_position;
-    let t_hash = tri_hash(face_centroid);
-    let brightness = 0.7 + 0.3 * f32(t_hash % 256u) / 255.0;
-    let base_color = pal[idx] * brightness;
+    let base_color = pal[idx];
 
     // Unlit: write colour directly, flat face normal, no material/lighting.
     let face_n = normalize(cross(dpdx(input.world_position), dpdy(input.world_position)));
@@ -291,9 +285,8 @@ fn fs_debug(input: VertexOutput) -> GBufferOutput {
 }
 
 // ── VG LOD heatmap debug (mode 21) ─────────────────────────────────────────
-// Nanite-style: per-triangle colours tinted by LOD level.
-// Green (LOD0/full detail) → Red (LOD7/coarsest), with per-tri variation
-// so individual triangles remain visible within each LOD band.
+// One flat colour per selected object LOD. Green is LOD0/full detail and dark
+// magenta is LOD7/coarsest. Triangle variation would falsely imply mixed LODs.
 
 struct LodVertexOutput {
     @invariant @builtin(position) clip_position: vec4<f32>,
@@ -302,10 +295,10 @@ struct LodVertexOutput {
 }
 
 @vertex
-fn vs_debug_lod(v: Vertex, @builtin(instance_index) packed_slot: u32) -> LodVertexOutput {
-    let slot      = packed_slot & 0x00FFFFFFu;
-    let lod_level = packed_slot >> 24u;
-    let inst      = instance_data[slot];
+fn vs_debug_lod(v: Vertex, @builtin(instance_index) draw_slot: u32) -> LodVertexOutput {
+    let draw      = draw_metadata[draw_slot];
+    let lod_level = draw.lod_level;
+    let inst      = instance_data[draw.instance_index];
     let world_pos = inst.transform * vec4<f32>(v.position, 1.0);
 
     var out: LodVertexOutput;
@@ -331,18 +324,13 @@ fn fs_debug_lod(input: LodVertexOutput) -> GBufferOutput {
     let idx = min(u32(input.lod_level + 0.5), 7u);
     let lod_color = pal[idx];
 
-    // Per-triangle brightness variation so individual tris are visible.
-    let t_hash = tri_hash(input.world_position);
-    let brightness = 0.7 + 0.3 * f32(t_hash % 256u) / 255.0;
-    let final_color = lod_color * brightness;
-
     // Unlit: emit colour directly, no material/lighting.
     let face_n = normalize(cross(dpdx(input.world_position), dpdy(input.world_position)));
     var out: GBufferOutput;
-    out.albedo   = vec4<f32>(final_color, 1.0);
+    out.albedo   = vec4<f32>(lod_color, 1.0);
     out.normal   = vec4<f32>(face_n, 0.0);
     out.orm      = vec4<f32>(1.0, 1.0, 0.0, 0.0);
-    out.emissive = vec4<f32>(final_color, 0.0);
+    out.emissive = vec4<f32>(lod_color, 0.0);
     out.vg_flag  = vec2<f32>(-2.0, -2.0);
     return out;
 }

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -3,6 +3,7 @@ pub mod rendering;
 pub use rendering::VirtualGeometryPass;
 
 use bytemuck::{Pod, Zeroable};
+use helio_core::GpuInstanceData;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Constants
@@ -19,6 +20,57 @@ pub const LOD_LEVEL_COUNT: u32 = 8;
 
 pub(crate) const INITIAL_MESHLETS: u64 = 1024;
 pub(crate) const INITIAL_INSTANCES: u64 = 256;
+
+/// Per-instance values used by meshlet culling. Kept separate from
+/// `GpuInstanceData` so the cull shader does not recompute matrix norms for
+/// every meshlet in an instance.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+pub(crate) struct InstanceCullData {
+    pub max_scale: f32,
+    pub min_scale: f32,
+    pub cone_cull_enabled: u32,
+    pub valid_transform: u32,
+}
+
+impl InstanceCullData {
+    pub(crate) fn from_instance(instance: &GpuInstanceData) -> Self {
+        let model = &instance.model;
+        let scale_x = (model[0] * model[0] + model[1] * model[1] + model[2] * model[2]).sqrt();
+        let scale_y = (model[4] * model[4] + model[5] * model[5] + model[6] * model[6]).sqrt();
+        let scale_z = (model[8] * model[8] + model[9] * model[9] + model[10] * model[10]).sqrt();
+        let max_scale = scale_x.max(scale_y).max(scale_z);
+        let min_scale = scale_x.min(scale_y).min(scale_z);
+        let dot_xy = model[0] * model[4] + model[1] * model[5] + model[2] * model[6];
+        let dot_xz = model[0] * model[8] + model[1] * model[9] + model[2] * model[10];
+        let dot_yz = model[4] * model[8] + model[5] * model[9] + model[6] * model[10];
+        let determinant = model[0] * (model[5] * model[10] - model[6] * model[9])
+            - model[4] * (model[1] * model[10] - model[2] * model[9])
+            + model[8] * (model[1] * model[6] - model[2] * model[5]);
+        let affine = model[3].abs() <= 1.0e-6
+            && model[7].abs() <= 1.0e-6
+            && model[11].abs() <= 1.0e-6
+            && (model[15] - 1.0).abs() <= 1.0e-4;
+        let valid = model.iter().all(|value| value.is_finite())
+            && max_scale.is_finite()
+            && min_scale > 1.0e-8
+            && affine;
+        let uniform_tolerance = max_scale * 1.0e-4;
+        let orthogonal_tolerance = max_scale * max_scale * 1.0e-4;
+        let angle_preserving = max_scale - min_scale <= uniform_tolerance
+            && dot_xy.abs() <= orthogonal_tolerance
+            && dot_xz.abs() <= orthogonal_tolerance
+            && dot_yz.abs() <= orthogonal_tolerance;
+        let cone_cull_enabled = valid && angle_preserving && determinant > 0.0;
+
+        Self {
+            max_scale: if valid { max_scale } else { 0.0 },
+            min_scale: if valid { min_scale } else { 0.0 },
+            cone_cull_enabled: u32::from(cone_cull_enabled),
+            valid_transform: u32::from(valid),
+        }
+    }
+}
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // Lod quality preset
@@ -69,9 +121,91 @@ pub(crate) struct VgGlobals {
 #[derive(Clone, Copy, Pod, Zeroable)]
 pub(crate) struct CullUniforms {
     pub meshlet_count: u32,
-    pub screen_width:  u32,
+    pub screen_width: u32,
     pub screen_height: u32,
     pub hiz_mip_count: u32,
     pub lod_thresholds: [f32; 7],
     _pad3: f32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::InstanceCullData;
+    use helio_core::GpuInstanceData;
+
+    fn instance_with_model(model: [f32; 16]) -> GpuInstanceData {
+        GpuInstanceData {
+            model,
+            normal_mat: [0.0; 12],
+            bounds: [0.0; 4],
+            mesh_id: 0,
+            material_id: 0,
+            flags: 0,
+            lightmap_index: u32::MAX,
+        }
+    }
+
+    #[test]
+    fn instance_cull_data_is_gpu_aligned() {
+        assert_eq!(std::mem::size_of::<InstanceCullData>(), 16);
+    }
+
+    #[test]
+    fn uniform_scale_keeps_cone_culling_enabled() {
+        let instance = instance_with_model([
+            2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 4.0, 5.0, 6.0, 1.0,
+        ]);
+        let cull = InstanceCullData::from_instance(&instance);
+
+        assert_eq!(cull.valid_transform, 1);
+        assert_eq!(cull.cone_cull_enabled, 1);
+        assert_eq!(cull.max_scale, 2.0);
+        assert_eq!(cull.min_scale, 2.0);
+    }
+
+    #[test]
+    fn non_uniform_scale_disables_cone_culling_but_keeps_conservative_radius() {
+        let instance = instance_with_model([
+            4.0, 0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ]);
+        let cull = InstanceCullData::from_instance(&instance);
+
+        assert_eq!(cull.valid_transform, 1);
+        assert_eq!(cull.cone_cull_enabled, 0);
+        assert_eq!(cull.max_scale, 4.0);
+        assert_eq!(cull.min_scale, 1.0);
+    }
+
+    #[test]
+    fn singular_or_non_finite_transform_is_rejected() {
+        let singular = instance_with_model([0.0; 16]);
+        assert_eq!(
+            InstanceCullData::from_instance(&singular).valid_transform,
+            0
+        );
+
+        let mut non_finite_model = [0.0; 16];
+        non_finite_model[0] = f32::NAN;
+        let non_finite = instance_with_model(non_finite_model);
+        assert_eq!(
+            InstanceCullData::from_instance(&non_finite).valid_transform,
+            0
+        );
+    }
+
+    #[test]
+    fn shear_or_reflection_disables_cone_culling() {
+        let shear = instance_with_model([
+            1.0, 0.0, 0.0, 0.0, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ]);
+        assert_eq!(InstanceCullData::from_instance(&shear).cone_cull_enabled, 0);
+
+        let reflection = instance_with_model([
+            -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 1.0,
+        ]);
+        assert_eq!(
+            InstanceCullData::from_instance(&reflection).cone_cull_enabled,
+            0
+        );
+    }
 }

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -169,8 +169,12 @@ pub(crate) struct CullUniforms {
     pub hiz_mip_count: u32,
     pub draw_capacity: u32,
     pub lod_error_threshold_px: f32,
-    pub dispatch_width: u32,
+    pub object_dispatch_width: u32,
+    pub work_item_count: u32,
+    pub work_dispatch_width: u32,
     _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
 }
 
 #[cfg(test)]
@@ -193,7 +197,7 @@ mod tests {
     #[test]
     fn instance_cull_data_is_gpu_aligned() {
         assert_eq!(std::mem::size_of::<InstanceCullData>(), 16);
-        assert_eq!(std::mem::size_of::<CullUniforms>(), 32);
+        assert_eq!(std::mem::size_of::<CullUniforms>(), 48);
     }
 
     #[test]

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -19,6 +19,7 @@ pub(crate) const MAX_TEXTURES: usize = 16;
 pub const LOD_LEVEL_COUNT: u32 = 8;
 
 pub(crate) const INITIAL_MESHLETS: u64 = 1024;
+pub(crate) const INITIAL_OBJECTS: u64 = 256;
 pub(crate) const INITIAL_INSTANCES: u64 = 256;
 
 /// Per-instance values used by meshlet culling. Kept separate from
@@ -94,6 +95,48 @@ impl LodQuality {
             LodQuality::Ultra => [0.008, 0.005, 0.003, 0.002, 0.001, 0.0005, 0.0002],
         }
     }
+
+    /// Maximum tolerated geometric simplification error in output pixels.
+    /// The cull shader selects the coarsest whole-object LOD below this bound.
+    pub fn max_error_pixels(self) -> f32 {
+        match self {
+            LodQuality::Low => 4.0,
+            LodQuality::Medium => 2.0,
+            LodQuality::High => 1.0,
+            LodQuality::Ultra => 0.5,
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn select_object_lod(
+    errors: &[f32; LOD_LEVEL_COUNT as usize],
+    lod_count: u32,
+    max_scale: f32,
+    focal_pixels: f32,
+    closest_distance: f32,
+    max_error_pixels: f32,
+) -> u32 {
+    if lod_count == 0
+        || !max_scale.is_finite()
+        || !focal_pixels.is_finite()
+        || !closest_distance.is_finite()
+        || !max_error_pixels.is_finite()
+    {
+        return 0;
+    }
+
+    let mut selected = 0;
+    let denominator = closest_distance.max(1.0e-4);
+    for level in 1..lod_count.min(LOD_LEVEL_COUNT) {
+        let projected_error = errors[level as usize] * max_scale * focal_pixels / denominator;
+        if projected_error <= max_error_pixels {
+            selected = level;
+        } else {
+            break;
+        }
+    }
+    selected
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -120,17 +163,19 @@ pub(crate) struct VgGlobals {
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 pub(crate) struct CullUniforms {
-    pub meshlet_count: u32,
+    pub object_count: u32,
     pub screen_width: u32,
     pub screen_height: u32,
     pub hiz_mip_count: u32,
-    pub lod_thresholds: [f32; 7],
-    _pad3: f32,
+    pub draw_capacity: u32,
+    pub lod_error_threshold_px: f32,
+    pub dispatch_width: u32,
+    _pad0: u32,
 }
 
 #[cfg(test)]
 mod tests {
-    use super::InstanceCullData;
+    use super::{select_object_lod, CullUniforms, InstanceCullData, LodQuality};
     use helio_core::GpuInstanceData;
 
     fn instance_with_model(model: [f32; 16]) -> GpuInstanceData {
@@ -148,6 +193,7 @@ mod tests {
     #[test]
     fn instance_cull_data_is_gpu_aligned() {
         assert_eq!(std::mem::size_of::<InstanceCullData>(), 16);
+        assert_eq!(std::mem::size_of::<CullUniforms>(), 32);
     }
 
     #[test]
@@ -207,5 +253,21 @@ mod tests {
             InstanceCullData::from_instance(&reflection).cone_cull_enabled,
             0
         );
+    }
+
+    #[test]
+    fn object_lod_uses_measured_projected_error() {
+        let errors = [0.0, 0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64];
+
+        assert_eq!(select_object_lod(&errors, 8, 1.0, 1000.0, 100.0, 1.0), 4);
+        assert_eq!(select_object_lod(&errors, 8, 1.0, 1000.0, 10.0, 1.0), 1);
+        assert_eq!(select_object_lod(&errors, 8, 2.0, 1000.0, 100.0, 1.0), 3);
+    }
+
+    #[test]
+    fn higher_lod_quality_has_a_stricter_pixel_error_bound() {
+        assert!(LodQuality::Low.max_error_pixels() > LodQuality::Medium.max_error_pixels());
+        assert!(LodQuality::Medium.max_error_pixels() > LodQuality::High.max_error_pixels());
+        assert!(LodQuality::High.max_error_pixels() > LodQuality::Ultra.max_error_pixels());
     }
 }

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -18,6 +18,54 @@ pub(crate) const MAX_TEXTURES: usize = 16;
 
 pub const LOD_LEVEL_COUNT: u32 = 8;
 
+/// Draw publication counters written by the GPU cull stages.
+///
+/// Slot 0 is the attempted visible-meshlet count used for indirect drawing,
+/// slot 1 is the capacity-rejection count, slots 2..10 form the selected-LOD
+/// object histogram, and slot 10 stores the largest LOD available among
+/// visible objects.
+pub(crate) const DRAW_COUNTER_COUNT: u64 = 11;
+pub(crate) const DRAW_COUNTER_BYTES: u64 = DRAW_COUNTER_COUNT * 4;
+
+/// Latest non-blocking GPU readback from the virtual-geometry cull pass.
+///
+/// Debug readback is only scheduled while the LOD heatmap is active. Values
+/// can trail the rendered frame by a few frames rather than stalling the GPU.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct VirtualGeometryDebugStats {
+    pub visible_meshlets: u32,
+    pub rejected_meshlets: u32,
+    pub lod_object_counts: [u32; LOD_LEVEL_COUNT as usize],
+    pub max_available_lod: u32,
+}
+
+impl VirtualGeometryDebugStats {
+    pub fn visible_objects(self) -> u32 {
+        self.lod_object_counts.iter().copied().sum()
+    }
+
+    pub fn selected_lod_range(self) -> Option<(u32, u32)> {
+        let first = self.lod_object_counts.iter().position(|&count| count != 0)? as u32;
+        let last = self.lod_object_counts.iter().rposition(|&count| count != 0)? as u32;
+        Some((first, last))
+    }
+
+    fn from_counters(counters: &[u32]) -> Option<Self> {
+        if counters.len() < DRAW_COUNTER_COUNT as usize {
+            return None;
+        }
+
+        let mut lod_object_counts = [0; LOD_LEVEL_COUNT as usize];
+        lod_object_counts.copy_from_slice(&counters[2..10]);
+        Some(Self {
+            visible_meshlets: counters[0],
+            rejected_meshlets: counters[1],
+            lod_object_counts,
+            max_available_lod: counters[10].min(LOD_LEVEL_COUNT - 1),
+        })
+    }
+}
+
 pub(crate) const INITIAL_MESHLETS: u64 = 1024;
 pub(crate) const INITIAL_OBJECTS: u64 = 256;
 pub(crate) const INITIAL_INSTANCES: u64 = 256;
@@ -46,7 +94,7 @@ impl VirtualGeometryBudget {
     }
 
     pub const fn publication_bytes(self) -> u64 {
-        self.max_published_meshlets as u64 * 36 + 8
+        self.max_published_meshlets as u64 * 36 + DRAW_COUNTER_BYTES
     }
 
     pub const fn max_published_meshlets(self) -> u32 {
@@ -227,7 +275,7 @@ pub(crate) struct CullUniforms {
 mod tests {
     use super::{
         select_object_lod, CullUniforms, InstanceCullData, LodQuality,
-        VirtualGeometryBudget, DEFAULT_MAX_PUBLISHED_MESHLETS,
+        VirtualGeometryBudget, VirtualGeometryDebugStats, DEFAULT_MAX_PUBLISHED_MESHLETS,
     };
     use helio_core::GpuInstanceData;
 
@@ -253,7 +301,7 @@ mod tests {
     fn default_publication_budget_is_nine_mib_plus_counters() {
         let budget = VirtualGeometryBudget::default();
         assert_eq!(budget.max_published_meshlets(), DEFAULT_MAX_PUBLISHED_MESHLETS);
-        assert_eq!(budget.publication_bytes(), 9 * 1024 * 1024 + 8);
+        assert_eq!(budget.publication_bytes(), 9 * 1024 * 1024 + 44);
         assert_eq!(budget.clamp_draw_count(65_536), 65_536);
         assert_eq!(budget.clamp_draw_count(u32::MAX), DEFAULT_MAX_PUBLISHED_MESHLETS);
     }
@@ -337,5 +385,20 @@ mod tests {
         assert!(LodQuality::Low.max_error_pixels() > LodQuality::Medium.max_error_pixels());
         assert!(LodQuality::Medium.max_error_pixels() > LodQuality::High.max_error_pixels());
         assert!(LodQuality::High.max_error_pixels() > LodQuality::Ultra.max_error_pixels());
+    }
+
+    #[test]
+    fn debug_stats_decode_the_gpu_counter_layout() {
+        let stats = VirtualGeometryDebugStats::from_counters(&[
+            123, 4, 0, 2, 5, 0, 0, 1, 0, 0, 6,
+        ])
+        .expect("complete counter layout");
+
+        assert_eq!(stats.visible_meshlets, 123);
+        assert_eq!(stats.rejected_meshlets, 4);
+        assert_eq!(stats.visible_objects(), 8);
+        assert_eq!(stats.selected_lod_range(), Some((1, 5)));
+        assert_eq!(stats.max_available_lod, 6);
+        assert!(VirtualGeometryDebugStats::from_counters(&[0; 10]).is_none());
     }
 }

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -22,6 +22,52 @@ pub(crate) const INITIAL_MESHLETS: u64 = 1024;
 pub(crate) const INITIAL_OBJECTS: u64 = 256;
 pub(crate) const INITIAL_INSTANCES: u64 = 256;
 
+/// Default ceiling for visible meshlets published as indexed indirect draws.
+///
+/// At 36 bytes per slot (20-byte indirect command plus 16-byte draw metadata),
+/// this bounds the publication buffers to 9 MiB plus the two counters. Callers
+/// with a measured platform-specific budget can override it explicitly.
+pub const DEFAULT_MAX_PUBLISHED_MESHLETS: u32 = 262_144;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VirtualGeometryBudget {
+    max_published_meshlets: u32,
+}
+
+impl VirtualGeometryBudget {
+    pub const fn new(max_published_meshlets: u32) -> Self {
+        assert!(
+            max_published_meshlets > 0,
+            "virtual geometry publication budget must be non-zero"
+        );
+        Self {
+            max_published_meshlets,
+        }
+    }
+
+    pub const fn publication_bytes(self) -> u64 {
+        self.max_published_meshlets as u64 * 36 + 8
+    }
+
+    pub const fn max_published_meshlets(self) -> u32 {
+        self.max_published_meshlets
+    }
+
+    pub const fn clamp_draw_count(self, worst_case_draw_count: u32) -> u32 {
+        if worst_case_draw_count < self.max_published_meshlets {
+            worst_case_draw_count
+        } else {
+            self.max_published_meshlets
+        }
+    }
+}
+
+impl Default for VirtualGeometryBudget {
+    fn default() -> Self {
+        Self::new(DEFAULT_MAX_PUBLISHED_MESHLETS)
+    }
+}
+
 /// Per-instance values used by meshlet culling. Kept separate from
 /// `GpuInstanceData` so the cull shader does not recompute matrix norms for
 /// every meshlet in an instance.
@@ -179,7 +225,10 @@ pub(crate) struct CullUniforms {
 
 #[cfg(test)]
 mod tests {
-    use super::{select_object_lod, CullUniforms, InstanceCullData, LodQuality};
+    use super::{
+        select_object_lod, CullUniforms, InstanceCullData, LodQuality,
+        VirtualGeometryBudget, DEFAULT_MAX_PUBLISHED_MESHLETS,
+    };
     use helio_core::GpuInstanceData;
 
     fn instance_with_model(model: [f32; 16]) -> GpuInstanceData {
@@ -198,6 +247,21 @@ mod tests {
     fn instance_cull_data_is_gpu_aligned() {
         assert_eq!(std::mem::size_of::<InstanceCullData>(), 16);
         assert_eq!(std::mem::size_of::<CullUniforms>(), 48);
+    }
+
+    #[test]
+    fn default_publication_budget_is_nine_mib_plus_counters() {
+        let budget = VirtualGeometryBudget::default();
+        assert_eq!(budget.max_published_meshlets(), DEFAULT_MAX_PUBLISHED_MESHLETS);
+        assert_eq!(budget.publication_bytes(), 9 * 1024 * 1024 + 8);
+        assert_eq!(budget.clamp_draw_count(65_536), 65_536);
+        assert_eq!(budget.clamp_draw_count(u32::MAX), DEFAULT_MAX_PUBLISHED_MESHLETS);
+    }
+
+    #[test]
+    #[should_panic(expected = "publication budget must be non-zero")]
+    fn publication_budget_rejects_zero() {
+        let _ = VirtualGeometryBudget::new(0);
     }
 
     #[test]

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -9,12 +9,14 @@ use helio_core::{
     DebugViewDescriptor, GpuInstanceData, PassContext, PrepareContext, RenderPass,
     Result as HelioResult,
 };
+use libhelio::VG_CULL_MESHLETS_PER_WORK_ITEM;
 
 // ═══════════════════════════════════════════════════════════════════════════════
 // VirtualGeometryPass
 // ═══════════════════════════════════════════════════════════════════════════════
 
 pub struct VirtualGeometryPass {
+    pub(crate) select_pipeline: wgpu::ComputePipeline,
     pub(crate) cull_pipeline: wgpu::ComputePipeline,
     pub(crate) cull_bgl: wgpu::BindGroupLayout,
     pub(crate) cull_bind_group: Option<wgpu::BindGroup>,
@@ -33,6 +35,7 @@ pub struct VirtualGeometryPass {
     pub(crate) object_buf: wgpu::Buffer,
     pub(crate) instance_buf: wgpu::Buffer,
     pub(crate) instance_cull_buf: wgpu::Buffer,
+    pub(crate) work_item_buf: wgpu::Buffer,
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_metadata_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
@@ -42,8 +45,10 @@ pub struct VirtualGeometryPass {
     pub(crate) last_version: u64,
     pub(crate) last_meshlet_count: u32,
     pub(crate) last_object_count: u32,
+    pub(crate) last_work_item_count: u32,
     pub(crate) last_max_draw_count: u32,
-    pub(crate) last_dispatch_width: u32,
+    pub(crate) object_dispatch_width: u32,
+    pub(crate) work_dispatch_width: u32,
 }
 
 impl VirtualGeometryPass {
@@ -82,6 +87,7 @@ impl VirtualGeometryPass {
         let object_buf = Self::make_object_buf(device, INITIAL_OBJECTS);
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
         let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
+        let work_item_buf = Self::make_work_item_buf(device, INITIAL_OBJECTS);
         let indirect_buf = Self::make_indirect_buf(device, INITIAL_MESHLETS);
         let draw_metadata_buf = Self::make_draw_metadata_buf(device, INITIAL_MESHLETS);
         let draw_count_buf = Self::make_draw_count_buf(device);
@@ -138,12 +144,12 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
-                // Immutable per-object LOD ranges and bounds.
+                // Per-object LOD ranges/bounds plus per-frame selected-LOD scratch.
                 wgpu::BindGroupLayoutEntry {
                     binding: 3,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
                         has_dynamic_offset: false,
                         min_binding_size: None,
                     },
@@ -217,6 +223,16 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 11,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -225,11 +241,19 @@ impl VirtualGeometryPass {
             bind_group_layouts: &[Some(&cull_bgl)],
             immediate_size: 0,
         });
-        let cull_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-            label: Some("VG Cull Pipeline"),
+        let select_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("VG Object Select Pipeline"),
             layout: Some(&cull_pipeline_layout),
             module: &cull_shader,
-            entry_point: Some("cs_cull"),
+            entry_point: Some("cs_select_objects"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+        let cull_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("VG Meshlet Cull Pipeline"),
+            layout: Some(&cull_pipeline_layout),
+            module: &cull_shader,
+            entry_point: Some("cs_cull_meshlets"),
             compilation_options: Default::default(),
             cache: None,
         });
@@ -398,6 +422,7 @@ impl VirtualGeometryPass {
             });
 
         Self {
+            select_pipeline,
             cull_pipeline,
             cull_bgl,
             cull_bind_group: None,
@@ -416,6 +441,7 @@ impl VirtualGeometryPass {
             object_buf,
             instance_buf,
             instance_cull_buf,
+            work_item_buf,
             indirect_buf,
             draw_metadata_buf,
             draw_count_buf,
@@ -425,8 +451,10 @@ impl VirtualGeometryPass {
             last_version: u64::MAX,
             last_meshlet_count: 0,
             last_object_count: 0,
+            last_work_item_count: 0,
             last_max_draw_count: 0,
-            last_dispatch_width: 1,
+            object_dispatch_width: 1,
+            work_dispatch_width: 1,
         }
     }
 
@@ -461,6 +489,15 @@ impl VirtualGeometryPass {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Instance Cull Buffer"),
             size: capacity * std::mem::size_of::<InstanceCullData>() as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_work_item_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Work Item Buffer"),
+            size: capacity * std::mem::size_of::<libhelio::GpuVgWorkItem>() as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -546,6 +583,13 @@ impl RenderPass for VirtualGeometryPass {
                 self.instance_cull_buf = Self::make_instance_cull_buf(ctx.device, vg.object_count as u64 * 2);
                 grew = true;
             }
+            let work_item_capacity = self.work_item_buf.size()
+                / std::mem::size_of::<libhelio::GpuVgWorkItem>() as u64;
+            if (vg.work_item_count as u64) > work_item_capacity {
+                self.work_item_buf =
+                    Self::make_work_item_buf(ctx.device, vg.work_item_count as u64 * 2);
+                grew = true;
+            }
             let indirect_capacity = self.indirect_buf.size() / 20;
             if (vg.max_draw_count as u64) > indirect_capacity {
                 let new_capacity = vg.max_draw_count as u64 * 2;
@@ -562,6 +606,7 @@ impl RenderPass for VirtualGeometryPass {
             ctx.write_buffer(&self.meshlet_buf, 0, vg.meshlets);
             ctx.write_buffer(&self.object_buf, 0, vg.objects);
             ctx.write_buffer(&self.instance_buf, 0, vg.instances);
+            ctx.write_buffer(&self.work_item_buf, 0, vg.work_items);
 
             let instances: &[GpuInstanceData] = bytemuck::cast_slice(vg.instances);
             let cull_data: Vec<InstanceCullData> = instances
@@ -573,21 +618,36 @@ impl RenderPass for VirtualGeometryPass {
             self.last_version = vg.buffer_version;
             self.last_meshlet_count = vg.meshlet_count;
             self.last_object_count = vg.object_count;
+            self.last_work_item_count = vg.work_item_count;
             self.last_max_draw_count = vg.max_draw_count;
         }
 
-        if self.last_object_count == 0 || self.last_max_draw_count == 0 {
+        if self.last_object_count == 0
+            || self.last_work_item_count == 0
+            || self.last_max_draw_count == 0
+        {
             return Ok(());
         }
 
         let max_dim = ctx.width.max(ctx.height);
         let hiz_mip_count = (u32::BITS - max_dim.leading_zeros()).max(1);
         let max_dispatch = ctx.device.limits().max_compute_workgroups_per_dimension;
-        self.last_dispatch_width = self.last_object_count.min(max_dispatch).max(1);
-        let dispatch_height = self.last_object_count.div_ceil(self.last_dispatch_width);
+        let object_workgroups = self
+            .last_object_count
+            .div_ceil(VG_CULL_MESHLETS_PER_WORK_ITEM);
+        self.object_dispatch_width = object_workgroups.min(max_dispatch).max(1);
+        let object_dispatch_height = object_workgroups.div_ceil(self.object_dispatch_width);
         assert!(
-            dispatch_height <= max_dispatch,
+            object_dispatch_height <= max_dispatch,
             "virtual geometry object dispatch exceeds the device's 2D workgroup grid"
+        );
+        self.work_dispatch_width = self.last_work_item_count.min(max_dispatch).max(1);
+        let work_dispatch_height = self
+            .last_work_item_count
+            .div_ceil(self.work_dispatch_width);
+        assert!(
+            work_dispatch_height <= max_dispatch,
+            "virtual geometry meshlet-work dispatch exceeds the device's 2D workgroup grid"
         );
         let cull_uni = CullUniforms {
             object_count: self.last_object_count,
@@ -596,8 +656,12 @@ impl RenderPass for VirtualGeometryPass {
             hiz_mip_count,
             draw_capacity: self.last_max_draw_count,
             lod_error_threshold_px: self.lod_quality.max_error_pixels(),
-            dispatch_width: self.last_dispatch_width,
+            object_dispatch_width: self.object_dispatch_width,
+            work_item_count: self.last_work_item_count,
+            work_dispatch_width: self.work_dispatch_width,
             _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
         };
         ctx.write_buffer(&self.cull_buf, 0, bytemuck::bytes_of(&cull_uni));
 
@@ -682,6 +746,7 @@ impl RenderPass for VirtualGeometryPass {
 
     fn execute(&mut self, ctx: &mut PassContext) -> HelioResult<()> {
         if self.last_object_count == 0
+            || self.last_work_item_count == 0
             || self.last_max_draw_count == 0
             || ctx.resources.vg.is_none()
         {
@@ -709,6 +774,7 @@ impl RenderPass for VirtualGeometryPass {
                     wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(hiz_view) },
                     wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(hiz_sampler) },
                     wgpu::BindGroupEntry { binding: 10, resource: self.instance_cull_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 11, resource: self.work_item_buf.as_entire_binding() },
                 ],
             }));
             self.cull_bind_group_hiz_key = Some(hiz_key);
@@ -719,7 +785,6 @@ impl RenderPass for VirtualGeometryPass {
         let Some(draw_bg1) = self.draw_bg_1.as_ref() else { return Ok(()); };
         let Some(main_scene) = ctx.resources.main_scene.read("VirtualGeometry") else { return Ok(()); };
 
-        let object_count = self.last_object_count;
         let max_draw_count = self.last_max_draw_count;
 
         unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(&self.draw_count_buf, 0, None);
@@ -730,14 +795,32 @@ impl RenderPass for VirtualGeometryPass {
         {
             let mut cpass = unsafe { &mut *ctx.compute_encoder_ptr }
                 .begin_compute_pass(&wgpu::ComputePassDescriptor {
-                    label: Some("VG Cull"),
+                    label: Some("VG Object Select"),
+                    timestamp_writes: None,
+                });
+            cpass.set_pipeline(&self.select_pipeline);
+            cpass.set_bind_group(0, cull_bg, &[]);
+            let object_workgroups = self
+                .last_object_count
+                .div_ceil(VG_CULL_MESHLETS_PER_WORK_ITEM);
+            cpass.dispatch_workgroups(
+                self.object_dispatch_width,
+                object_workgroups.div_ceil(self.object_dispatch_width),
+                1,
+            );
+        }
+
+        {
+            let mut cpass = unsafe { &mut *ctx.compute_encoder_ptr }
+                .begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("VG Meshlet Cull"),
                     timestamp_writes: None,
                 });
             cpass.set_pipeline(&self.cull_pipeline);
             cpass.set_bind_group(0, cull_bg, &[]);
             cpass.dispatch_workgroups(
-                self.last_dispatch_width,
-                object_count.div_ceil(self.last_dispatch_width),
+                self.work_dispatch_width,
+                self.last_work_item_count.div_ceil(self.work_dispatch_width),
                 1,
             );
         }

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -35,6 +35,7 @@ pub struct VirtualGeometryPass {
     pub(crate) object_buf: wgpu::Buffer,
     pub(crate) instance_buf: wgpu::Buffer,
     pub(crate) instance_cull_buf: wgpu::Buffer,
+    pub(crate) instance_cull_scratch: Vec<InstanceCullData>,
     pub(crate) work_item_buf: wgpu::Buffer,
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_metadata_buf: wgpu::Buffer,
@@ -43,6 +44,7 @@ pub struct VirtualGeometryPass {
     pub debug_mode: u32,
     pub lod_quality: LodQuality,
     pub(crate) last_version: u64,
+    pub(crate) last_instance_version: u64,
     pub(crate) last_meshlet_count: u32,
     pub(crate) last_object_count: u32,
     pub(crate) last_work_item_count: u32,
@@ -441,6 +443,7 @@ impl VirtualGeometryPass {
             object_buf,
             instance_buf,
             instance_cull_buf,
+            instance_cull_scratch: Vec::with_capacity(INITIAL_INSTANCES as usize),
             work_item_buf,
             indirect_buf,
             draw_metadata_buf,
@@ -449,6 +452,7 @@ impl VirtualGeometryPass {
             debug_mode: 0,
             lod_quality: LodQuality::default(),
             last_version: u64::MAX,
+            last_instance_version: u64::MAX,
             last_meshlet_count: 0,
             last_object_count: 0,
             last_work_item_count: 0,
@@ -611,17 +615,56 @@ impl RenderPass for VirtualGeometryPass {
             ctx.write_buffer(&self.work_item_buf, 0, vg.work_items);
 
             let instances: &[GpuInstanceData] = bytemuck::cast_slice(vg.instances);
-            let cull_data: Vec<InstanceCullData> = instances
-                .iter()
-                .map(InstanceCullData::from_instance)
-                .collect();
-            ctx.write_buffer(&self.instance_cull_buf, 0, bytemuck::cast_slice(&cull_data));
+            self.instance_cull_scratch.clear();
+            self.instance_cull_scratch.extend(
+                instances.iter().map(InstanceCullData::from_instance),
+            );
+            ctx.write_buffer(
+                &self.instance_cull_buf,
+                0,
+                bytemuck::cast_slice(&self.instance_cull_scratch),
+            );
 
             self.last_version = vg.buffer_version;
+            self.last_instance_version = vg.instance_version;
             self.last_meshlet_count = vg.meshlet_count;
             self.last_object_count = vg.object_count;
             self.last_work_item_count = vg.work_item_count;
             self.last_max_draw_count = vg.max_draw_count;
+        } else if vg.instance_version != self.last_instance_version {
+            let start = vg.instance_dirty_start as usize;
+            let count = vg.instance_dirty_count as usize;
+            let end = start
+                .checked_add(count)
+                .expect("virtual geometry dirty instance range overflow");
+            let instances: &[GpuInstanceData] = bytemuck::cast_slice(vg.instances);
+            assert!(
+                count > 0 && end <= instances.len(),
+                "virtual geometry published an invalid dirty instance range"
+            );
+
+            let instance_offset = start as u64
+                * std::mem::size_of::<GpuInstanceData>() as u64;
+            ctx.write_buffer(
+                &self.instance_buf,
+                instance_offset,
+                bytemuck::cast_slice(&instances[start..end]),
+            );
+
+            self.instance_cull_scratch.clear();
+            self.instance_cull_scratch.extend(
+                instances[start..end]
+                    .iter()
+                    .map(InstanceCullData::from_instance),
+            );
+            let cull_offset = start as u64
+                * std::mem::size_of::<InstanceCullData>() as u64;
+            ctx.write_buffer(
+                &self.instance_cull_buf,
+                cull_offset,
+                bytemuck::cast_slice(&self.instance_cull_scratch),
+            );
+            self.last_instance_version = vg.instance_version;
         }
 
         if self.last_object_count == 0

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -1,6 +1,6 @@
 use std::num::NonZeroU32;
 
-use crate::{CullUniforms, LodQuality, VgGlobals, INITIAL_INSTANCES, INITIAL_MESHLETS, MAX_TEXTURES};
+use crate::{CullUniforms, InstanceCullData, LodQuality, VgGlobals, INITIAL_INSTANCES, INITIAL_MESHLETS, MAX_TEXTURES};
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
     DebugViewDescriptor, GpuInstanceData, PassContext, PrepareContext, RenderPass,
@@ -28,7 +28,7 @@ pub struct VirtualGeometryPass {
     pub(crate) globals_buf: wgpu::Buffer,
     pub(crate) meshlet_buf: wgpu::Buffer,
     pub(crate) instance_buf: wgpu::Buffer,
-    pub(crate) instance_scale_buf: wgpu::Buffer,
+    pub(crate) instance_cull_buf: wgpu::Buffer,
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
     pub(crate) use_count_indirect: bool,
@@ -77,7 +77,7 @@ impl VirtualGeometryPass {
 
         let meshlet_buf = Self::make_meshlet_buf(device, INITIAL_MESHLETS);
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
-        let instance_scale_buf = Self::make_instance_scale_buf(device, INITIAL_INSTANCES);
+        let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
         let indirect_buf = Self::make_indirect_buf(device, INITIAL_MESHLETS);
         let draw_count_buf = Self::make_draw_count_buf(device);
         let use_count_indirect = device
@@ -379,7 +379,7 @@ impl VirtualGeometryPass {
             globals_buf,
             meshlet_buf,
             instance_buf,
-            instance_scale_buf,
+            instance_cull_buf,
             indirect_buf,
             draw_count_buf,
             use_count_indirect,
@@ -408,10 +408,10 @@ impl VirtualGeometryPass {
         })
     }
 
-    fn make_instance_scale_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
+    fn make_instance_cull_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("VG Instance Scale Buffer"),
-            size: capacity * 4,
+            label: Some("VG Instance Cull Buffer"),
+            size: capacity * std::mem::size_of::<InstanceCullData>() as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -480,7 +480,7 @@ impl RenderPass for VirtualGeometryPass {
             let instance_capacity = self.instance_buf.size() / 144;
             if (vg.instance_count as u64) > instance_capacity {
                 self.instance_buf = Self::make_instance_buf(ctx.device, vg.instance_count as u64 * 2);
-                self.instance_scale_buf = Self::make_instance_scale_buf(ctx.device, vg.instance_count as u64 * 2);
+                self.instance_cull_buf = Self::make_instance_cull_buf(ctx.device, vg.instance_count as u64 * 2);
                 grew = true;
             }
 
@@ -492,13 +492,11 @@ impl RenderPass for VirtualGeometryPass {
             ctx.write_buffer(&self.instance_buf, 0, vg.instances);
 
             let instances: &[GpuInstanceData] = bytemuck::cast_slice(vg.instances);
-            let scales: Vec<f32> = instances.iter().map(|inst| {
-                let scale_x = (inst.model[0] * inst.model[0] + inst.model[1] * inst.model[1] + inst.model[2] * inst.model[2]).sqrt();
-                let scale_y = (inst.model[4] * inst.model[4] + inst.model[5] * inst.model[5] + inst.model[6] * inst.model[6]).sqrt();
-                let scale_z = (inst.model[8] * inst.model[8] + inst.model[9] * inst.model[9] + inst.model[10] * inst.model[10]).sqrt();
-                scale_x.max(scale_y).max(scale_z)
-            }).collect();
-            ctx.write_buffer(&self.instance_scale_buf, 0, bytemuck::cast_slice(&scales));
+            let cull_data: Vec<InstanceCullData> = instances
+                .iter()
+                .map(InstanceCullData::from_instance)
+                .collect();
+            ctx.write_buffer(&self.instance_cull_buf, 0, bytemuck::cast_slice(&cull_data));
 
             self.last_version = vg.buffer_version;
             self.last_meshlet_count = vg.meshlet_count;
@@ -623,7 +621,7 @@ impl RenderPass for VirtualGeometryPass {
                     wgpu::BindGroupEntry { binding: 5, resource: self.draw_count_buf.as_entire_binding() },
                     wgpu::BindGroupEntry { binding: 6, resource: wgpu::BindingResource::TextureView(hiz_view) },
                     wgpu::BindGroupEntry { binding: 7, resource: wgpu::BindingResource::Sampler(hiz_sampler) },
-                    wgpu::BindGroupEntry { binding: 8, resource: self.instance_scale_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 8, resource: self.instance_cull_buf.as_entire_binding() },
                 ],
             }));
             self.cull_bind_group_hiz_key = Some(hiz_key);

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -1,6 +1,9 @@
 use std::num::NonZeroU32;
 
-use crate::{CullUniforms, InstanceCullData, LodQuality, VgGlobals, INITIAL_INSTANCES, INITIAL_MESHLETS, MAX_TEXTURES};
+use crate::{
+    CullUniforms, InstanceCullData, LodQuality, VgGlobals, INITIAL_INSTANCES,
+    INITIAL_MESHLETS, INITIAL_OBJECTS, MAX_TEXTURES,
+};
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
     DebugViewDescriptor, GpuInstanceData, PassContext, PrepareContext, RenderPass,
@@ -18,7 +21,7 @@ pub struct VirtualGeometryPass {
     pub(crate) cull_bind_group_hiz_key: Option<(usize, usize)>,
     pub(crate) cull_buf: wgpu::Buffer,
     pub(crate) draw_pipeline: wgpu::RenderPipeline,
-    pub(crate) debug_draw_pipeline: Option<wgpu::RenderPipeline>,
+    pub(crate) debug_draw_pipeline: wgpu::RenderPipeline,
     pub(crate) lod_debug_pipeline: wgpu::RenderPipeline,
     pub(crate) draw_bgl_0: wgpu::BindGroupLayout,
     pub(crate) draw_bgl_1: wgpu::BindGroupLayout,
@@ -27,15 +30,20 @@ pub struct VirtualGeometryPass {
     pub(crate) bg1_version: Option<u64>,
     pub(crate) globals_buf: wgpu::Buffer,
     pub(crate) meshlet_buf: wgpu::Buffer,
+    pub(crate) object_buf: wgpu::Buffer,
     pub(crate) instance_buf: wgpu::Buffer,
     pub(crate) instance_cull_buf: wgpu::Buffer,
     pub(crate) indirect_buf: wgpu::Buffer,
+    pub(crate) draw_metadata_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
     pub(crate) use_count_indirect: bool,
     pub debug_mode: u32,
     pub lod_quality: LodQuality,
     pub(crate) last_version: u64,
     pub(crate) last_meshlet_count: u32,
+    pub(crate) last_object_count: u32,
+    pub(crate) last_max_draw_count: u32,
+    pub(crate) last_dispatch_width: u32,
 }
 
 impl VirtualGeometryPass {
@@ -65,20 +73,17 @@ impl VirtualGeometryPass {
                     .replace(
                         "return textureSample(scene_textures, scene_samplers, uv);",
                         "return textureSampleLevel(scene_textures, scene_samplers, uv, 0.0);",
-                    )
-                    .replace(", @builtin(primitive_index) prim_id: u32", "")
-                    .replace(
-                        "    var h = prim_id *",
-                        "    let prim_id: u32 = 0u;\n    var h = prim_id *",
                     );
                 s.into()
             }),
         });
 
         let meshlet_buf = Self::make_meshlet_buf(device, INITIAL_MESHLETS);
+        let object_buf = Self::make_object_buf(device, INITIAL_OBJECTS);
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
         let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
         let indirect_buf = Self::make_indirect_buf(device, INITIAL_MESHLETS);
+        let draw_metadata_buf = Self::make_draw_metadata_buf(device, INITIAL_MESHLETS);
         let draw_count_buf = Self::make_draw_count_buf(device);
         let use_count_indirect = device
             .features()
@@ -101,6 +106,7 @@ impl VirtualGeometryPass {
         let cull_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
             label: Some("VG Cull BGL"),
             entries: &[
+                // Camera and cull uniforms.
                 wgpu::BindGroupLayoutEntry {
                     binding: 0,
                     visibility: wgpu::ShaderStages::COMPUTE,
@@ -121,6 +127,7 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                // Immutable shared meshlet descriptors.
                 wgpu::BindGroupLayoutEntry {
                     binding: 2,
                     visibility: wgpu::ShaderStages::COMPUTE,
@@ -131,6 +138,7 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                // Immutable per-object LOD ranges and bounds.
                 wgpu::BindGroupLayoutEntry {
                     binding: 3,
                     visibility: wgpu::ShaderStages::COMPUTE,
@@ -141,16 +149,18 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                // Instance transforms/materials.
                 wgpu::BindGroupLayoutEntry {
                     binding: 4,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
-                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
                         has_dynamic_offset: false,
                         min_binding_size: None,
                     },
                     count: None,
                 },
+                // Compacted indirect commands, parallel draw metadata, and count.
                 wgpu::BindGroupLayoutEntry {
                     binding: 5,
                     visibility: wgpu::ShaderStages::COMPUTE,
@@ -162,7 +172,27 @@ impl VirtualGeometryPass {
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding:    6,
+                    binding: 6,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 7,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding:    8,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Texture {
                         sample_type:    wgpu::TextureSampleType::Float { filterable: false },
@@ -172,13 +202,13 @@ impl VirtualGeometryPass {
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding:    7,
+                    binding:    9,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
-                    binding: 8,
+                    binding: 10,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: true },
@@ -237,6 +267,16 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -247,6 +287,7 @@ impl VirtualGeometryPass {
                 wgpu::BindGroupEntry { binding: 0, resource: camera_buf.as_entire_binding() },
                 wgpu::BindGroupEntry { binding: 1, resource: globals_buf.as_entire_binding() },
                 wgpu::BindGroupEntry { binding: 2, resource: instance_buf.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 3, resource: draw_metadata_buf.as_entire_binding() },
             ],
         }));
 
@@ -310,11 +351,8 @@ impl VirtualGeometryPass {
             cache: None,
         });
 
-        let debug_draw_pipeline = if device
-            .features()
-            .contains(wgpu::Features::SHADER_PRIMITIVE_INDEX)
-        {
-            Some(device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        let debug_draw_pipeline =
+            device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("VG Debug Pipeline"),
                 layout: Some(&draw_pipeline_layout),
                 vertex: wgpu::VertexState {
@@ -334,10 +372,7 @@ impl VirtualGeometryPass {
                 multisample: wgpu::MultisampleState::default(),
                 multiview_mask: None,
                 cache: None,
-            }))
-        } else {
-            None
-        };
+            });
 
         let lod_debug_pipeline =
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -378,15 +413,20 @@ impl VirtualGeometryPass {
             bg1_version: None,
             globals_buf,
             meshlet_buf,
+            object_buf,
             instance_buf,
             instance_cull_buf,
             indirect_buf,
+            draw_metadata_buf,
             draw_count_buf,
             use_count_indirect,
             debug_mode: 0,
             lod_quality: LodQuality::default(),
             last_version: u64::MAX,
             last_meshlet_count: 0,
+            last_object_count: 0,
+            last_max_draw_count: 0,
+            last_dispatch_width: 1,
         }
     }
 
@@ -403,6 +443,15 @@ impl VirtualGeometryPass {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Instance Buffer"),
             size: capacity * 144,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_object_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Object Buffer"),
+            size: capacity * 128,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -428,6 +477,15 @@ impl VirtualGeometryPass {
         })
     }
 
+    fn make_draw_metadata_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Draw Metadata Buffer"),
+            size: capacity * std::mem::size_of::<libhelio::GpuVgDraw>() as u64,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        })
+    }
+
     fn make_draw_count_buf(device: &wgpu::Device) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Draw Count"),
@@ -448,6 +506,7 @@ impl VirtualGeometryPass {
                 wgpu::BindGroupEntry { binding: 0, resource: camera_buf.as_entire_binding() },
                 wgpu::BindGroupEntry { binding: 1, resource: self.globals_buf.as_entire_binding() },
                 wgpu::BindGroupEntry { binding: 2, resource: self.instance_buf.as_entire_binding() },
+                wgpu::BindGroupEntry { binding: 3, resource: self.draw_metadata_buf.as_entire_binding() },
             ],
         }));
     }
@@ -474,13 +533,25 @@ impl RenderPass for VirtualGeometryPass {
             let meshlet_capacity = self.meshlet_buf.size() / 64;
             if (vg.meshlet_count as u64) > meshlet_capacity {
                 self.meshlet_buf = Self::make_meshlet_buf(ctx.device, vg.meshlet_count as u64 * 2);
-                self.indirect_buf = Self::make_indirect_buf(ctx.device, vg.meshlet_count as u64 * 2);
+                grew = true;
+            }
+            let object_capacity = self.object_buf.size() / 128;
+            if (vg.object_count as u64) > object_capacity {
+                self.object_buf = Self::make_object_buf(ctx.device, vg.object_count as u64 * 2);
                 grew = true;
             }
             let instance_capacity = self.instance_buf.size() / 144;
-            if (vg.instance_count as u64) > instance_capacity {
-                self.instance_buf = Self::make_instance_buf(ctx.device, vg.instance_count as u64 * 2);
-                self.instance_cull_buf = Self::make_instance_cull_buf(ctx.device, vg.instance_count as u64 * 2);
+            if (vg.object_count as u64) > instance_capacity {
+                self.instance_buf = Self::make_instance_buf(ctx.device, vg.object_count as u64 * 2);
+                self.instance_cull_buf = Self::make_instance_cull_buf(ctx.device, vg.object_count as u64 * 2);
+                grew = true;
+            }
+            let indirect_capacity = self.indirect_buf.size() / 20;
+            if (vg.max_draw_count as u64) > indirect_capacity {
+                let new_capacity = vg.max_draw_count as u64 * 2;
+                self.indirect_buf = Self::make_indirect_buf(ctx.device, new_capacity);
+                self.draw_metadata_buf =
+                    Self::make_draw_metadata_buf(ctx.device, new_capacity);
                 grew = true;
             }
 
@@ -489,6 +560,7 @@ impl RenderPass for VirtualGeometryPass {
             }
 
             ctx.write_buffer(&self.meshlet_buf, 0, vg.meshlets);
+            ctx.write_buffer(&self.object_buf, 0, vg.objects);
             ctx.write_buffer(&self.instance_buf, 0, vg.instances);
 
             let instances: &[GpuInstanceData] = bytemuck::cast_slice(vg.instances);
@@ -500,22 +572,32 @@ impl RenderPass for VirtualGeometryPass {
 
             self.last_version = vg.buffer_version;
             self.last_meshlet_count = vg.meshlet_count;
+            self.last_object_count = vg.object_count;
+            self.last_max_draw_count = vg.max_draw_count;
         }
 
-        if self.last_meshlet_count == 0 {
+        if self.last_object_count == 0 || self.last_max_draw_count == 0 {
             return Ok(());
         }
 
-        let lod_thresholds = self.lod_quality.thresholds();
         let max_dim = ctx.width.max(ctx.height);
         let hiz_mip_count = (u32::BITS - max_dim.leading_zeros()).max(1);
+        let max_dispatch = ctx.device.limits().max_compute_workgroups_per_dimension;
+        self.last_dispatch_width = self.last_object_count.min(max_dispatch).max(1);
+        let dispatch_height = self.last_object_count.div_ceil(self.last_dispatch_width);
+        assert!(
+            dispatch_height <= max_dispatch,
+            "virtual geometry object dispatch exceeds the device's 2D workgroup grid"
+        );
         let cull_uni = CullUniforms {
-            meshlet_count: self.last_meshlet_count,
+            object_count: self.last_object_count,
             screen_width:  ctx.width,
             screen_height: ctx.height,
             hiz_mip_count,
-            lod_thresholds,
-            _pad3: 0.0,
+            draw_capacity: self.last_max_draw_count,
+            lod_error_threshold_px: self.lod_quality.max_error_pixels(),
+            dispatch_width: self.last_dispatch_width,
+            _pad0: 0,
         };
         ctx.write_buffer(&self.cull_buf, 0, bytemuck::bytes_of(&cull_uni));
 
@@ -599,7 +681,10 @@ impl RenderPass for VirtualGeometryPass {
     }
 
     fn execute(&mut self, ctx: &mut PassContext) -> HelioResult<()> {
-        if self.last_meshlet_count == 0 || ctx.resources.vg.is_none() {
+        if self.last_object_count == 0
+            || self.last_max_draw_count == 0
+            || ctx.resources.vg.is_none()
+        {
             return Ok(());
         }
 
@@ -616,12 +701,14 @@ impl RenderPass for VirtualGeometryPass {
                     wgpu::BindGroupEntry { binding: 0, resource: ctx.scene.camera.as_entire_binding() },
                     wgpu::BindGroupEntry { binding: 1, resource: self.cull_buf.as_entire_binding() },
                     wgpu::BindGroupEntry { binding: 2, resource: self.meshlet_buf.as_entire_binding() },
-                    wgpu::BindGroupEntry { binding: 3, resource: self.instance_buf.as_entire_binding() },
-                    wgpu::BindGroupEntry { binding: 4, resource: self.indirect_buf.as_entire_binding() },
-                    wgpu::BindGroupEntry { binding: 5, resource: self.draw_count_buf.as_entire_binding() },
-                    wgpu::BindGroupEntry { binding: 6, resource: wgpu::BindingResource::TextureView(hiz_view) },
-                    wgpu::BindGroupEntry { binding: 7, resource: wgpu::BindingResource::Sampler(hiz_sampler) },
-                    wgpu::BindGroupEntry { binding: 8, resource: self.instance_cull_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 3, resource: self.object_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 4, resource: self.instance_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 5, resource: self.indirect_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 6, resource: self.draw_metadata_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 7, resource: self.draw_count_buf.as_entire_binding() },
+                    wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(hiz_view) },
+                    wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(hiz_sampler) },
+                    wgpu::BindGroupEntry { binding: 10, resource: self.instance_cull_buf.as_entire_binding() },
                 ],
             }));
             self.cull_bind_group_hiz_key = Some(hiz_key);
@@ -632,7 +719,8 @@ impl RenderPass for VirtualGeometryPass {
         let Some(draw_bg1) = self.draw_bg_1.as_ref() else { return Ok(()); };
         let Some(main_scene) = ctx.resources.main_scene.read("VirtualGeometry") else { return Ok(()); };
 
-        let meshlet_count = self.last_meshlet_count;
+        let object_count = self.last_object_count;
+        let max_draw_count = self.last_max_draw_count;
 
         unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(&self.draw_count_buf, 0, None);
         if !self.use_count_indirect {
@@ -647,14 +735,18 @@ impl RenderPass for VirtualGeometryPass {
                 });
             cpass.set_pipeline(&self.cull_pipeline);
             cpass.set_bind_group(0, cull_bg, &[]);
-            cpass.dispatch_workgroups((meshlet_count + 63) / 64, 1, 1);
+            cpass.dispatch_workgroups(
+                self.last_dispatch_width,
+                object_count.div_ceil(self.last_dispatch_width),
+                1,
+            );
         }
 
         {
             let rpass = unsafe { &mut *ctx.active_render_pass_ptr().unwrap() };
 
             let active_pipeline = match self.debug_mode {
-                20 => self.debug_draw_pipeline.as_ref().unwrap_or(&self.draw_pipeline),
+                20 => &self.debug_draw_pipeline,
                 21 => &self.lod_debug_pipeline,
                 _ => &self.draw_pipeline,
             };
@@ -664,12 +756,12 @@ impl RenderPass for VirtualGeometryPass {
             rpass.set_vertex_buffer(0, main_scene.mesh_buffers.vertices.slice(..));
             rpass.set_index_buffer(main_scene.mesh_buffers.indices.slice(..), wgpu::IndexFormat::Uint32);
             if self.use_count_indirect {
-                rpass.multi_draw_indexed_indirect_count(&self.indirect_buf, 0, &self.draw_count_buf, 0, meshlet_count);
+                rpass.multi_draw_indexed_indirect_count(&self.indirect_buf, 0, &self.draw_count_buf, 0, max_draw_count);
             } else {
                 #[cfg(not(target_arch = "wasm32"))]
-                rpass.multi_draw_indexed_indirect(&self.indirect_buf, 0, meshlet_count);
+                rpass.multi_draw_indexed_indirect(&self.indirect_buf, 0, max_draw_count);
                 #[cfg(target_arch = "wasm32")]
-                for i in 0..meshlet_count {
+                for i in 0..max_draw_count {
                     rpass.draw_indexed_indirect(&self.indirect_buf, i as u64 * 20);
                 }
             }
@@ -693,8 +785,8 @@ impl RenderPass for VirtualGeometryPass {
 
     fn debug_views(&self) -> &'static [DebugViewDescriptor] {
         static VIEWS: &[DebugViewDescriptor] = &[
-            DebugViewDescriptor { name: "VG Mesh Triangles", debug_mode: 20, description: "Per-meshlet solid colour — visualises meshlet boundaries" },
-            DebugViewDescriptor { name: "VG LOD Heatmap",    debug_mode: 21, description: "Colour by LOD level: green=LOD0 through red=LOD7" },
+            DebugViewDescriptor { name: "VG Meshlets", debug_mode: 20, description: "One solid colour per meshlet — visualises cluster boundaries" },
+            DebugViewDescriptor { name: "VG LOD Heatmap",    debug_mode: 21, description: "One flat colour per object LOD; green=LOD0 through magenta=LOD7" },
         ];
         VIEWS
     }

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -3,6 +3,7 @@ use std::num::NonZeroU32;
 use crate::{
     CullUniforms, InstanceCullData, LodQuality, VgGlobals, INITIAL_INSTANCES,
     INITIAL_MESHLETS, INITIAL_OBJECTS, MAX_TEXTURES, VirtualGeometryBudget,
+    VirtualGeometryDebugStats, DRAW_COUNTER_BYTES,
 };
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
@@ -14,6 +15,12 @@ use libhelio::VG_CULL_MESHLETS_PER_WORK_ITEM;
 // ═══════════════════════════════════════════════════════════════════════════════
 // VirtualGeometryPass
 // ═══════════════════════════════════════════════════════════════════════════════
+
+enum DebugReadbackState {
+    Idle,
+    CopySubmitted,
+    Mapping(std::sync::Arc<std::sync::Mutex<Option<Result<(), wgpu::BufferAsyncError>>>>),
+}
 
 pub struct VirtualGeometryPass {
     pub(crate) select_pipeline: wgpu::ComputePipeline,
@@ -40,6 +47,9 @@ pub struct VirtualGeometryPass {
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_metadata_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
+    pub(crate) debug_readback_buf: wgpu::Buffer,
+    debug_readback_state: DebugReadbackState,
+    debug_stats: VirtualGeometryDebugStats,
     pub(crate) publication_limit: u32,
     pub(crate) use_count_indirect: bool,
     pub debug_mode: u32,
@@ -105,6 +115,7 @@ impl VirtualGeometryPass {
         let draw_metadata_buf =
             Self::make_draw_metadata_buf(device, initial_publication_capacity);
         let draw_count_buf = Self::make_draw_count_buf(device);
+        let debug_readback_buf = Self::make_debug_readback_buf(device);
         let use_count_indirect = device
             .features()
             .contains(wgpu::Features::MULTI_DRAW_INDIRECT_COUNT);
@@ -460,6 +471,9 @@ impl VirtualGeometryPass {
             indirect_buf,
             draw_metadata_buf,
             draw_count_buf,
+            debug_readback_buf,
+            debug_readback_state: DebugReadbackState::Idle,
+            debug_stats: VirtualGeometryDebugStats::default(),
             publication_limit: budget.max_published_meshlets(),
             use_count_indirect,
             debug_mode: 0,
@@ -477,6 +491,47 @@ impl VirtualGeometryPass {
 
     pub const fn publication_limit(&self) -> u32 {
         self.publication_limit
+    }
+
+    pub const fn debug_stats(&self) -> VirtualGeometryDebugStats {
+        self.debug_stats
+    }
+
+    fn poll_debug_readback(&mut self, device: &wgpu::Device) {
+        if matches!(self.debug_readback_state, DebugReadbackState::CopySubmitted) {
+            let completion = std::sync::Arc::new(std::sync::Mutex::new(None));
+            let callback_completion = std::sync::Arc::clone(&completion);
+            self.debug_readback_buf
+                .slice(..)
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    *callback_completion.lock().unwrap() = Some(result);
+                });
+            self.debug_readback_state = DebugReadbackState::Mapping(completion);
+        }
+
+        let DebugReadbackState::Mapping(completion) = &self.debug_readback_state else {
+            return;
+        };
+
+        let _ = device.poll(wgpu::PollType::Poll);
+        let result = completion.lock().unwrap().take();
+        match result {
+            Some(Ok(())) => {
+                let mapped = self.debug_readback_buf.slice(..).get_mapped_range();
+                let counters: &[u32] = bytemuck::cast_slice(&mapped);
+                if let Some(stats) = VirtualGeometryDebugStats::from_counters(counters) {
+                    self.debug_stats = stats;
+                }
+                drop(mapped);
+                self.debug_readback_buf.unmap();
+                self.debug_readback_state = DebugReadbackState::Idle;
+            }
+            Some(Err(error)) => {
+                log::warn!("virtual geometry debug readback failed: {error}");
+                self.debug_readback_state = DebugReadbackState::Idle;
+            }
+            None => {}
+        }
     }
 
     fn make_meshlet_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
@@ -548,11 +603,22 @@ impl VirtualGeometryPass {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Draw And Overflow Counters"),
             // draw_count at byte 0 remains directly consumable by
-            // multi_draw_indexed_indirect_count; overflow_count is at byte 4.
-            size: 8,
+            // multi_draw_indexed_indirect_count; the remaining counters are
+            // optional debug telemetry and do not affect indirect execution.
+            size: DRAW_COUNTER_BYTES,
             usage: wgpu::BufferUsages::STORAGE
                 | wgpu::BufferUsages::INDIRECT
+                | wgpu::BufferUsages::COPY_SRC
                 | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_debug_readback_buf(device: &wgpu::Device) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Debug Counter Readback"),
+            size: DRAW_COUNTER_BYTES,
+            usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
             mapped_at_creation: false,
         })
     }
@@ -582,6 +648,8 @@ impl RenderPass for VirtualGeometryPass {
     }
 
     fn prepare(&mut self, ctx: &PrepareContext) -> HelioResult<()> {
+        self.poll_debug_readback(ctx.device);
+
         let Some(vg) = ctx.frame_resources.vg.get() else {
             return Ok(());
         };
@@ -896,6 +964,19 @@ impl RenderPass for VirtualGeometryPass {
                 self.last_work_item_count.div_ceil(self.work_dispatch_width),
                 1,
             );
+        }
+
+        if self.debug_mode == 21
+            && matches!(self.debug_readback_state, DebugReadbackState::Idle)
+        {
+            unsafe { &mut *ctx.compute_encoder_ptr }.copy_buffer_to_buffer(
+                &self.draw_count_buf,
+                0,
+                &self.debug_readback_buf,
+                0,
+                DRAW_COUNTER_BYTES,
+            );
+            self.debug_readback_state = DebugReadbackState::CopySubmitted;
         }
 
         {

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use crate::{
     CullUniforms, InstanceCullData, LodQuality, VgGlobals, INITIAL_INSTANCES,
-    INITIAL_MESHLETS, INITIAL_OBJECTS, MAX_TEXTURES,
+    INITIAL_MESHLETS, INITIAL_OBJECTS, MAX_TEXTURES, VirtualGeometryBudget,
 };
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
@@ -40,6 +40,7 @@ pub struct VirtualGeometryPass {
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_metadata_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
+    pub(crate) publication_limit: u32,
     pub(crate) use_count_indirect: bool,
     pub debug_mode: u32,
     pub lod_quality: LodQuality,
@@ -55,6 +56,14 @@ pub struct VirtualGeometryPass {
 
 impl VirtualGeometryPass {
     pub fn new(device: &wgpu::Device, camera_buf: &wgpu::Buffer) -> Self {
+        Self::new_with_budget(device, camera_buf, VirtualGeometryBudget::default())
+    }
+
+    pub fn new_with_budget(
+        device: &wgpu::Device,
+        camera_buf: &wgpu::Buffer,
+        budget: VirtualGeometryBudget,
+    ) -> Self {
         let cull_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("VG Cull Shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/vg_cull.wgsl").into()),
@@ -90,8 +99,11 @@ impl VirtualGeometryPass {
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
         let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
         let work_item_buf = Self::make_work_item_buf(device, INITIAL_OBJECTS);
-        let indirect_buf = Self::make_indirect_buf(device, INITIAL_MESHLETS);
-        let draw_metadata_buf = Self::make_draw_metadata_buf(device, INITIAL_MESHLETS);
+        let initial_publication_capacity =
+            INITIAL_MESHLETS.min(u64::from(budget.max_published_meshlets()));
+        let indirect_buf = Self::make_indirect_buf(device, initial_publication_capacity);
+        let draw_metadata_buf =
+            Self::make_draw_metadata_buf(device, initial_publication_capacity);
         let draw_count_buf = Self::make_draw_count_buf(device);
         let use_count_indirect = device
             .features()
@@ -448,6 +460,7 @@ impl VirtualGeometryPass {
             indirect_buf,
             draw_metadata_buf,
             draw_count_buf,
+            publication_limit: budget.max_published_meshlets(),
             use_count_indirect,
             debug_mode: 0,
             lod_quality: LodQuality::default(),
@@ -460,6 +473,10 @@ impl VirtualGeometryPass {
             object_dispatch_width: 1,
             work_dispatch_width: 1,
         }
+    }
+
+    pub const fn publication_limit(&self) -> u32 {
+        self.publication_limit
     }
 
     fn make_meshlet_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
@@ -572,6 +589,16 @@ impl RenderPass for VirtualGeometryPass {
         if vg.buffer_version != self.last_version {
             let camera_buf = ctx.scene.camera.buffer();
             let mut grew = false;
+            let bounded_max_draw_count = VirtualGeometryBudget::new(self.publication_limit)
+                .clamp_draw_count(vg.max_draw_count);
+
+            if vg.max_draw_count > self.publication_limit {
+                log::warn!(
+                    "virtual geometry worst-case draw count {} exceeds the publication budget {}; excess visible meshlets will be counted and rejected",
+                    vg.max_draw_count,
+                    self.publication_limit,
+                );
+            }
 
             let meshlet_capacity = self.meshlet_buf.size() / 64;
             if (vg.meshlet_count as u64) > meshlet_capacity {
@@ -597,8 +624,9 @@ impl RenderPass for VirtualGeometryPass {
                 grew = true;
             }
             let indirect_capacity = self.indirect_buf.size() / 20;
-            if (vg.max_draw_count as u64) > indirect_capacity {
-                let new_capacity = vg.max_draw_count as u64 * 2;
+            if u64::from(bounded_max_draw_count) > indirect_capacity {
+                let new_capacity = (u64::from(bounded_max_draw_count) * 2)
+                    .min(u64::from(self.publication_limit));
                 self.indirect_buf = Self::make_indirect_buf(ctx.device, new_capacity);
                 self.draw_metadata_buf =
                     Self::make_draw_metadata_buf(ctx.device, new_capacity);
@@ -630,7 +658,7 @@ impl RenderPass for VirtualGeometryPass {
             self.last_meshlet_count = vg.meshlet_count;
             self.last_object_count = vg.object_count;
             self.last_work_item_count = vg.work_item_count;
-            self.last_max_draw_count = vg.max_draw_count;
+            self.last_max_draw_count = bounded_max_draw_count;
         } else if vg.instance_version != self.last_instance_version {
             let start = vg.instance_dirty_start as usize;
             let count = vg.instance_dirty_count as usize;

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -525,8 +525,10 @@ impl VirtualGeometryPass {
 
     fn make_draw_count_buf(device: &wgpu::Device) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
-            label: Some("VG Draw Count"),
-            size: 4,
+            label: Some("VG Draw And Overflow Counters"),
+            // draw_count at byte 0 remains directly consumable by
+            // multi_draw_indexed_indirect_count; overflow_count is at byte 4.
+            size: 8,
             usage: wgpu::BufferUsages::STORAGE
                 | wgpu::BufferUsages::INDIRECT
                 | wgpu::BufferUsages::COPY_DST,

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -783,6 +783,10 @@ impl RenderPass for VirtualGeometryPass {
         builder.read("hiz");
     }
 
+    fn set_debug_mode(&mut self, mode: u32) {
+        self.debug_mode = mode;
+    }
+
     fn debug_views(&self) -> &'static [DebugViewDescriptor] {
         static VIEWS: &[DebugViewDescriptor] = &[
             DebugViewDescriptor { name: "VG Meshlets", debug_mode: 20, description: "One solid colour per meshlet — visualises cluster boundaries" },

--- a/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
+++ b/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
@@ -2,8 +2,8 @@
 // meshlet visibility, screen coverage, LOD transitions, backface cone culling.
 // Uses the actual public LodQuality API + locally mirrored private types.
 
-use std::mem;
 use helio_pass_virtual_geometry::LodQuality;
+use std::mem;
 
 // ── Mirror private types ──────────────────────────────────────────────────────
 
@@ -40,6 +40,19 @@ struct VgGlobals {
 const WORKGROUP_SIZE: u32 = 64;
 const INITIAL_MESHLETS: u64 = 1024;
 const INITIAL_INSTANCES: u64 = 256;
+
+#[test]
+fn cull_shader_parses_and_validates() {
+    let source = include_str!("../shaders/vg_cull.wgsl");
+    let module = wgpu::naga::front::wgsl::parse_str(source).expect("VG cull shader must parse");
+    let mut validator = wgpu::naga::valid::Validator::new(
+        wgpu::naga::valid::ValidationFlags::all(),
+        wgpu::naga::valid::Capabilities::all(),
+    );
+    validator
+        .validate(&module)
+        .expect("VG cull shader must validate");
+}
 
 // ── CullUniforms layout tests ─────────────────────────────────────────────────
 
@@ -86,7 +99,9 @@ fn workgroup_size_is_64() {
 
 #[test]
 fn dispatch_groups_ceil_division() {
-    fn ceil_div(n: u32, d: u32) -> u32 { (n + d - 1) / d }
+    fn ceil_div(n: u32, d: u32) -> u32 {
+        (n + d - 1) / d
+    }
     assert_eq!(ceil_div(64, 64), 1);
     assert_eq!(ceil_div(65, 64), 2);
     assert_eq!(ceil_div(128, 64), 2);
@@ -142,7 +157,12 @@ fn screen_radius_close_object_above_ultra_s0() {
 
 #[test]
 fn all_quality_levels_have_positive_thresholds() {
-    for q in [LodQuality::Low, LodQuality::Medium, LodQuality::High, LodQuality::Ultra] {
+    for q in [
+        LodQuality::Low,
+        LodQuality::Medium,
+        LodQuality::High,
+        LodQuality::Ultra,
+    ] {
         let t = q.thresholds();
         for &v in &t {
             assert!(v > 0.0, "{:?} threshold {v}", q);
@@ -152,21 +172,63 @@ fn all_quality_levels_have_positive_thresholds() {
 
 // ── Backface cone culling tests ───────────────────────────────────────────────
 
-fn is_backfacing_cone(view_dir: [f32; 3], cone_axis: [f32; 3], cos_half_angle: f32) -> bool {
-    let dot = view_dir[0] * cone_axis[0]
-        + view_dir[1] * cone_axis[1]
-        + view_dir[2] * cone_axis[2];
-    dot + cos_half_angle <= 0.0
+fn meshopt_perspective_cone_reject(
+    camera: [f32; 3],
+    cone_apex: [f32; 3],
+    cone_axis: [f32; 3],
+    cone_cutoff: f32,
+) -> bool {
+    let to_apex = [
+        cone_apex[0] - camera[0],
+        cone_apex[1] - camera[1],
+        cone_apex[2] - camera[2],
+    ];
+    let length =
+        (to_apex[0] * to_apex[0] + to_apex[1] * to_apex[1] + to_apex[2] * to_apex[2]).sqrt();
+    if length <= 1.0e-6 {
+        return false;
+    }
+    let dot = (to_apex[0] * cone_axis[0] + to_apex[1] * cone_axis[1] + to_apex[2] * cone_axis[2])
+        / length;
+    dot >= cone_cutoff
 }
 
 #[test]
 fn cone_culling_backfacing_when_view_behind_cone() {
-    assert!(is_backfacing_cone([0.0, 0.0, -1.0], [0.0, 0.0, 1.0], 0.5));
+    assert!(meshopt_perspective_cone_reject(
+        [0.0, 0.0, -10.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        0.5,
+    ));
 }
 
 #[test]
 fn cone_culling_visible_when_view_in_front_of_cone() {
-    assert!(!is_backfacing_cone([0.0, 0.0, 1.0], [0.0, 0.0, 1.0], 0.5));
+    assert!(!meshopt_perspective_cone_reject(
+        [0.0, 0.0, 10.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 0.0, 1.0],
+        0.5,
+    ));
+}
+
+#[test]
+fn cone_culling_is_disabled_at_the_apex_singularity() {
+    assert!(!meshopt_perspective_cone_reject(
+        [1.0, 2.0, 3.0],
+        [1.0, 2.0, 3.0],
+        [0.0, 0.0, 1.0],
+        0.5,
+    ));
+}
+
+#[test]
+fn conservative_hiz_uses_the_farthest_corner() {
+    let samples = [0.2_f32, 0.3, 0.9, 0.4];
+    let farthest = samples.into_iter().fold(0.0_f32, f32::max);
+    assert_eq!(farthest, 0.9);
+    assert!(!(0.8 > farthest), "a visible corner must prevent occlusion");
 }
 
 // ── Frustum culling stub tests ────────────────────────────────────────────────

--- a/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
+++ b/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
@@ -7,7 +7,7 @@ use std::mem;
 
 // ── Mirror private types ──────────────────────────────────────────────────────
 
-/// Mirrors private CullUniforms (32 bytes).
+/// Mirrors private CullUniforms (48 bytes).
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct CullUniforms {
@@ -17,8 +17,12 @@ struct CullUniforms {
     hiz_mip_count: u32,
     draw_capacity: u32,
     lod_error_threshold_px: f32,
-    dispatch_width: u32,
+    object_dispatch_width: u32,
+    work_item_count: u32,
+    work_dispatch_width: u32,
     _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
 }
 
 /// Mirrors private VgGlobals (96 bytes).
@@ -73,8 +77,8 @@ fn gbuffer_shader_parses_and_validates() {
 // ── CullUniforms layout tests ─────────────────────────────────────────────────
 
 #[test]
-fn cull_uniforms_size_is_32() {
-    assert_eq!(mem::size_of::<CullUniforms>(), 32);
+fn cull_uniforms_size_is_48() {
+    assert_eq!(mem::size_of::<CullUniforms>(), 48);
 }
 
 #[test]
@@ -119,17 +123,17 @@ fn workgroup_size_is_64() {
 }
 
 #[test]
-fn dispatch_uses_one_workgroup_per_object_across_a_2d_grid() {
-    fn grid(object_count: u32, limit: u32) -> (u32, u32) {
-        if object_count == 0 {
+fn dispatch_uses_parallel_object_lanes_and_meshlet_spans() {
+    fn grid(workgroup_count: u32, limit: u32) -> (u32, u32) {
+        if workgroup_count == 0 {
             return (0, 0);
         }
-        let width = object_count.min(limit);
-        (width, object_count.div_ceil(width))
+        let width = workgroup_count.min(limit);
+        (width, workgroup_count.div_ceil(width))
     }
 
-    assert_eq!(grid(1, 65_535), (1, 1));
-    assert_eq!(grid(65_535, 65_535), (65_535, 1));
+    assert_eq!(grid(1_u32.div_ceil(WORKGROUP_SIZE), 65_535), (1, 1));
+    assert_eq!(grid(65_536_u32.div_ceil(WORKGROUP_SIZE), 65_535), (1024, 1));
     assert_eq!(grid(65_536, 65_535), (65_535, 2));
     assert_eq!(grid(0, 65_535), (0, 0));
 }

--- a/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
+++ b/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
@@ -7,16 +7,18 @@ use std::mem;
 
 // ── Mirror private types ──────────────────────────────────────────────────────
 
-/// Mirrors private CullUniforms (48 bytes: 16 header + 32 thresholds).
+/// Mirrors private CullUniforms (32 bytes).
 #[repr(C)]
 #[derive(Clone, Copy)]
 struct CullUniforms {
-    meshlet_count: u32,
+    object_count: u32,
+    screen_width: u32,
+    screen_height: u32,
+    hiz_mip_count: u32,
+    draw_capacity: u32,
+    lod_error_threshold_px: f32,
+    dispatch_width: u32,
     _pad0: u32,
-    _pad1: u32,
-    _pad2: u32,
-    lod_thresholds: [f32; 7],
-    _pad3: f32,
 }
 
 /// Mirrors private VgGlobals (96 bytes).
@@ -39,6 +41,7 @@ struct VgGlobals {
 
 const WORKGROUP_SIZE: u32 = 64;
 const INITIAL_MESHLETS: u64 = 1024;
+const INITIAL_OBJECTS: u64 = 256;
 const INITIAL_INSTANCES: u64 = 256;
 
 #[test]
@@ -54,11 +57,24 @@ fn cull_shader_parses_and_validates() {
         .expect("VG cull shader must validate");
 }
 
+#[test]
+fn gbuffer_shader_parses_and_validates() {
+    let source = include_str!("../shaders/vg_gbuffer.wgsl");
+    let module = wgpu::naga::front::wgsl::parse_str(source).expect("VG draw shader must parse");
+    let mut validator = wgpu::naga::valid::Validator::new(
+        wgpu::naga::valid::ValidationFlags::all(),
+        wgpu::naga::valid::Capabilities::all(),
+    );
+    validator
+        .validate(&module)
+        .expect("VG draw shader must validate");
+}
+
 // ── CullUniforms layout tests ─────────────────────────────────────────────────
 
 #[test]
-fn cull_uniforms_size_is_48() {
-    assert_eq!(mem::size_of::<CullUniforms>(), 48);
+fn cull_uniforms_size_is_32() {
+    assert_eq!(mem::size_of::<CullUniforms>(), 32);
 }
 
 #[test]
@@ -86,6 +102,11 @@ fn initial_meshlets_is_1024() {
 }
 
 #[test]
+fn initial_objects_is_256() {
+    assert_eq!(INITIAL_OBJECTS, 256u64);
+}
+
+#[test]
 fn initial_instances_is_256() {
     assert_eq!(INITIAL_INSTANCES, 256u64);
 }
@@ -98,15 +119,19 @@ fn workgroup_size_is_64() {
 }
 
 #[test]
-fn dispatch_groups_ceil_division() {
-    fn ceil_div(n: u32, d: u32) -> u32 {
-        (n + d - 1) / d
+fn dispatch_uses_one_workgroup_per_object_across_a_2d_grid() {
+    fn grid(object_count: u32, limit: u32) -> (u32, u32) {
+        if object_count == 0 {
+            return (0, 0);
+        }
+        let width = object_count.min(limit);
+        (width, object_count.div_ceil(width))
     }
-    assert_eq!(ceil_div(64, 64), 1);
-    assert_eq!(ceil_div(65, 64), 2);
-    assert_eq!(ceil_div(128, 64), 2);
-    assert_eq!(ceil_div(1024, 64), 16);
-    assert_eq!(ceil_div(0, 64), 0);
+
+    assert_eq!(grid(1, 65_535), (1, 1));
+    assert_eq!(grid(65_535, 65_535), (65_535, 1));
+    assert_eq!(grid(65_536, 65_535), (65_535, 2));
+    assert_eq!(grid(0, 65_535), (0, 0));
 }
 
 // ── Meshlet visibility / LOD threshold tests ────────────────────────────────

--- a/crates/helio-pass-virtual-geometry/tests/lod_tests.rs
+++ b/crates/helio-pass-virtual-geometry/tests/lod_tests.rs
@@ -84,6 +84,13 @@ fn higher_quality_has_lower_s6() {
     assert!(high[6] > ultra[6]);
 }
 
+#[test]
+fn higher_quality_has_stricter_projected_error() {
+    assert!(LodQuality::Low.max_error_pixels() > LodQuality::Medium.max_error_pixels());
+    assert!(LodQuality::Medium.max_error_pixels() > LodQuality::High.max_error_pixels());
+    assert!(LodQuality::High.max_error_pixels() > LodQuality::Ultra.max_error_pixels());
+}
+
 // ── All thresholds positive and below 1.0 ────────────────────────────────────
 
 #[test]

--- a/crates/helio/src/renderer/config.rs
+++ b/crates/helio/src/renderer/config.rs
@@ -21,7 +21,6 @@ pub fn required_wgpu_features(adapter_features: wgpu::Features) -> wgpu::Feature
     let optional =
         wgpu::Features::INDIRECT_FIRST_INSTANCE | // non-zero firstInstance in indirect draws (WebGPU: indirect-first-instance)
         wgpu::Features::MULTI_DRAW_INDIRECT_COUNT | // compacted indirect count buffer
-        wgpu::Features::SHADER_PRIMITIVE_INDEX | // @builtin(primitive_index) in fs
         wgpu::Features::TIMESTAMP_QUERY | // GPU profiling timestamp queries
         wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS | // GPU profiling timestamps via encoder
         wgpu::Features::VERTEX_WRITABLE_STORAGE;

--- a/crates/helio/src/renderer/config.rs
+++ b/crates/helio/src/renderer/config.rs
@@ -15,16 +15,36 @@ pub fn required_wgpu_features(adapter_features: wgpu::Features) -> wgpu::Feature
     #[cfg(not(target_arch = "wasm32"))]
     let required =
         wgpu::Features::TEXTURE_BINDING_ARRAY |
-        wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING;
+        wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING |
+        wgpu::Features::INDIRECT_FIRST_INSTANCE;
     #[cfg(target_arch = "wasm32")]
-    let required = wgpu::Features::empty();
+    let required = wgpu::Features::INDIRECT_FIRST_INSTANCE;
     let optional =
-        wgpu::Features::INDIRECT_FIRST_INSTANCE | // non-zero firstInstance in indirect draws (WebGPU: indirect-first-instance)
         wgpu::Features::MULTI_DRAW_INDIRECT_COUNT | // compacted indirect count buffer
         wgpu::Features::TIMESTAMP_QUERY | // GPU profiling timestamp queries
         wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS | // GPU profiling timestamps via encoder
         wgpu::Features::VERTEX_WRITABLE_STORAGE;
     required | (adapter_features & optional)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::required_wgpu_features;
+
+    #[test]
+    fn indirect_first_instance_is_required_even_when_adapter_does_not_report_it() {
+        assert!(
+            required_wgpu_features(wgpu::Features::empty())
+                .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE)
+        );
+    }
+
+    #[test]
+    fn unsupported_optional_features_are_not_requested() {
+        let requested = required_wgpu_features(wgpu::Features::empty());
+        assert!(!requested.contains(wgpu::Features::MULTI_DRAW_INDIRECT_COUNT));
+        assert!(!requested.contains(wgpu::Features::TIMESTAMP_QUERY));
+    }
 }
 
 pub fn required_wgpu_limits(adapter_limits: wgpu::Limits) -> wgpu::Limits {

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -270,6 +270,7 @@ impl Renderer {
 
     pub fn set_debug_mode(&mut self, mode: u32) {
         self.debug_mode = mode;
+        self.graph.set_debug_mode(mode);
     }
 
     pub fn available_debug_views(&self) -> Vec<helio_core::DebugViewDescriptor> {

--- a/crates/helio/src/renderer/setup.rs
+++ b/crates/helio/src/renderer/setup.rs
@@ -62,15 +62,14 @@ impl Renderer {
     ) -> Self {
         scene.set_render_size(width, height);
 
-        #[cfg(target_arch = "wasm32")]
-        if !device.features().contains(wgpu::Features::INDIRECT_FIRST_INSTANCE) {
-            log::error!(
-                "helio: INDIRECT_FIRST_INSTANCE (WebGPU indirect-first-instance) is not \
-                 available on this device. Only the first object in every scene will render. \
-                 Please use a browser that supports the indirect-first-instance WebGPU feature \
-                 (Chrome 113+, Firefox 122+, Safari 17+)."
-            );
-        }
+        assert!(
+            device
+                .features()
+                .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE),
+            "Helio requires INDIRECT_FIRST_INSTANCE because GPU-driven object and meshlet \
+             draws use non-zero indirect first_instance values; create the device with \
+             helio::required_wgpu_features(adapter.features())"
+        );
 
         let internal_w = config.internal_width();
         let internal_h = config.internal_height();

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -119,12 +119,21 @@ pub struct Scene {
     /// Dense array of virtual objects (one entry per `insert_virtual_object` call).
     pub(in crate::scene) vg_objects: DenseArena<VirtualObjectRecord, VirtualObjectId>,
 
-    /// Set when VG topology or transforms change; triggers `rebuild_vg_buffers()`.
+    /// Set when VG topology changes; triggers `rebuild_vg_buffers()`.
     pub(in crate::scene) vg_objects_dirty: bool,
 
     /// Monotonically increasing counter forwarded to `VgFrameData::buffer_version`.
     /// The VG pass re-uploads GPU buffers only when this advances.
     pub(in crate::scene) vg_buffer_version: u64,
+
+    /// Transform-only changes accumulated until the next scene flush (end exclusive).
+    pub(in crate::scene) vg_instance_dirty_range: Option<(usize, usize)>,
+
+    /// Last transform-only range published to the render pass (end exclusive).
+    pub(in crate::scene) vg_published_instance_dirty_range: Option<(usize, usize)>,
+
+    /// Monotonic version for published transform-only changes.
+    pub(in crate::scene) vg_instance_version: u64,
 
     /// Unique meshlet entries for virtual meshes referenced by the current VG layout.
     pub(in crate::scene) vg_cpu_meshlets: Vec<libhelio::GpuMeshletEntry>,
@@ -285,6 +294,9 @@ impl Scene {
             vg_objects: DenseArena::new(),
             vg_objects_dirty: false,
             vg_buffer_version: 0,
+            vg_instance_dirty_range: None,
+            vg_published_instance_dirty_range: None,
+            vg_instance_version: 0,
             vg_cpu_meshlets: Vec::new(),
             vg_cpu_objects: Vec::new(),
             vg_cpu_instances: Vec::new(),

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -135,6 +135,9 @@ pub struct Scene {
     /// Instance data for all VG objects (one entry per VG object, in order).
     pub(in crate::scene) vg_cpu_instances: Vec<helio_core::GpuInstanceData>,
 
+    /// Immutable 64-meshlet expansion spans for the second GPU cull stage.
+    pub(in crate::scene) vg_cpu_work_items: Vec<libhelio::GpuVgWorkItem>,
+
     /// Exact worst-case number of draws after choosing one LOD per object.
     pub(in crate::scene) vg_max_draw_count: u32,
 
@@ -285,6 +288,7 @@ impl Scene {
             vg_cpu_meshlets: Vec::new(),
             vg_cpu_objects: Vec::new(),
             vg_cpu_instances: Vec::new(),
+            vg_cpu_work_items: Vec::new(),
             vg_max_draw_count: 0,
             water_volumes: DenseArena::new(),
             water_volumes_dirty: false,

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -126,11 +126,17 @@ pub struct Scene {
     /// The VG pass re-uploads GPU buffers only when this advances.
     pub(in crate::scene) vg_buffer_version: u64,
 
-    /// Flattened meshlet entries for the current VG layout (rebuilt when dirty).
+    /// Unique meshlet entries for virtual meshes referenced by the current VG layout.
     pub(in crate::scene) vg_cpu_meshlets: Vec<libhelio::GpuMeshletEntry>,
+
+    /// Object-level LOD ranges and bounds (one entry per VG object).
+    pub(in crate::scene) vg_cpu_objects: Vec<libhelio::GpuVgObject>,
 
     /// Instance data for all VG objects (one entry per VG object, in order).
     pub(in crate::scene) vg_cpu_instances: Vec<helio_core::GpuInstanceData>,
+
+    /// Exact worst-case number of draws after choosing one LOD per object.
+    pub(in crate::scene) vg_max_draw_count: u32,
 
     // ── Water volumes ─────────────────────────────────────────────────────────
     /// Water volumes (dense array)
@@ -277,7 +283,9 @@ impl Scene {
             vg_objects_dirty: false,
             vg_buffer_version: 0,
             vg_cpu_meshlets: Vec::new(),
+            vg_cpu_objects: Vec::new(),
             vg_cpu_instances: Vec::new(),
+            vg_max_draw_count: 0,
             water_volumes: DenseArena::new(),
             water_volumes_dirty: false,
             water_volumes_dirty_range: None,

--- a/crates/helio/src/scene/flush.rs
+++ b/crates/helio/src/scene/flush.rs
@@ -254,10 +254,14 @@ impl Scene {
             self.rebuild_shadow_partition_buffers();
             self.shadow_partition_dirty = false;
         }
-        // Rebuild virtual geometry CPU buffers when VG topology or transforms changed.
+        // Topology changes rebuild all mirrors. Transform-only changes publish
+        // one bounded instance range without touching descriptors or work spans.
         if self.vg_objects_dirty {
             self.rebuild_vg_buffers();
             self.vg_objects_dirty = false;
+        } else if let Some(range) = self.vg_instance_dirty_range.take() {
+            self.vg_published_instance_dirty_range = Some(range);
+            self.vg_instance_version = self.vg_instance_version.wrapping_add(1);
         }
 
         // ── Voxel volume flush ───────────────────────────────────────────────

--- a/crates/helio/src/scene/types.rs
+++ b/crates/helio/src/scene/types.rs
@@ -204,13 +204,29 @@ pub(crate) struct TextureRecord {
 /// Stores mesh handles for each LOD level and precomputed meshlet descriptors.
 #[derive(Debug, Clone)]
 pub(crate) struct VirtualMeshRecord {
-    /// Mesh pool handles for each LOD level: index 0 = full detail, 1 = medium, 2 = coarse.
+    /// Mesh pool handles for each uploaded LOD level.
     pub mesh_ids: Vec<MeshId>,
 
     /// Precomputed meshlet descriptors for all LODs combined.
-    ///
-    /// `lod_error` field encodes the LOD level: 0.0 = full, 1.0 = medium, 2.0 = coarse.
     pub meshlets: Vec<GpuMeshletEntry>,
+
+    /// Conservative mesh-local sphere used for object culling and LOD distance.
+    pub local_bounds: [f32; 4],
+
+    /// Number of valid LOD ranges.
+    pub lod_count: u32,
+
+    /// Measured accumulated object-space simplification errors.
+    pub lod_errors: [f32; libhelio::VG_LOD_LEVELS],
+
+    /// Per-LOD offsets into `meshlets`, before the shared frame-buffer base is applied.
+    pub lod_first_meshlets: [u32; libhelio::VG_LOD_LEVELS],
+
+    /// Per-LOD meshlet counts.
+    pub lod_meshlet_counts: [u32; libhelio::VG_LOD_LEVELS],
+
+    /// Largest per-LOD meshlet count.
+    pub max_meshlet_count: u32,
 
     /// Number of virtual objects currently using this mesh.
     pub ref_count: u32,
@@ -264,4 +280,3 @@ pub(crate) struct PostProcessVolumeRecord {
     /// GPU post-process volume descriptor with bounds, priority, and settings.
     pub gpu: GpuPostProcessVolume,
 }
-

--- a/crates/helio/src/scene/virtual_geometry/meshes.rs
+++ b/crates/helio/src/scene/virtual_geometry/meshes.rs
@@ -5,7 +5,8 @@
 use crate::handles::MeshId;
 use crate::mesh::MeshUpload;
 use crate::vg::{
-    generate_lod_meshes, meshletize_with_indices, VirtualMeshId, VirtualMeshUpload,
+    generate_lod_meshes, meshletize_with_indices, GeneratedLodMesh, VirtualMeshId,
+    VirtualMeshUpload,
 };
 
 use super::super::errors::{invalid, Result, SceneError};
@@ -25,7 +26,12 @@ impl super::super::Scene {
         let mut all_meshlets: Vec<libhelio::GpuMeshletEntry> = Vec::new();
         let mut mesh_ids: Vec<MeshId> = Vec::new();
 
-        for (lod_level, (lod_verts, lod_indices)) in lod_meshes.into_iter().enumerate() {
+        for (lod_level, lod_mesh) in lod_meshes.into_iter().enumerate() {
+            let GeneratedLodMesh {
+                vertices: lod_verts,
+                indices: lod_indices,
+                error: _,
+            } = lod_mesh;
             // Build meshlets with meshoptimizer — this produces a reordered
             // index buffer that groups spatially coherent triangles.
             let (mut meshlets, meshlet_indices) =
@@ -107,4 +113,3 @@ impl super::super::Scene {
         Ok(())
     }
 }
-

--- a/crates/helio/src/scene/virtual_geometry/meshes.rs
+++ b/crates/helio/src/scene/virtual_geometry/meshes.rs
@@ -47,12 +47,13 @@ impl super::super::Scene {
     /// geometry rendering.
     ///
     /// Uses meshoptimizer for LOD simplification and meshlet building. Generates
-    /// 8 LOD levels and decomposes each into spatially coherent meshlets with
-    /// tight bounding spheres and backface cones.
+    /// up to 8 distinct LOD levels and decomposes each into spatially coherent
+    /// meshlets with tight bounding spheres and backface cones. Small or rigid
+    /// assets may expose fewer levels rather than duplicated placeholder LODs.
     pub(in crate::scene) fn insert_virtual_mesh(&mut self, upload: VirtualMeshUpload) -> VirtualMeshId {
         let local_bounds = referenced_bounds(&upload.vertices, &upload.indices).unwrap_or([0.0; 4]);
 
-        // Generate 8 LOD levels via meshopt simplification.
+        // Generate the asset's distinct LOD chain via meshopt simplification.
         let lod_meshes = generate_lod_meshes(&upload.vertices, &upload.indices);
 
         let mut all_meshlets: Vec<libhelio::GpuMeshletEntry> = Vec::new();

--- a/crates/helio/src/scene/virtual_geometry/meshes.rs
+++ b/crates/helio/src/scene/virtual_geometry/meshes.rs
@@ -12,6 +12,36 @@ use crate::vg::{
 use super::super::errors::{invalid, Result, SceneError};
 use super::super::types::VirtualMeshRecord;
 
+fn referenced_bounds(
+    vertices: &[crate::mesh::PackedVertex],
+    indices: &[u32],
+) -> Option<[f32; 4]> {
+    let mut min = glam::Vec3::splat(f32::INFINITY);
+    let mut max = glam::Vec3::splat(f32::NEG_INFINITY);
+
+    for &index in indices {
+        let position = glam::Vec3::from_array(vertices.get(index as usize)?.position);
+        if !position.is_finite() {
+            return None;
+        }
+        min = min.min(position);
+        max = max.max(position);
+    }
+
+    if indices.is_empty() {
+        return None;
+    }
+
+    let center = (min + max) * 0.5;
+    let mut radius = 0.0_f32;
+    for &index in indices {
+        let position = glam::Vec3::from_array(vertices[index as usize].position);
+        radius = radius.max(position.distance(center));
+    }
+
+    Some([center.x, center.y, center.z, radius])
+}
+
 impl super::super::Scene {
     /// Upload a high-resolution mesh and decompose it into GPU meshlets for virtual
     /// geometry rendering.
@@ -20,18 +50,26 @@ impl super::super::Scene {
     /// 8 LOD levels and decomposes each into spatially coherent meshlets with
     /// tight bounding spheres and backface cones.
     pub(in crate::scene) fn insert_virtual_mesh(&mut self, upload: VirtualMeshUpload) -> VirtualMeshId {
+        let local_bounds = referenced_bounds(&upload.vertices, &upload.indices).unwrap_or([0.0; 4]);
+
         // Generate 8 LOD levels via meshopt simplification.
         let lod_meshes = generate_lod_meshes(&upload.vertices, &upload.indices);
 
         let mut all_meshlets: Vec<libhelio::GpuMeshletEntry> = Vec::new();
         let mut mesh_ids: Vec<MeshId> = Vec::new();
+        let mut lod_errors = [0.0; libhelio::VG_LOD_LEVELS];
+        let mut lod_first_meshlets = [0; libhelio::VG_LOD_LEVELS];
+        let mut lod_meshlet_counts = [0; libhelio::VG_LOD_LEVELS];
+        let mut max_meshlet_count = 0;
 
         for (lod_level, lod_mesh) in lod_meshes.into_iter().enumerate() {
             let GeneratedLodMesh {
                 vertices: lod_verts,
                 indices: lod_indices,
-                error: _,
+                error,
             } = lod_mesh;
+            let first_meshlet = u32::try_from(all_meshlets.len())
+                .expect("virtual mesh exceeds the u32 descriptor address space");
             // Build meshlets with meshoptimizer — this produces a reordered
             // index buffer that groups spatially coherent triangles.
             let (mut meshlets, meshlet_indices) =
@@ -47,11 +85,20 @@ impl super::super::Scene {
             for m in &mut meshlets {
                 m.first_index += slice.first_index;
                 m.vertex_offset += slice.first_vertex as i32;
-                m.lod_error = lod_level as f32;
+                m.lod_error = error;
             }
+
+            let meshlet_count = u32::try_from(meshlets.len())
+                .expect("virtual-mesh LOD exceeds the u32 descriptor address space");
+            lod_errors[lod_level] = error;
+            lod_first_meshlets[lod_level] = first_meshlet;
+            lod_meshlet_counts[lod_level] = meshlet_count;
+            max_meshlet_count = max_meshlet_count.max(meshlet_count);
             all_meshlets.extend(meshlets);
             mesh_ids.push(mesh_id);
         }
+
+        let lod_count = u32::try_from(mesh_ids.len()).expect("LOD count must fit in u32");
 
         let id = VirtualMeshId(self.vg_next_mesh_id);
         self.vg_next_mesh_id += 1;
@@ -60,6 +107,12 @@ impl super::super::Scene {
             VirtualMeshRecord {
                 mesh_ids,
                 meshlets: all_meshlets,
+                local_bounds,
+                lod_count,
+                lod_errors,
+                lod_first_meshlets,
+                lod_meshlet_counts,
+                max_meshlet_count,
                 ref_count: 0,
             },
         );
@@ -111,5 +164,41 @@ impl super::super::Scene {
             }
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::referenced_bounds;
+    use crate::mesh::PackedVertex;
+
+    fn vertex(position: [f32; 3]) -> PackedVertex {
+        PackedVertex::from_components(
+            position,
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            1.0,
+        )
+    }
+
+    #[test]
+    fn bounds_only_include_referenced_vertices() {
+        let vertices = [
+            vertex([-1.0, -1.0, -1.0]),
+            vertex([1.0, 1.0, 1.0]),
+            vertex([10_000.0, 10_000.0, 10_000.0]),
+        ];
+        let bounds = referenced_bounds(&vertices, &[0, 1, 0]).unwrap();
+
+        assert_eq!(&bounds[..3], &[0.0, 0.0, 0.0]);
+        assert!((bounds[3] - 3.0_f32.sqrt()).abs() < 1.0e-6);
+    }
+
+    #[test]
+    fn bounds_reject_missing_or_non_finite_geometry() {
+        assert!(referenced_bounds(&[], &[]).is_none());
+        assert!(referenced_bounds(&[vertex([0.0; 3])], &[1]).is_none());
+        assert!(referenced_bounds(&[vertex([f32::NAN, 0.0, 0.0])], &[0]).is_none());
     }
 }

--- a/crates/helio/src/scene/virtual_geometry/mod.rs
+++ b/crates/helio/src/scene/virtual_geometry/mod.rs
@@ -12,7 +12,8 @@
 //! virtual geometry is **fully GPU-driven**:
 //! - Meshlets are stored in a flat GPU buffer
 //! - Instances reference ranges in the meshlet buffer
-//! - GPU compute shader performs per-meshlet culling and LOD selection
+//! - GPU stage one performs conservative object culling and selects one LOD per object
+//! - GPU stage two culls the selected LOD through fixed 64-meshlet work spans
 //! - No CPU readback or per-frame iteration
 //!
 //! # Module Organization

--- a/crates/helio/src/scene/virtual_geometry/objects.rs
+++ b/crates/helio/src/scene/virtual_geometry/objects.rs
@@ -65,13 +65,18 @@ impl super::super::Scene {
             .vg_meshes
             .get_mut(&desc.virtual_mesh)
             .ok_or_else(|| invalid("virtual_mesh"))?;
+        let mesh_id = record
+            .mesh_ids
+            .first()
+            .copied()
+            .ok_or_else(|| invalid("virtual_mesh_geometry"))?;
         record.ref_count += 1;
 
         let instance = GpuInstanceData {
             model: desc.transform.to_cols_array(),
             normal_mat: normal_matrix(desc.transform),
             bounds: desc.bounds,
-            mesh_id: record.mesh_ids[0].slot(),
+            mesh_id: mesh_id.slot(),
             material_id: desc.material_id,
             flags: desc.flags,
             lightmap_index: 0xFFFFFFFF,  // Virtual geometry doesn't use lightmaps

--- a/crates/helio/src/scene/virtual_geometry/objects.rs
+++ b/crates/helio/src/scene/virtual_geometry/objects.rs
@@ -12,6 +12,13 @@ use super::super::errors::{invalid, Result};
 use super::super::helpers::normal_matrix;
 use super::super::types::VirtualObjectRecord;
 
+fn include_dirty_instance(range: &mut Option<(usize, usize)>, index: usize) {
+    *range = Some(match *range {
+        Some((start, end)) => (start.min(index), end.max(index + 1)),
+        None => (index, index + 1),
+    });
+}
+
 impl super::super::Scene {
     /// Place an instance of a virtual mesh into the scene.
     ///
@@ -94,7 +101,7 @@ impl super::super::Scene {
     /// Update the world transform of a virtual object.
     ///
     /// Modifies the object's model matrix and recomputes the normal matrix.
-    /// The change is reflected in the next VG buffer rebuild (on next `flush()`).
+    /// The change is reflected by a bounded instance-buffer upload on next `flush()`.
     ///
     /// # Parameters
     /// - `id`: Virtual object handle
@@ -107,15 +114,14 @@ impl super::super::Scene {
     /// `Ok(())` if the transform was successfully updated.
     ///
     /// # Performance
-    /// - CPU cost: O(1) - updates CPU-side record, marks VG dirty
-    /// - GPU cost: Deferred to next `flush()` when VG buffers are rebuilt
+    /// - CPU cost: O(1) - updates the record and expands one dirty range
+    /// - GPU cost: Uploads only the contiguous dirty instance range on next `flush()`
     /// - Memory: No allocations
     ///
     /// # Deferred Updates
     ///
-    /// Unlike regular objects (which support O(1) in-place GPU updates), virtual
-    /// geometry transforms are always applied via full buffer rebuild. This is
-    /// acceptable because VG is designed for static or infrequently-updated geometry.
+    /// Meshlet descriptors, object LOD ranges, and work spans remain immutable.
+    /// Insertions/removals still rebuild topology, but transform-only changes do not.
     ///
     /// # Example
     /// ```ignore
@@ -133,7 +139,7 @@ impl super::super::Scene {
         id: VirtualObjectId,
         transform: Mat4,
     ) -> Result<()> {
-        let Some((_, record)) = self.vg_objects.get_mut_with_index(id) else {
+        let Some((dense_index, record)) = self.vg_objects.get_mut_with_index(id) else {
             return Err(invalid("virtual_object"));
         };
         // Enforce movability: Static objects cannot have transforms updated
@@ -146,13 +152,23 @@ impl super::super::Scene {
         }
         record.instance.model = transform.to_cols_array();
         record.instance.normal_mat = normal_matrix(transform);
+        let updated_instance = record.instance;
 
         // Increment generation counter for movable objects (for shadow cache invalidation)
         self.movable_objects_generation += 1;
         self.gpu_scene.movable_objects_generation = self.movable_objects_generation;
 
-        // Mark dirty so vg_frame_data() picks up the new transform.
-        self.vg_objects_dirty = true;
+        // Topology rebuilds republish every instance. Otherwise keep the CPU
+        // mirror in place and publish only the affected range on the next flush.
+        if !self.vg_objects_dirty {
+            if let Some(instance) = self.vg_cpu_instances.get_mut(dense_index) {
+                *instance = updated_instance;
+                include_dirty_instance(&mut self.vg_instance_dirty_range, dense_index);
+            } else {
+                // A missing mirror means topology has not been published yet.
+                self.vg_objects_dirty = true;
+            }
+        }
         Ok(())
     }
 
@@ -196,6 +212,119 @@ impl super::super::Scene {
         }
         self.vg_objects_dirty = true;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use glam::{Mat4, Vec3};
+    use libhelio::Movability;
+
+    use crate::{
+        groups::GroupMask,
+        mesh::PackedVertex,
+        vg::{VirtualMeshUpload, VirtualObjectDescriptor},
+        Scene,
+    };
+
+    use super::include_dirty_instance;
+
+    fn create_test_scene() -> Scene {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            ..Default::default()
+        });
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("no adapter found");
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                ..Default::default()
+            },
+        ))
+        .expect("failed to create device");
+        Scene::new(Arc::new(device), Arc::new(queue))
+    }
+
+    #[test]
+    fn transform_dirty_range_is_end_exclusive_and_coalesced() {
+        let mut range = None;
+        include_dirty_instance(&mut range, 7);
+        assert_eq!(range, Some((7, 8)));
+        include_dirty_instance(&mut range, 3);
+        include_dirty_instance(&mut range, 11);
+        include_dirty_instance(&mut range, 5);
+        assert_eq!(range, Some((3, 12)));
+    }
+
+    #[test]
+    fn transform_only_flush_keeps_topology_version_and_publishes_one_instance() {
+        let mut scene = create_test_scene();
+        let vertices = vec![
+            PackedVertex::from_components(
+                [0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                1.0,
+            ),
+            PackedVertex::from_components(
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [1.0, 0.0],
+                [1.0, 0.0, 0.0],
+                1.0,
+            ),
+            PackedVertex::from_components(
+                [0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0],
+                [1.0, 0.0, 0.0],
+                1.0,
+            ),
+        ];
+        let mesh = scene.insert_virtual_mesh(VirtualMeshUpload {
+            vertices,
+            indices: vec![0, 1, 2],
+        });
+        let object = scene
+            .insert_virtual_object(VirtualObjectDescriptor {
+                virtual_mesh: mesh,
+                material_id: 0,
+                transform: Mat4::IDENTITY,
+                bounds: [0.5, 0.0, 0.5, 1.0],
+                flags: 0,
+                groups: GroupMask::NONE,
+                movability: Some(Movability::Movable),
+            })
+            .expect("insert virtual object");
+        scene.flush();
+
+        let topology_version = scene.vg_buffer_version;
+        let instance_version = scene.vg_instance_version;
+        let moved = Mat4::from_translation(Vec3::new(4.0, 5.0, 6.0));
+        scene
+            .update_virtual_object_transform(object, moved)
+            .expect("update virtual object transform");
+
+        assert!(!scene.vg_objects_dirty);
+        assert_eq!(scene.vg_instance_dirty_range, Some((0, 1)));
+        scene.flush();
+
+        assert_eq!(scene.vg_buffer_version, topology_version);
+        assert_eq!(scene.vg_instance_version, instance_version + 1);
+        assert_eq!(scene.vg_published_instance_dirty_range, Some((0, 1)));
+        assert_eq!(scene.vg_cpu_instances[0].model, moved.to_cols_array());
+        let frame = scene.vg_frame_data().expect("VG frame data");
+        assert_eq!(frame.instance_dirty_start, 0);
+        assert_eq!(frame.instance_dirty_count, 1);
     }
 }
 

--- a/crates/helio/src/scene/virtual_geometry/rebuild.rs
+++ b/crates/helio/src/scene/virtual_geometry/rebuild.rs
@@ -6,7 +6,10 @@
 
 use std::collections::HashMap;
 
-use libhelio::{GpuMeshletEntry, GpuVgObject, VgFrameData, VG_LOD_LEVELS};
+use libhelio::{
+    GpuMeshletEntry, GpuVgObject, GpuVgWorkItem, VgFrameData,
+    VG_CULL_MESHLETS_PER_WORK_ITEM, VG_LOD_LEVELS,
+};
 
 use crate::vg::VirtualMeshId;
 
@@ -39,6 +42,21 @@ fn append_unique_meshlets(
     bases
 }
 
+fn append_work_items(
+    object_index: u32,
+    max_meshlet_count: u32,
+    output: &mut Vec<GpuVgWorkItem>,
+) {
+    for local_meshlet_base in
+        (0..max_meshlet_count).step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
+    {
+        output.push(GpuVgWorkItem {
+            object_index,
+            local_meshlet_base,
+        });
+    }
+}
+
 impl super::super::Scene {
     /// Returns the immutable mesh descriptors, object-level LOD metadata, and
     /// instance data consumed by the virtual-geometry pass.
@@ -50,10 +68,13 @@ impl super::super::Scene {
             meshlets: bytemuck::cast_slice(&self.vg_cpu_meshlets),
             objects: bytemuck::cast_slice(&self.vg_cpu_objects),
             instances: bytemuck::cast_slice(&self.vg_cpu_instances),
+            work_items: bytemuck::cast_slice(&self.vg_cpu_work_items),
             meshlet_count: u32::try_from(self.vg_cpu_meshlets.len())
                 .expect("virtual geometry exceeds the u32 descriptor address space"),
             object_count: u32::try_from(self.vg_cpu_objects.len())
                 .expect("virtual geometry exceeds the u32 object address space"),
+            work_item_count: u32::try_from(self.vg_cpu_work_items.len())
+                .expect("virtual geometry exceeds the u32 work-item address space"),
             max_draw_count: self.vg_max_draw_count,
             buffer_version: self.vg_buffer_version,
         })
@@ -70,6 +91,7 @@ impl super::super::Scene {
         self.vg_cpu_meshlets.clear();
         self.vg_cpu_objects.clear();
         self.vg_cpu_instances.clear();
+        self.vg_cpu_work_items.clear();
         self.vg_max_draw_count = 0;
         self.vg_cpu_objects.reserve(dense_object_count);
         self.vg_cpu_instances.reserve(dense_object_count);
@@ -97,6 +119,8 @@ impl super::super::Scene {
 
             let instance_index = u32::try_from(self.vg_cpu_instances.len())
                 .expect("virtual geometry exceeds the u32 instance address space");
+            let object_index = u32::try_from(self.vg_cpu_objects.len())
+                .expect("virtual geometry exceeds the u32 object address space");
             let mut lod_first_meshlets = [0; VG_LOD_LEVELS];
             for (level, first) in lod_first_meshlets.iter_mut().enumerate() {
                 *first = mesh_base
@@ -115,6 +139,11 @@ impl super::super::Scene {
                 lod_first_meshlets,
                 lod_meshlet_counts: mesh.lod_meshlet_counts,
             });
+            append_work_items(
+                object_index,
+                mesh.max_meshlet_count,
+                &mut self.vg_cpu_work_items,
+            );
             self.vg_max_draw_count = self
                 .vg_max_draw_count
                 .checked_add(mesh.max_meshlet_count)
@@ -123,9 +152,10 @@ impl super::super::Scene {
 
         self.vg_buffer_version = self.vg_buffer_version.wrapping_add(1);
         eprintln!(
-            "[vg] rebuild: {} objects, {} unique meshlets, {} max draws",
+            "[vg] rebuild: {} objects, {} unique meshlets, {} work spans, {} max draws",
             self.vg_cpu_objects.len(),
             self.vg_cpu_meshlets.len(),
+            self.vg_cpu_work_items.len(),
             self.vg_max_draw_count,
         );
     }
@@ -137,7 +167,7 @@ mod tests {
 
     use libhelio::{GpuMeshletEntry, VG_LOD_LEVELS};
 
-    use super::{append_unique_meshlets, VirtualMeshId, VirtualMeshRecord};
+    use super::{append_unique_meshlets, append_work_items, VirtualMeshId, VirtualMeshRecord};
 
     fn meshlet(first_index: u32) -> GpuMeshletEntry {
         GpuMeshletEntry {
@@ -188,5 +218,32 @@ mod tests {
         assert_eq!(bases[&first], 0);
         assert_eq!(bases[&second], 2);
         assert_eq!(output.iter().map(|entry| entry.first_index).collect::<Vec<_>>(), [11, 12, 20]);
+    }
+
+    #[test]
+    fn work_items_cover_exact_fixed_meshlet_spans() {
+        let mut output = Vec::new();
+
+        append_work_items(3, 0, &mut output);
+        append_work_items(5, 1, &mut output);
+        append_work_items(7, 64, &mut output);
+        append_work_items(11, 65, &mut output);
+        append_work_items(13, 130, &mut output);
+
+        assert_eq!(
+            output
+                .iter()
+                .map(|item| (item.object_index, item.local_meshlet_base))
+                .collect::<Vec<_>>(),
+            [
+                (5, 0),
+                (7, 0),
+                (11, 0),
+                (11, 64),
+                (13, 0),
+                (13, 64),
+                (13, 128),
+            ]
+        );
     }
 }

--- a/crates/helio/src/scene/virtual_geometry/rebuild.rs
+++ b/crates/helio/src/scene/virtual_geometry/rebuild.rs
@@ -77,6 +77,15 @@ impl super::super::Scene {
                 .expect("virtual geometry exceeds the u32 work-item address space"),
             max_draw_count: self.vg_max_draw_count,
             buffer_version: self.vg_buffer_version,
+            instance_version: self.vg_instance_version,
+            instance_dirty_start: self
+                .vg_published_instance_dirty_range
+                .map_or(0, |(start, _)| u32::try_from(start).expect("VG dirty start exceeds u32")),
+            instance_dirty_count: self
+                .vg_published_instance_dirty_range
+                .map_or(0, |(start, end)| {
+                    u32::try_from(end - start).expect("VG dirty count exceeds u32")
+                }),
         })
     }
 
@@ -92,6 +101,8 @@ impl super::super::Scene {
         self.vg_cpu_objects.clear();
         self.vg_cpu_instances.clear();
         self.vg_cpu_work_items.clear();
+        self.vg_instance_dirty_range = None;
+        self.vg_published_instance_dirty_range = None;
         self.vg_max_draw_count = 0;
         self.vg_cpu_objects.reserve(dense_object_count);
         self.vg_cpu_instances.reserve(dense_object_count);

--- a/crates/helio/src/scene/virtual_geometry/rebuild.rs
+++ b/crates/helio/src/scene/virtual_geometry/rebuild.rs
@@ -1,136 +1,192 @@
 //! Virtual geometry buffer rebuild and frame data packaging.
 //!
-//! Handles CPU-side buffer reconstruction and provides frame data views for the renderer.
+//! Meshlet descriptors are stored once per referenced virtual mesh. A separate
+//! object array supplies the instance index, conservative local bounds, measured
+//! LOD errors, and the descriptor range for each LOD.
 
-use libhelio::VgFrameData;
+use std::collections::HashMap;
+
+use libhelio::{GpuMeshletEntry, GpuVgObject, VgFrameData, VG_LOD_LEVELS};
+
+use crate::vg::VirtualMeshId;
+
+use super::super::types::VirtualMeshRecord;
+
+fn append_unique_meshlets(
+    referenced_meshes: impl IntoIterator<Item = VirtualMeshId>,
+    mesh_records: &HashMap<VirtualMeshId, VirtualMeshRecord>,
+    output: &mut Vec<GpuMeshletEntry>,
+) -> HashMap<VirtualMeshId, u32> {
+    let mut bases = HashMap::new();
+
+    for mesh_id in referenced_meshes {
+        if bases.contains_key(&mesh_id) {
+            continue;
+        }
+        let Some(record) = mesh_records.get(&mesh_id) else {
+            continue;
+        };
+        if record.meshlets.is_empty() || record.lod_count == 0 {
+            continue;
+        }
+
+        let base = u32::try_from(output.len())
+            .expect("virtual geometry exceeds the u32 descriptor address space");
+        output.extend_from_slice(&record.meshlets);
+        bases.insert(mesh_id, base);
+    }
+
+    bases
+}
 
 impl super::super::Scene {
-    /// Returns a view into the CPU-side meshlet/instance buffers for VG rendering.
-    ///
-    /// Returns `None` if there are no virtual geometry objects in the scene.
-    ///
-    /// # Returns
-    /// - `Some(VgFrameData)` if there are VG objects
-    /// - `None` if the scene has no VG objects
-    ///
-    /// # Frame Data Contents
-    ///
-    /// The returned [`VgFrameData`] contains:
-    /// - `meshlets`: Flat array of all meshlet descriptors (for all instances)
-    /// - `instances`: Array of instance data (transforms, bounds, material IDs)
-    /// - `meshlet_count`: Total number of meshlets
-    /// - `instance_count`: Total number of instances
-    /// - `buffer_version`: Monotonically increasing version number
-    ///
-    /// # Buffer Version
-    ///
-    /// The `buffer_version` increments whenever VG buffers are rebuilt. The renderer
-    /// uses this to detect when GPU buffers need to be re-uploaded.
-    ///
-    /// # Performance
-    /// - CPU cost: O(1) - returns references to existing buffers
-    /// - GPU cost: None (this is a read-only view)
-    /// - Memory: No allocations
-    ///
-    /// # Example
-    /// ```ignore
-    /// if let Some(vg_data) = scene.vg_frame_data() {
-    ///     // Upload to GPU if version changed
-    ///     if vg_data.buffer_version != last_version {
-    ///         upload_vg_buffers(vg_data);
-    ///         last_version = vg_data.buffer_version;
-    ///     }
-    /// }
-    /// ```
+    /// Returns the immutable mesh descriptors, object-level LOD metadata, and
+    /// instance data consumed by the virtual-geometry pass.
     pub fn vg_frame_data(&self) -> Option<VgFrameData<'_>> {
-        if self.vg_cpu_meshlets.is_empty() {
+        if self.vg_cpu_objects.is_empty() {
             return None;
         }
         Some(VgFrameData {
             meshlets: bytemuck::cast_slice(&self.vg_cpu_meshlets),
+            objects: bytemuck::cast_slice(&self.vg_cpu_objects),
             instances: bytemuck::cast_slice(&self.vg_cpu_instances),
-            meshlet_count: self.vg_cpu_meshlets.len() as u32,
-            instance_count: self.vg_cpu_instances.len() as u32,
+            meshlet_count: u32::try_from(self.vg_cpu_meshlets.len())
+                .expect("virtual geometry exceeds the u32 descriptor address space"),
+            object_count: u32::try_from(self.vg_cpu_objects.len())
+                .expect("virtual geometry exceeds the u32 object address space"),
+            max_draw_count: self.vg_max_draw_count,
             buffer_version: self.vg_buffer_version,
         })
     }
 
-    /// Rebuild CPU-side VG buffers from the current VG object set.
+    /// Rebuild the CPU mirrors used by the GPU-driven virtual-geometry pass.
     ///
-    /// This assigns each VG object a contiguous `instance_index` slot and patches the
-    /// `GpuMeshletEntry::instance_index` field in all meshlets owned by that object.
-    ///
-    /// Called from `flush()` when `vg_objects_dirty` is true.
-    ///
-    /// # Algorithm
-    ///
-    /// 1. Clear CPU-side meshlet and instance buffers
-    /// 2. For each VG object:
-    ///    - Assign sequential instance_index
-    ///    - Push instance data to instance buffer
-    ///    - Clone all meshlets from the object's virtual mesh
-    ///    - Patch each meshlet's instance_index to reference this instance
-    ///    - Append meshlets to flat meshlet buffer
-    /// 3. Increment buffer_version to signal re-upload needed
-    ///
-    /// # Performance
-    /// - CPU cost: O(N) over VG objects + O(M) over total meshlets
-    /// - GPU cost: None (GPU upload happens in renderer)
-    /// - Memory: Rebuilds two vectors (meshlets and instances)
-    ///
-    /// # Buffer Layout
-    ///
-    /// **Meshlet buffer (flat array):**
-    /// ```text
-    /// [obj0_meshlet0, obj0_meshlet1, ..., obj1_meshlet0, obj1_meshlet1, ...]
-    /// ```
-    ///
-    /// **Instance buffer:**
-    /// ```text
-    /// [obj0_instance, obj1_instance, obj2_instance, ...]
-    /// ```
-    ///
-    /// Each meshlet references its owning instance via `instance_index`.
-    ///
-    /// # Example Output
-    ///
-    /// For 2 VG objects:
-    /// - Object 0: 100 meshlets
-    /// - Object 1: 150 meshlets
-    ///
-    /// Result:
-    /// - `vg_cpu_instances.len() = 2`
-    /// - `vg_cpu_meshlets.len() = 250`
-    /// - Object 0's meshlets have `instance_index = 0`
-    /// - Object 1's meshlets have `instance_index = 1`
+    /// Each referenced virtual mesh contributes its descriptors exactly once,
+    /// regardless of instance count. Each object then points at the shared
+    /// per-LOD ranges. `vg_max_draw_count` is the exact worst case after one LOD
+    /// is selected for every object, and therefore bounds every atomic append.
     pub(in crate::scene) fn rebuild_vg_buffers(&mut self) {
-        let instance_count = self.vg_objects.dense_len();
-        self.vg_cpu_instances.clear();
+        let dense_object_count = self.vg_objects.dense_len();
         self.vg_cpu_meshlets.clear();
-        self.vg_cpu_instances.reserve(instance_count);
+        self.vg_cpu_objects.clear();
+        self.vg_cpu_instances.clear();
+        self.vg_max_draw_count = 0;
+        self.vg_cpu_objects.reserve(dense_object_count);
+        self.vg_cpu_instances.reserve(dense_object_count);
 
-        for i in 0..instance_count {
-            let Some(obj) = self.vg_objects.get_dense(i) else {
+        let referenced_meshes = (0..dense_object_count)
+            .filter_map(|index| self.vg_objects.get_dense(index))
+            .map(|object| object.virtual_mesh)
+            .collect::<Vec<_>>();
+        let mesh_bases = append_unique_meshlets(
+            referenced_meshes,
+            &self.vg_meshes,
+            &mut self.vg_cpu_meshlets,
+        );
+
+        for dense_index in 0..dense_object_count {
+            let Some(object) = self.vg_objects.get_dense(dense_index) else {
                 continue;
             };
-            let instance_index = self.vg_cpu_instances.len() as u32;
-            self.vg_cpu_instances.push(obj.instance);
-
-            let Some(mesh_record) = self.vg_meshes.get(&obj.virtual_mesh) else {
+            let Some(mesh) = self.vg_meshes.get(&object.virtual_mesh) else {
                 continue;
             };
-            for mut meshlet in mesh_record.meshlets.iter().copied() {
-                meshlet.instance_index = instance_index;
-                self.vg_cpu_meshlets.push(meshlet);
+            let Some(&mesh_base) = mesh_bases.get(&object.virtual_mesh) else {
+                continue;
+            };
+
+            let instance_index = u32::try_from(self.vg_cpu_instances.len())
+                .expect("virtual geometry exceeds the u32 instance address space");
+            let mut lod_first_meshlets = [0; VG_LOD_LEVELS];
+            for (level, first) in lod_first_meshlets.iter_mut().enumerate() {
+                *first = mesh_base
+                    .checked_add(mesh.lod_first_meshlets[level])
+                    .expect("virtual geometry descriptor offset overflow");
             }
+
+            self.vg_cpu_instances.push(object.instance);
+            self.vg_cpu_objects.push(GpuVgObject {
+                instance_index,
+                lod_count: mesh.lod_count,
+                max_meshlet_count: mesh.max_meshlet_count,
+                reserved: 0,
+                local_bounds: mesh.local_bounds,
+                lod_errors: mesh.lod_errors,
+                lod_first_meshlets,
+                lod_meshlet_counts: mesh.lod_meshlet_counts,
+            });
+            self.vg_max_draw_count = self
+                .vg_max_draw_count
+                .checked_add(mesh.max_meshlet_count)
+                .expect("virtual geometry indirect draw capacity exceeds u32");
         }
 
         self.vg_buffer_version = self.vg_buffer_version.wrapping_add(1);
         eprintln!(
-            "[vg] rebuild_vg_buffers: {} VG objects → {} meshlets",
-            instance_count,
-            self.vg_cpu_meshlets.len()
+            "[vg] rebuild: {} objects, {} unique meshlets, {} max draws",
+            self.vg_cpu_objects.len(),
+            self.vg_cpu_meshlets.len(),
+            self.vg_max_draw_count,
         );
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use libhelio::{GpuMeshletEntry, VG_LOD_LEVELS};
+
+    use super::{append_unique_meshlets, VirtualMeshId, VirtualMeshRecord};
+
+    fn meshlet(first_index: u32) -> GpuMeshletEntry {
+        GpuMeshletEntry {
+            center: [0.0; 3],
+            radius: 1.0,
+            cone_apex: [0.0; 3],
+            cone_cutoff: 2.0,
+            cone_axis: [0.0, 1.0, 0.0],
+            lod_error: 0.0,
+            first_index,
+            index_count: 3,
+            vertex_offset: 0,
+            instance_index: 0,
+        }
+    }
+
+    fn record(meshlets: Vec<GpuMeshletEntry>) -> VirtualMeshRecord {
+        VirtualMeshRecord {
+            mesh_ids: Vec::new(),
+            meshlets,
+            local_bounds: [0.0, 0.0, 0.0, 1.0],
+            lod_count: 1,
+            lod_errors: [0.0; VG_LOD_LEVELS],
+            lod_first_meshlets: [0; VG_LOD_LEVELS],
+            lod_meshlet_counts: [1; VG_LOD_LEVELS],
+            max_meshlet_count: 1,
+            ref_count: 0,
+        }
+    }
+
+    #[test]
+    fn repeated_instances_share_one_descriptor_copy() {
+        let first = VirtualMeshId(3);
+        let second = VirtualMeshId(7);
+        let records = HashMap::from([
+            (first, record(vec![meshlet(11), meshlet(12)])),
+            (second, record(vec![meshlet(20)])),
+        ]);
+        let mut output = Vec::new();
+
+        let bases = append_unique_meshlets(
+            [first, first, second, first, second],
+            &records,
+            &mut output,
+        );
+
+        assert_eq!(output.len(), 3);
+        assert_eq!(bases[&first], 0);
+        assert_eq!(bases[&second], 2);
+        assert_eq!(output.iter().map(|entry| entry.first_index).collect::<Vec<_>>(), [11, 12, 20]);
+    }
+}

--- a/crates/helio/src/vg.rs
+++ b/crates/helio/src/vg.rs
@@ -12,6 +12,14 @@ use meshopt::DecodePosition;
 
 use crate::mesh::PackedVertex;
 
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedLodMesh {
+    pub vertices: Vec<PackedVertex>,
+    pub indices: Vec<u32>,
+    /// Conservative accumulated object-space simplification error.
+    pub error: f32,
+}
+
 // ─── Handle types ───────────────────────────────────────────────────────────
 
 /// Opaque handle to a virtual mesh uploaded to the scene.
@@ -50,7 +58,7 @@ impl DecodePosition for PackedVertex {
 // ─── Full meshopt optimization pipeline ───────────────────────────────────
 
 /// Run the full meshopt optimization pipeline on a mesh:
-/// 1. Weld duplicate vertices by position
+/// 1. Weld byte-identical vertices while preserving attribute seams
 /// 2. Vertex cache optimization (reorder tris for GPU transform cache)
 /// 3. Overdraw optimization (reorder tris to reduce pixel overdraw)
 /// 4. Vertex fetch optimization (reorder verts for memory locality)
@@ -59,8 +67,9 @@ fn optimize_mesh(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVerte
         return (vertices.to_vec(), indices.to_vec());
     }
 
-    // Step 1: Weld vertices that share the same position.
-    let (welded_verts, welded_indices) = weld_by_position(vertices, indices);
+    // Step 1: Weld only byte-identical vertices. Position-only welding corrupts
+    // hard normals, tangents, lightmap UVs, and texture seams.
+    let (welded_verts, welded_indices) = weld_exact_vertices(vertices, indices);
 
     // Step 2: Vertex cache optimization.
     let vcache_indices = meshopt::optimize_vertex_cache(&welded_indices, welded_verts.len());
@@ -84,66 +93,92 @@ fn optimize_mesh(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVerte
 /// LOD 0 is the fully optimized original mesh. Each successive level targets
 /// ~50% of the previous level's triangle count. The full meshopt pipeline
 /// (cache, overdraw, fetch optimization) is applied to every level.
-pub fn generate_lod_meshes(
+pub(crate) fn generate_lod_meshes(
     vertices: &[PackedVertex],
     indices: &[u32],
-) -> Vec<(Vec<PackedVertex>, Vec<u32>)> {
+) -> Vec<GeneratedLodMesh> {
+    if vertices.is_empty()
+        || indices.is_empty()
+        || indices.len() % 3 != 0
+        || indices
+            .iter()
+            .any(|&index| index as usize >= vertices.len())
+    {
+        return Vec::new();
+    }
+
     // Optimize the base mesh first.
     let (opt_verts, opt_indices) = optimize_mesh(vertices, indices);
     let base_tri_count = opt_indices.len() / 3;
 
-    let mut levels: Vec<(Vec<PackedVertex>, Vec<u32>)> = Vec::with_capacity(8);
-    levels.push((opt_verts.clone(), opt_indices.clone()));
+    let mut levels = Vec::with_capacity(8);
+    levels.push(GeneratedLodMesh {
+        vertices: opt_verts,
+        indices: opt_indices,
+        error: 0.0,
+    });
 
     eprintln!(
         "[vg] base: {} verts, {} tris (from {} verts, {} tris)",
-        opt_verts.len(), base_tri_count,
-        vertices.len(), indices.len() / 3,
+        levels[0].vertices.len(),
+        base_tri_count,
+        vertices.len(),
+        indices.len() / 3,
     );
 
-    let lod_params: [(f32, f32); 7] = [
-        (0.50,  0.05),
-        (0.25,  0.1),
-        (0.125, 0.2),
-        (0.06,  0.4),
-        (0.03,  0.7),
-        (0.015, 1.0),
-        (0.008, 2.0),
-    ];
-    for &(ratio, max_error) in &lod_params {
+    let lod_ratios = [0.50, 0.25, 0.125, 0.06, 0.03, 0.015, 0.008];
+    for &ratio in &lod_ratios {
         let target_indices = (((base_tri_count as f32 * ratio) as usize).max(1)) * 3;
+        let previous = levels.last().expect("base LOD exists");
 
-        // Simplify from the optimized base mesh for globally optimal results.
-        let simplified_indices = meshopt::simplify_decoder(
-            &opt_indices,
-            &opt_verts,
+        if previous.indices.len() <= target_indices {
+            levels.push(previous.clone());
+            continue;
+        }
+
+        let attributes = simplification_attributes(&previous.vertices);
+        let locks = vec![false; previous.vertices.len()];
+        let mut relative_error = 0.0;
+
+        // Build a progressive chain. Meshoptimizer recommends accumulating the
+        // measured error when each level starts from the previous one.
+        let simplified_indices = meshopt::simplify_with_attributes_and_locks_decoder(
+            &previous.indices,
+            &previous.vertices,
+            &attributes,
+            &[10.0, 10.0, 10.0, 10.0, 0.5, 0.5, 0.5, 0.25, 0.25, 0.25, 1.0],
+            11 * std::mem::size_of::<f32>(),
+            &locks,
             target_indices,
-            max_error,
+            f32::MAX,
             meshopt::SimplifyOptions::None,
-            None,
+            Some(&mut relative_error),
         );
 
         if simplified_indices.is_empty() {
-            let last = levels.last().unwrap().clone();
-            levels.push(last);
+            levels.push(previous.clone());
         } else {
-            // Compact, then run cache+overdraw+fetch optimization on the LOD.
+            let absolute_error = previous.error
+                + relative_error * meshopt::simplify_scale_decoder(&previous.vertices);
+
+            // Compact, then run the full cache/overdraw/fetch pipeline on the LOD.
             let (compact_verts, compact_indices) =
-                compact_mesh(&opt_verts, &simplified_indices);
-            let mut opt_idx = meshopt::optimize_vertex_cache(&compact_indices, compact_verts.len());
-            meshopt::optimize_overdraw_in_place_decoder(&mut opt_idx, &compact_verts, 1.05);
-            let remap = meshopt::optimize_vertex_fetch_remap(&opt_idx, compact_verts.len());
-            let final_indices = meshopt::remap_index_buffer(Some(&opt_idx), compact_verts.len(), &remap);
-            let final_verts = meshopt::remap_vertex_buffer(&compact_verts, compact_verts.len(), &remap);
+                compact_mesh(&previous.vertices, &simplified_indices);
+            let (final_verts, final_indices) = optimize_mesh(&compact_verts, &compact_indices);
 
             eprintln!(
-                "[vg] LOD {}: {}/{} tris (target {})",
+                "[vg] LOD {}: {}/{} tris (target {}, error {:.6})",
                 levels.len(),
                 final_indices.len() / 3,
                 base_tri_count,
                 target_indices / 3,
+                absolute_error,
             );
-            levels.push((final_verts, final_indices));
+            levels.push(GeneratedLodMesh {
+                vertices: final_verts,
+                indices: final_indices,
+                error: absolute_error,
+            });
         }
     }
 
@@ -157,25 +192,35 @@ pub fn generate_lod_meshes(
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
-/// Weld vertices that share the same position, merging duplicates.
-fn weld_by_position(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVertex>, Vec<u32>) {
+/// Weld byte-identical vertices without crossing any attribute discontinuity.
+fn weld_exact_vertices(
+    vertices: &[PackedVertex],
+    indices: &[u32],
+) -> (Vec<PackedVertex>, Vec<u32>) {
     use std::collections::HashMap;
 
-    fn pos_key(p: &[f32; 3]) -> (i64, i64, i64) {
-        (
-            (p[0] as f64 * 1_000_000.0).round() as i64,
-            (p[1] as f64 * 1_000_000.0).round() as i64,
-            (p[2] as f64 * 1_000_000.0).round() as i64,
-        )
+    fn vertex_key(v: &PackedVertex) -> [u32; 10] {
+        [
+            v.position[0].to_bits(),
+            v.position[1].to_bits(),
+            v.position[2].to_bits(),
+            v.bitangent_sign.to_bits(),
+            v.tex_coords0[0].to_bits(),
+            v.tex_coords0[1].to_bits(),
+            v.tex_coords1[0].to_bits(),
+            v.tex_coords1[1].to_bits(),
+            v.normal,
+            v.tangent,
+        ]
     }
 
-    let mut pos_to_new: HashMap<(i64, i64, i64), u32> = HashMap::new();
+    let mut vertex_to_new: HashMap<[u32; 10], u32> = HashMap::new();
     let mut remap = vec![0u32; vertices.len()];
     let mut welded_verts: Vec<PackedVertex> = Vec::new();
 
     for (old_idx, v) in vertices.iter().enumerate() {
-        let key = pos_key(&v.position);
-        let new_idx = *pos_to_new.entry(key).or_insert_with(|| {
+        let key = vertex_key(v);
+        let new_idx = *vertex_to_new.entry(key).or_insert_with(|| {
             let idx = welded_verts.len() as u32;
             welded_verts.push(*v);
             idx
@@ -183,11 +228,36 @@ fn weld_by_position(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVe
         remap[old_idx] = new_idx;
     }
 
-    let welded_indices: Vec<u32> = indices.iter().map(|&i| {
-        if (i as usize) < remap.len() { remap[i as usize] } else { 0 }
-    }).collect();
+    let welded_indices = indices.iter().map(|&i| remap[i as usize]).collect();
 
     (welded_verts, welded_indices)
+}
+
+fn simplification_attributes(vertices: &[PackedVertex]) -> Vec<f32> {
+    fn unpack_snorm3(packed: u32) -> [f32; 3] {
+        let component = |shift| ((packed >> shift) as u8 as i8) as f32 / 127.0;
+        [component(0), component(8), component(16)]
+    }
+
+    let mut attributes = Vec::with_capacity(vertices.len() * 11);
+    for vertex in vertices {
+        let normal = unpack_snorm3(vertex.normal);
+        let tangent = unpack_snorm3(vertex.tangent);
+        attributes.extend_from_slice(&[
+            vertex.tex_coords0[0],
+            vertex.tex_coords0[1],
+            vertex.tex_coords1[0],
+            vertex.tex_coords1[1],
+            normal[0],
+            normal[1],
+            normal[2],
+            tangent[0],
+            tangent[1],
+            tangent[2],
+            vertex.bitangent_sign,
+        ]);
+    }
+    attributes
 }
 
 /// Remove unreferenced vertices and remap indices.
@@ -225,7 +295,13 @@ pub fn meshletize_with_indices(
     mesh_first_vertex: u32,
 ) -> (Vec<GpuMeshletEntry>, Vec<u32>) {
     let tri_count = indices.len() / 3;
-    if tri_count == 0 || vertices.is_empty() {
+    if tri_count == 0
+        || vertices.is_empty()
+        || indices.len() % 3 != 0
+        || indices
+            .iter()
+            .any(|&index| index as usize >= vertices.len())
+    {
         return (Vec::new(), Vec::new());
     }
 
@@ -281,4 +357,108 @@ pub fn meshletize_with_indices(
     }
 
     (entries, flat_indices)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vertex(position: [f32; 3], uv: [f32; 2], normal: [f32; 3]) -> PackedVertex {
+        PackedVertex::from_components(position, normal, uv, [1.0, 0.0, 0.0], 1.0)
+    }
+
+    #[test]
+    fn exact_weld_preserves_uv_and_normal_seams() {
+        let a = vertex([0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 1.0, 0.0]);
+        let exact_duplicate = a;
+        let uv_seam = vertex([0.0, 0.0, 0.0], [1.0, 0.0], [0.0, 1.0, 0.0]);
+        let hard_normal = vertex([0.0, 0.0, 0.0], [0.0, 0.0], [1.0, 0.0, 0.0]);
+
+        let (welded, remapped) =
+            weld_exact_vertices(&[a, exact_duplicate, uv_seam, hard_normal], &[0, 1, 2, 3]);
+
+        assert_eq!(welded.len(), 3);
+        assert_eq!(remapped[0], remapped[1]);
+        assert_ne!(remapped[0], remapped[2]);
+        assert_ne!(remapped[0], remapped[3]);
+    }
+
+    #[test]
+    fn malformed_indices_are_rejected_before_meshoptimizer() {
+        let vertices = vec![
+            vertex([0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([1.0, 0.0, 0.0], [1.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([0.0, 1.0, 0.0], [0.0, 1.0], [0.0, 0.0, 1.0]),
+        ];
+
+        assert!(generate_lod_meshes(&vertices, &[0, 1]).is_empty());
+        assert!(generate_lod_meshes(&vertices, &[0, 1, 3]).is_empty());
+        assert!(meshletize_with_indices(&vertices, &[0, 1], 0, 0)
+            .0
+            .is_empty());
+        assert!(meshletize_with_indices(&vertices, &[0, 1, 3], 0, 0)
+            .0
+            .is_empty());
+    }
+
+    #[test]
+    fn meshlet_indices_and_bounds_cover_the_source_geometry() {
+        let vertices = vec![
+            vertex([0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([1.0, 0.0, 0.0], [1.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([1.0, 1.0, 0.0], [1.0, 1.0], [0.0, 0.0, 1.0]),
+            vertex([0.0, 1.0, 0.0], [0.0, 1.0], [0.0, 0.0, 1.0]),
+        ];
+        let source = vec![0, 1, 2, 0, 2, 3];
+        let (meshlets, flattened) = meshletize_with_indices(&vertices, &source, 0, 0);
+
+        assert_eq!(flattened.len(), source.len());
+        let mut flattened_sorted = flattened.clone();
+        let mut source_sorted = source.clone();
+        flattened_sorted.sort_unstable();
+        source_sorted.sort_unstable();
+        assert_eq!(flattened_sorted, source_sorted);
+
+        for meshlet in &meshlets {
+            let first = meshlet.first_index as usize;
+            let end = first + meshlet.index_count as usize;
+            for &index in &flattened[first..end] {
+                let p = glam::Vec3::from_array(vertices[index as usize].position);
+                let center = glam::Vec3::from_array(meshlet.center);
+                assert!(p.distance(center) <= meshlet.radius + 1e-5);
+            }
+        }
+    }
+
+    #[test]
+    fn generated_lod_errors_are_finite_and_monotonic() {
+        let side = 12usize;
+        let mut vertices = Vec::with_capacity(side * side);
+        for y in 0..side {
+            for x in 0..side {
+                vertices.push(vertex(
+                    [x as f32, y as f32, ((x * y) % 5) as f32 * 0.05],
+                    [x as f32 / side as f32, y as f32 / side as f32],
+                    [0.0, 0.0, 1.0],
+                ));
+            }
+        }
+        let mut indices = Vec::new();
+        for y in 0..side - 1 {
+            for x in 0..side - 1 {
+                let i = (y * side + x) as u32;
+                indices.extend_from_slice(&[i, i + 1, i + side as u32 + 1]);
+                indices.extend_from_slice(&[i, i + side as u32 + 1, i + side as u32]);
+            }
+        }
+
+        let lods = generate_lod_meshes(&vertices, &indices);
+        assert_eq!(lods.len(), 8);
+        assert_eq!(lods[0].error, 0.0);
+        for pair in lods.windows(2) {
+            assert!(pair[1].error.is_finite());
+            assert!(pair[1].error >= pair[0].error);
+            assert!(pair[1].indices.len() <= pair[0].indices.len());
+        }
+    }
 }

--- a/crates/helio/src/vg.rs
+++ b/crates/helio/src/vg.rs
@@ -100,6 +100,9 @@ pub(crate) fn generate_lod_meshes(
     if vertices.is_empty()
         || indices.is_empty()
         || indices.len() % 3 != 0
+        || vertices
+            .iter()
+            .any(|vertex| vertex.position.iter().any(|value| !value.is_finite()))
         || indices
             .iter()
             .any(|&index| index as usize >= vertices.len())
@@ -393,6 +396,9 @@ mod tests {
 
         assert!(generate_lod_meshes(&vertices, &[0, 1]).is_empty());
         assert!(generate_lod_meshes(&vertices, &[0, 1, 3]).is_empty());
+        let mut non_finite = vertices.clone();
+        non_finite[0].position[0] = f32::NAN;
+        assert!(generate_lod_meshes(&non_finite, &[0, 1, 2]).is_empty());
         assert!(meshletize_with_indices(&vertices, &[0, 1], 0, 0)
             .0
             .is_empty());

--- a/crates/helio/src/vg.rs
+++ b/crates/helio/src/vg.rs
@@ -88,11 +88,13 @@ fn optimize_mesh(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVerte
 
 // ─── LOD generation ───────────────────────────────────────────────────────
 
-/// Generate exactly 8 LOD levels using meshoptimizer's simplifier.
+/// Generate up to 8 distinct LOD levels using meshoptimizer's simplifier.
 ///
 /// LOD 0 is the fully optimized original mesh. Each successive level targets
-/// ~50% of the previous level's triangle count. The full meshopt pipeline
-/// (cache, overdraw, fetch optimization) is applied to every level.
+/// a smaller fraction of the original triangle count. The chain stops rather
+/// than padding with mislabeled clones when an asset cannot be simplified any
+/// further. The full meshopt pipeline (cache, overdraw, fetch optimization) is
+/// applied to every retained level.
 pub(crate) fn generate_lod_meshes(
     vertices: &[PackedVertex],
     indices: &[u32],
@@ -135,7 +137,6 @@ pub(crate) fn generate_lod_meshes(
         let previous = levels.last().expect("base LOD exists");
 
         if previous.indices.len() <= target_indices {
-            levels.push(previous.clone());
             continue;
         }
 
@@ -158,9 +159,7 @@ pub(crate) fn generate_lod_meshes(
             Some(&mut relative_error),
         );
 
-        if simplified_indices.is_empty() {
-            levels.push(previous.clone());
-        } else {
+        if !simplified_indices.is_empty() && simplified_indices.len() < previous.indices.len() {
             let absolute_error = previous.error
                 + relative_error * meshopt::simplify_scale_decoder(&previous.vertices);
 
@@ -168,6 +167,10 @@ pub(crate) fn generate_lod_meshes(
             let (compact_verts, compact_indices) =
                 compact_mesh(&previous.vertices, &simplified_indices);
             let (final_verts, final_indices) = optimize_mesh(&compact_verts, &compact_indices);
+
+            if final_indices.len() >= previous.indices.len() {
+                continue;
+            }
 
             eprintln!(
                 "[vg] LOD {}: {}/{} tris (target {}, error {:.6})",
@@ -183,11 +186,6 @@ pub(crate) fn generate_lod_meshes(
                 error: absolute_error,
             });
         }
-    }
-
-    while levels.len() < 8 {
-        let last = levels.last().unwrap().clone();
-        levels.push(last);
     }
 
     levels
@@ -459,12 +457,25 @@ mod tests {
         }
 
         let lods = generate_lod_meshes(&vertices, &indices);
-        assert_eq!(lods.len(), 8);
+        assert!((2..=8).contains(&lods.len()));
         assert_eq!(lods[0].error, 0.0);
         for pair in lods.windows(2) {
             assert!(pair[1].error.is_finite());
             assert!(pair[1].error >= pair[0].error);
-            assert!(pair[1].indices.len() <= pair[0].indices.len());
+            assert!(pair[1].indices.len() < pair[0].indices.len());
         }
+    }
+
+    #[test]
+    fn irreducible_triangle_is_not_padded_with_fake_lods() {
+        let vertices = vec![
+            vertex([0.0, 0.0, 0.0], [0.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([1.0, 0.0, 0.0], [1.0, 0.0], [0.0, 0.0, 1.0]),
+            vertex([0.0, 1.0, 0.0], [0.0, 1.0], [0.0, 0.0, 1.0]),
+        ];
+
+        let lods = generate_lod_meshes(&vertices, &[0, 1, 2]);
+        assert_eq!(lods.len(), 1);
+        assert_eq!(lods[0].indices.len(), 3);
     }
 }

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -494,10 +494,14 @@ pub struct VgFrameData<'a> {
     pub objects: &'a [u8],
     /// Raw bytes of a `GpuInstanceData` array (one entry per VG object).
     pub instances: &'a [u8],
+    /// Raw bytes of immutable `GpuVgWorkItem` expansion records.
+    pub work_items: &'a [u8],
     /// Number of unique meshlet descriptors across all referenced virtual meshes.
     pub meshlet_count: u32,
     /// Number of VG objects (and corresponding instance entries).
     pub object_count: u32,
+    /// Number of second-stage 64-meshlet work spans.
+    pub work_item_count: u32,
     /// Exact worst-case number of indirect draws after selecting one LOD per object.
     pub max_draw_count: u32,
     /// Version counter incremented each time meshlet or instance data changes.

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -482,10 +482,11 @@ impl<'a> FrameResources<'a> {
     }
 }
 
-/// Per-frame virtual geometry data: immutable mesh, object, and instance slices.
+/// Per-frame virtual geometry data: immutable mesh/object slices and dirty-tracked instances.
 ///
 /// The `VirtualGeometryPass` uploads these slices to its owned GPU buffers on the
-/// first frame and whenever `buffer_version` advances (topology or transform change).
+/// first frame and whenever `buffer_version` advances. Transform-only changes
+/// advance `instance_version` and upload only `instance_dirty_start..+count`.
 #[derive(Clone, Copy)]
 pub struct VgFrameData<'a> {
     /// Raw bytes of a `GpuMeshletEntry` array.
@@ -504,8 +505,13 @@ pub struct VgFrameData<'a> {
     pub work_item_count: u32,
     /// Exact worst-case number of indirect draws after selecting one LOD per object.
     pub max_draw_count: u32,
-    /// Version counter incremented each time meshlet or instance data changes.
-    /// The pass re-uploads GPU buffers only when this advances.
+    /// Version counter incremented when meshlet, object, or work-item topology changes.
     pub buffer_version: u64,
+    /// Version counter incremented when a transform-only dirty range is published.
+    pub instance_version: u64,
+    /// First dirty instance in the current transform-only publication.
+    pub instance_dirty_start: u32,
+    /// Number of dirty instances; zero when `buffer_version` owns the update.
+    pub instance_dirty_count: u32,
 }
 

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -482,7 +482,7 @@ impl<'a> FrameResources<'a> {
     }
 }
 
-/// Per-frame virtual geometry data: CPU-side meshlet and instance byte slices.
+/// Per-frame virtual geometry data: immutable mesh, object, and instance slices.
 ///
 /// The `VirtualGeometryPass` uploads these slices to its owned GPU buffers on the
 /// first frame and whenever `buffer_version` advances (topology or transform change).
@@ -490,12 +490,16 @@ impl<'a> FrameResources<'a> {
 pub struct VgFrameData<'a> {
     /// Raw bytes of a `GpuMeshletEntry` array.
     pub meshlets: &'a [u8],
+    /// Raw bytes of a `GpuVgObject` array (one entry per VG object).
+    pub objects: &'a [u8],
     /// Raw bytes of a `GpuInstanceData` array (one entry per VG object).
     pub instances: &'a [u8],
-    /// Total number of meshlets across all VG objects.
+    /// Number of unique meshlet descriptors across all referenced virtual meshes.
     pub meshlet_count: u32,
-    /// Number of VG object instances.
-    pub instance_count: u32,
+    /// Number of VG objects (and corresponding instance entries).
+    pub object_count: u32,
+    /// Exact worst-case number of indirect draws after selecting one LOD per object.
+    pub max_draw_count: u32,
     /// Version counter incremented each time meshlet or instance data changes.
     /// The pass re-uploads GPU buffers only when this advances.
     pub buffer_version: u64,

--- a/crates/libhelio/src/meshlet.rs
+++ b/crates/libhelio/src/meshlet.rs
@@ -13,10 +13,14 @@ use bytemuck::{Pod, Zeroable};
 /// draw commands on less-detailed geometry.
 pub const MESHLET_MAX_TRIANGLES: u32 = 64;
 
+/// Number of progressive LOD levels stored for every virtual mesh.
+pub const VG_LOD_LEVELS: usize = 8;
+
 /// GPU-side descriptor for a single meshlet (a small cluster of triangles). Exactly 64 bytes.
 ///
-/// Stored in a tightly-packed storage buffer and indexed by `global_invocation_id` inside
-/// the virtual-geometry culling compute shader.
+/// Stored once per virtual mesh in a tightly-packed storage buffer. Virtual
+/// objects refer to contiguous per-LOD ranges in this immutable descriptor
+/// array, so instances never duplicate meshlet metadata.
 ///
 /// # Layout (64 bytes, 16-byte aligned)
 /// ```text
@@ -25,11 +29,11 @@ pub const MESHLET_MAX_TRIANGLES: u32 = 64;
 /// 16..28   cone_apex:       vec3<f32>  backface cone apex (mesh local space)
 /// 28..32   cone_cutoff:     f32        cos(half-angle); > 1.0 = disable cone cull
 /// 32..44   cone_axis:       vec3<f32>  normalised backface cone axis (mesh local)
-/// 44..48   lod_error:       f32        reserved for future hierarchical LOD
+/// 44..48   lod_error:       f32        accumulated object-space simplification error
 /// 48..52   first_index:     u32        absolute offset into the global index buffer
 /// 52..56   index_count:     u32        number of indices (triangles × 3, ≤ 64 × 3)
 /// 56..60   vertex_offset:   i32        base_vertex added to every index by the GPU
-/// 60..64   instance_index:  u32        slot in the VG instance buffer for this object
+/// 60..64   instance_index:  u32        reserved; object ownership is stored separately
 /// ```
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
@@ -48,7 +52,7 @@ pub struct GpuMeshletEntry {
 
     /// Normalised backface cone axis in mesh-local space.
     pub cone_axis: [f32; 3],
-    /// Reserved: screen-space error metric for future hierarchical LOD selection.
+    /// Accumulated object-space simplification error for this meshlet's LOD.
     pub lod_error: f32,
 
     /// Absolute byte-index offset into the global index mega-buffer
@@ -59,9 +63,51 @@ pub struct GpuMeshletEntry {
     /// Base vertex added by the GPU to every index value when drawing.
     /// Equals the mesh's `first_vertex` in the global vertex mega-buffer.
     pub vertex_offset: i32,
-    /// Slot in the per-frame VG instance buffer (`GpuInstanceData` array) that
-    /// provides the world transform, material ID, etc. for this meshlet's owning object.
+    /// Reserved for ABI stability. Object ownership is supplied by
+    /// [`GpuVgObject`] so descriptors can be shared by every instance.
     pub instance_index: u32,
+}
+
+/// GPU-side descriptor for one virtual-geometry object. Exactly 128 bytes.
+///
+/// One compute workgroup owns one object. Lane zero performs conservative
+/// object culling and selects a single LOD from the measured simplification
+/// errors; all lanes then cull only that LOD's immutable meshlet range.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+pub struct GpuVgObject {
+    /// Slot in the VG `GpuInstanceData` and `InstanceCullData` arrays.
+    pub instance_index: u32,
+    /// Number of valid entries in the LOD arrays (zero for invalid geometry).
+    pub lod_count: u32,
+    /// Largest meshlet count among the object's LODs. This object's exact
+    /// contribution to the worst-case indirect draw capacity.
+    pub max_meshlet_count: u32,
+    /// Reserved for future object flags.
+    pub reserved: u32,
+
+    /// Conservative mesh-local bounding sphere `[center.xyz, radius]`.
+    pub local_bounds: [f32; 4],
+    /// Accumulated object-space simplification error for each LOD.
+    pub lod_errors: [f32; VG_LOD_LEVELS],
+    /// First descriptor in the shared meshlet buffer for each LOD.
+    pub lod_first_meshlets: [u32; VG_LOD_LEVELS],
+    /// Number of descriptors in each LOD range.
+    pub lod_meshlet_counts: [u32; VG_LOD_LEVELS],
+}
+
+/// Per-visible-draw metadata emitted beside each indirect command. Exactly 16 bytes.
+///
+/// `DrawIndexedIndirect::first_instance` indexes this array. The draw shader
+/// follows `instance_index` to the transform/material array and uses the stable
+/// meshlet and LOD identifiers for truthful debug visualisations.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+pub struct GpuVgDraw {
+    pub instance_index: u32,
+    pub meshlet_index: u32,
+    pub lod_level: u32,
+    pub reserved: u32,
 }
 
 const _: () = {
@@ -69,5 +115,27 @@ const _: () = {
         std::mem::size_of::<GpuMeshletEntry>() == 64,
         "GpuMeshletEntry must be exactly 64 bytes"
     );
+    assert!(
+        std::mem::size_of::<GpuVgObject>() == 128,
+        "GpuVgObject must be exactly 128 bytes"
+    );
+    assert!(
+        std::mem::size_of::<GpuVgDraw>() == 16,
+        "GpuVgDraw must be exactly 16 bytes"
+    );
 };
+
+#[cfg(test)]
+mod tests {
+    use super::{GpuMeshletEntry, GpuVgDraw, GpuVgObject, VG_LOD_LEVELS};
+
+    #[test]
+    fn gpu_virtual_geometry_layouts_are_stable() {
+        assert_eq!(VG_LOD_LEVELS, 8);
+        assert_eq!(std::mem::size_of::<GpuMeshletEntry>(), 64);
+        assert_eq!(std::mem::size_of::<GpuVgObject>(), 128);
+        assert_eq!(std::mem::size_of::<GpuVgDraw>(), 16);
+        assert_eq!(std::mem::align_of::<GpuVgObject>(), 4);
+    }
+}
 

--- a/crates/libhelio/src/meshlet.rs
+++ b/crates/libhelio/src/meshlet.rs
@@ -16,6 +16,9 @@ pub const MESHLET_MAX_TRIANGLES: u32 = 64;
 /// Number of progressive LOD levels stored for every virtual mesh.
 pub const VG_LOD_LEVELS: usize = 8;
 
+/// Number of meshlets processed cooperatively by one VG cull workgroup.
+pub const VG_CULL_MESHLETS_PER_WORK_ITEM: u32 = 64;
+
 /// GPU-side descriptor for a single meshlet (a small cluster of triangles). Exactly 64 bytes.
 ///
 /// Stored once per virtual mesh in a tightly-packed storage buffer. Virtual
@@ -70,9 +73,9 @@ pub struct GpuMeshletEntry {
 
 /// GPU-side descriptor for one virtual-geometry object. Exactly 128 bytes.
 ///
-/// One compute workgroup owns one object. Lane zero performs conservative
-/// object culling and selects a single LOD from the measured simplification
-/// errors; all lanes then cull only that LOD's immutable meshlet range.
+/// The first compute stage assigns one lane to each object for conservative
+/// object culling and a single measured-error LOD decision. The second stage
+/// expands that selected LOD across immutable [`GpuVgWorkItem`] spans.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct GpuVgObject {
@@ -83,7 +86,9 @@ pub struct GpuVgObject {
     /// Largest meshlet count among the object's LODs. This object's exact
     /// contribution to the worst-case indirect draw capacity.
     pub max_meshlet_count: u32,
-    /// Reserved for future object flags.
+    /// Per-frame GPU scratch containing selected LOD + 1; zero means culled.
+    /// CPU publishers must initialize this to zero. The object-selection stage
+    /// overwrites it before any meshlet span reads it.
     pub reserved: u32,
 
     /// Conservative mesh-local bounding sphere `[center.xyz, radius]`.
@@ -110,6 +115,19 @@ pub struct GpuVgDraw {
     pub reserved: u32,
 }
 
+/// Immutable expansion record for the second-stage meshlet cull. Exactly 8 bytes.
+///
+/// Records are built once with the object layout. Each record covers up to 64
+/// meshlets from whichever whole-object LOD the first GPU stage selects. Using
+/// fixed spans keeps work bounded while allowing a very large object to occupy
+/// many GPU workgroups instead of serialising through one workgroup.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+pub struct GpuVgWorkItem {
+    pub object_index: u32,
+    pub local_meshlet_base: u32,
+}
+
 const _: () = {
     assert!(
         std::mem::size_of::<GpuMeshletEntry>() == 64,
@@ -123,11 +141,18 @@ const _: () = {
         std::mem::size_of::<GpuVgDraw>() == 16,
         "GpuVgDraw must be exactly 16 bytes"
     );
+    assert!(
+        std::mem::size_of::<GpuVgWorkItem>() == 8,
+        "GpuVgWorkItem must be exactly 8 bytes"
+    );
 };
 
 #[cfg(test)]
 mod tests {
-    use super::{GpuMeshletEntry, GpuVgDraw, GpuVgObject, VG_LOD_LEVELS};
+    use super::{
+        GpuMeshletEntry, GpuVgDraw, GpuVgObject, GpuVgWorkItem,
+        VG_CULL_MESHLETS_PER_WORK_ITEM, VG_LOD_LEVELS,
+    };
 
     #[test]
     fn gpu_virtual_geometry_layouts_are_stable() {
@@ -135,7 +160,9 @@ mod tests {
         assert_eq!(std::mem::size_of::<GpuMeshletEntry>(), 64);
         assert_eq!(std::mem::size_of::<GpuVgObject>(), 128);
         assert_eq!(std::mem::size_of::<GpuVgDraw>(), 16);
+        assert_eq!(std::mem::size_of::<GpuVgWorkItem>(), 8);
         assert_eq!(std::mem::align_of::<GpuVgObject>(), 4);
+        assert_eq!(VG_CULL_MESHLETS_PER_WORK_ITEM, 64);
     }
 }
 


### PR DESCRIPTION
## Current work

- preserve full vertex identity during welding so UV, normal, tangent, and lightmap seams survive meshlet construction
- reject malformed and non-finite topology before meshoptimizer FFI
- build a progressive attribute-aware LOD chain with measured monotonic object-space error
- deduplicate meshlet descriptors across instances and publish one object descriptor per instance
- select one measured-error LOD per object, then cull the selected range through immutable 64-meshlet work spans
- split scheduling into an object-selection pass (one lane per object) and a meshlet-cull pass (one lane per meshlet)
- bound indirect publication and draw metadata by the exact worst-case selected-LOD meshlet count
- preserve the indirect draw-count ABI at byte 0 and count rejected publications at byte 4
- carry stable meshlet and LOD metadata into draws without relying on non-portable draw-index shader features
- make mode 20 one solid color per real meshlet and mode 21 one flat color per object LOD with an automatic legend
- propagate F3/F4 debug-mode changes into already-created render graph passes
- retain conservative cone, projected-sphere, and Hi-Z culling behavior
- upload transform-only VG changes as bounded instance ranges with reusable culling scratch
- require `INDIRECT_FIRST_INSTANCE` at the renderer boundary after auditing Helio and Pulsar callers
- benchmark culling occupancy, indirect draw amplification, overflow behavior, and explicit scheduling/publication memory
- enforce a configurable publication ceiling, defaulting to 262,144 meshlets / 9 MiB of indirect commands and draw metadata

## Scheduling basis

The two-stage shape follows NVIDIA's [Using Mesh Shaders for Professional Graphics](https://developer.nvidia.com/blog/using-mesh-shaders-for-professional-graphics/) and [Introduction to Turing Mesh Shaders](https://developer.nvidia.com/blog/introduction-turing-mesh-shaders/): parallelize cluster decisions across lanes, batch enough independent work to occupy the GPU, and use a dedicated compute pass when task work becomes substantial. AMD's [Mesh Shader Optimization and Best Practices](https://gpuopen.com/learn/mesh_shaders/mesh_shaders-optimization_and_best_practices/) similarly separates per-instance LOD selection from per-meshlet culling. Helio maps that structure to portable WebGPU compute plus indexed indirect draws rather than requiring hardware mesh shaders.

NVIDIA also notes that hardware mesh shading replaces instancing/multi-draw-indirect for small meshes. Helio cannot assume hardware mesh shaders through portable WebGPU, so this PR measures the indexed-indirect front-end cost directly and treats visible draw count as a bounded resource.

## Verification

- `cargo test -p libhelio --lib` (3 passed)
- `cargo test -p helio --lib` (17 passed, including required-feature and transform-only publication tests)
- `cargo test -p helio-pass-virtual-geometry --lib --tests` (9 + 23 + 21 passed)
- `cargo build --release -p examples --bin meshlet_cull_benchmark --bin editor_demo_mini --bin voxel_demo --bin voxel_demo_raymarch`
- release `editor_demo_mini`, `voxel_demo`, and `voxel_demo_raymarch` each initialized and remained alive through a six-second smoke window
- visual runtime check confirmed contiguous solid-color meshlet clusters and a flat object-level LOD heatmap
- `cargo run --release -p examples --bin meshlet_cull_benchmark` (all normal cases zero overflow; forced capacity-minus-17 probe reports exactly 17 rejected writes)
- `HELIO_BENCH_BACKEND=dx12` forced a native D3D12 run of the same compute, indirect draw, memory, and overflow gates
- `git diff --check`

## Occupancy gate: one-stage rejected, two-stage passes

RTX 3060 / Vulkan, 1,048,576 visible meshlets, 5 warmups + 20 samples. The one-stage values are the rejected baseline; current two-stage values are from commit `2cbe4bf`.

| Shape | One-stage median | Two-stage median | Two-stage P95 |
|---|---:|---:|---:|
| 1 object x 1,048,576 meshlets | 21.2275 ms | 0.2232 ms | 0.2263 ms |
| 16 objects x 65,536 meshlets | 1.3107 ms | 0.2150 ms | 0.2161 ms |
| 4,096 objects x 256 meshlets | 0.1608 ms | 0.1915 ms | 0.1956 ms |
| 65,536 objects x 16 meshlets | 0.5683 ms | 0.5765 ms | 0.5857 ms |

The rejected path varied by 132x across equal-work shapes. The current two-stage path reduces that to 3.01x and improves the pathological single-object case by about 95x while publishing the exact expected count.

A forced D3D12 run also completed every gate. With 2 warmups + 5 samples, its equal-work medians were 0.3215, 0.3236, 0.2529, and 0.6246 ms; the forced overflow probe again rejected exactly 17 writes.

## Portable indexed-indirect front-end gate

This is intentionally a pre-rasterization comparison: the same triangle invocation count is submitted offscreen, meshlets use N one-triangle indirect draws, and the best-case conventional path uses one indexed instanced draw. It does not claim equivalent full material/raster cost.

RTX 3060 / Vulkan, 10 render samples:

| Triangles / meshlet draws | Meshlet indirect | One indexed draw | Added front-end cost |
|---:|---:|---:|---:|
| 1,024 | 0.0051 ms | 0.0041 ms | 0.0010 ms |
| 16,384 | 0.0522 ms | 0.0123 ms | 0.0399 ms |
| 65,536 | 0.2017 ms | 0.0430 ms | 0.1587 ms |
| 262,144 | 0.8018 ms | 0.1679 ms | 0.6339 ms |
| 1,048,576 | 3.2031 ms | 0.6636 ms | 2.5395 ms |

The amplification is negligible at small visible counts but becomes a real linear budget at planet scale. This is not an automatic rejection of portable meshlets; it requires view-driven LOD and a hard visible-publication cap.

## Scheduling/publication memory probe

The synthetic cases share one unique mesh per shape and reserve exact worst-case output capacity for 1,048,576 visible draws. These figures isolate scheduling/publication storage; they are not complete scene-memory comparisons.

| Shape | VG scheduling/publication total | Conventional object/draw records |
|---|---:|---:|
| single huge | 104,988,968 B | 164 B |
| few huge | 42,078,728 B | 2,624 B |
| balanced | 39,075,848 B | 671,744 B |
| many small | 57,148,424 B | 10,747,904 B |

The uncapped one-million-draw probe reserves 37,748,744 bytes (20-byte indirect command + 16-byte draw metadata per slot, plus counters). Commit `281b0f3` makes publication a first-class `VirtualGeometryBudget`: the default graph is capped at 262,144 meshlets / 9 MiB plus counters, custom graphs can choose a measured platform limit, growth never exceeds it, and excess visible publications are counted and rejected. Planetary residency must select a tighter target as needed rather than size from total planet content.

## Still required before ready

- rerun interactive visual checks on the final candidate across supported backends

Tracks #52

