### PR TITLE
Fix editor resize distortion and stale input capture

### DIFF
--- a/crates/examples/editor_demo.rs
+++ b/crates/examples/editor_demo.rs
@@ -80,6 +80,7 @@ struct AppState {
     cam_pitch: f32,
     keys: HashSet<KeyCode>,
     right_mouse_held: bool,
+    left_mouse_held: bool,
     mouse_delta: (f32, f32),
     cursor_pos: (f32, f32),
     cam_speed: f32,
@@ -577,6 +578,7 @@ impl ApplicationHandler for App {
             cam_pitch: -0.38,
             keys: HashSet::new(),
             right_mouse_held: false,
+            left_mouse_held: false,
             mouse_delta: (0.0, 0.0),
             cursor_pos: (640.0, 360.0),
             cam_speed: 18.0,
@@ -604,14 +606,17 @@ impl ApplicationHandler for App {
 
             WindowEvent::Focused(false) => state.reset_transient_input(),
             WindowEvent::Focused(true) => state.last_frame = std::time::Instant::now(),
+            WindowEvent::CursorLeft { .. } => state.reset_transient_input(),
 
             WindowEvent::CursorMoved { position, .. } => {
                 state.cursor_pos = (position.x as f32, position.y as f32);
                     if !state.right_mouse_held {
                         let (ray_o, ray_d) = state.build_ray();
                         state.editor.update_hover(ray_o, ray_d, &state.renderer);
-                        if state.editor.is_dragging() {
+                        if state.left_mouse_held && state.editor.is_dragging() {
                             state.editor.update_drag(ray_o, ray_d, &mut state.renderer);
+                        } else if state.editor.is_dragging() {
+                            state.editor.end_drag();
                         }
                     }
             }
@@ -705,6 +710,7 @@ impl ApplicationHandler for App {
                 button: MouseButton::Right,
                 ..
             } => {
+                state.left_mouse_held = true;
                 if !state.right_mouse_held {
                     let _ = state
                         .window
@@ -750,6 +756,7 @@ impl ApplicationHandler for App {
                 button: MouseButton::Left,
                 ..
             } => {
+                state.left_mouse_held = false;
                 state.editor.end_drag();
             }
 
@@ -808,6 +815,7 @@ impl AppState {
         self.keys.clear();
         self.mouse_delta = (0.0, 0.0);
         self.right_mouse_held = false;
+        self.left_mouse_held = false;
         self.editor.end_drag();
         let _ = self.window.set_cursor_grab(CursorGrabMode::None);
         self.window.set_cursor_visible(true);

--- a/crates/examples/editor_demo.rs
+++ b/crates/examples/editor_demo.rs
@@ -70,6 +70,7 @@ struct AppState {
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
     surface_format: wgpu::TextureFormat,
+    surface_alpha_mode: wgpu::CompositeAlphaMode,
     renderer: Renderer,
     last_frame: std::time::Instant,
 
@@ -143,6 +144,7 @@ impl ApplicationHandler for App {
             .copied()
             .find(|f| f.is_srgb())
             .unwrap_or(caps.formats[0]);
+        let alpha_mode = caps.alpha_modes[0];
         let sz = window.inner_size();
         surface.configure(
             &device,
@@ -152,7 +154,7 @@ impl ApplicationHandler for App {
                 width: sz.width,
                 height: sz.height,
                 present_mode: wgpu::PresentMode::AutoVsync,
-                alpha_mode: caps.alpha_modes[0],
+                alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
             },
@@ -566,6 +568,7 @@ impl ApplicationHandler for App {
             surface,
             device,
             surface_format: format,
+            surface_alpha_mode: alpha_mode,
             renderer,
             last_frame: std::time::Instant::now(),
             // Start back and high for a wide overview of the full expanded yard
@@ -597,22 +600,10 @@ impl ApplicationHandler for App {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
 
-            WindowEvent::Resized(sz) if sz.width > 0 && sz.height > 0 => {
-                state.surface.configure(
-                    &state.device,
-                    &wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: state.surface_format,
-                        width: sz.width,
-                        height: sz.height,
-                        present_mode: wgpu::PresentMode::AutoVsync,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![],
-                        desired_maximum_frame_latency: 2,
-                    },
-                );
-                state.renderer.set_render_size(sz.width, sz.height);
-            }
+            WindowEvent::Resized(sz) => state.resize(sz.width, sz.height),
+
+            WindowEvent::Focused(false) => state.reset_transient_input(),
+            WindowEvent::Focused(true) => state.last_frame = std::time::Instant::now(),
 
             WindowEvent::CursorMoved { position, .. } => {
                 state.cursor_pos = (position.x as f32, position.y as f32);
@@ -775,7 +766,7 @@ impl ApplicationHandler for App {
 
             WindowEvent::RedrawRequested => {
                 let now = std::time::Instant::now();
-                let dt = (now - state.last_frame).as_secs_f32();
+                let dt = (now - state.last_frame).as_secs_f32().min(0.1);
                 state.last_frame = now;
                 state.update_camera(dt);
                 state.render();
@@ -813,6 +804,41 @@ impl ApplicationHandler for App {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl AppState {
+    fn reset_transient_input(&mut self) {
+        self.keys.clear();
+        self.mouse_delta = (0.0, 0.0);
+        self.right_mouse_held = false;
+        self.editor.end_drag();
+        let _ = self.window.set_cursor_grab(CursorGrabMode::None);
+        self.window.set_cursor_visible(true);
+        self.last_frame = std::time::Instant::now();
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        // Native resize loops can swallow mouse/key release events. Cancel any
+        // capture before rebuilding size-dependent render targets so camera and
+        // gizmo input cannot remain latched after the resize completes.
+        self.reset_transient_input();
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        self.surface.configure(
+            &self.device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: self.surface_format,
+                width,
+                height,
+                present_mode: wgpu::PresentMode::AutoVsync,
+                alpha_mode: self.surface_alpha_mode,
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            },
+        );
+        self.renderer.set_render_size(width, height);
+    }
+
     fn build_ray(&self) -> (glam::Vec3, glam::Vec3) {
         let sz     = self.window.inner_size();
         let width  = sz.width as f32;

--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -70,6 +70,7 @@ struct AppState {
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
     surface_format: wgpu::TextureFormat,
+    surface_alpha_mode: wgpu::CompositeAlphaMode,
     renderer: Renderer,
     last_frame: std::time::Instant,
 
@@ -142,6 +143,7 @@ impl ApplicationHandler for App {
             .copied()
             .find(|f| f.is_srgb())
             .unwrap_or(caps.formats[0]);
+        let alpha_mode = caps.alpha_modes[0];
         let sz = window.inner_size();
         surface.configure(
             &device,
@@ -151,7 +153,7 @@ impl ApplicationHandler for App {
                 width: sz.width,
                 height: sz.height,
                 present_mode: wgpu::PresentMode::AutoVsync,
-                alpha_mode: caps.alpha_modes[0],
+                alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
             },
@@ -761,6 +763,7 @@ impl ApplicationHandler for App {
             surface,
             device,
             surface_format: format,
+            surface_alpha_mode: alpha_mode,
             renderer,
             last_frame: std::time::Instant::now(),
             // Start back and high for a wide overview of the full expanded yard
@@ -787,22 +790,10 @@ impl ApplicationHandler for App {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
 
-            WindowEvent::Resized(sz) if sz.width > 0 && sz.height > 0 => {
-                state.surface.configure(
-                    &state.device,
-                    &wgpu::SurfaceConfiguration {
-                        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                        format: state.surface_format,
-                        width: sz.width,
-                        height: sz.height,
-                        present_mode: wgpu::PresentMode::AutoVsync,
-                        alpha_mode: wgpu::CompositeAlphaMode::Auto,
-                        view_formats: vec![],
-                        desired_maximum_frame_latency: 2,
-                    },
-                );
-                state.renderer.set_render_size(sz.width, sz.height);
-            }
+            WindowEvent::Resized(sz) => state.resize(sz.width, sz.height),
+
+            WindowEvent::Focused(false) => state.reset_transient_input(),
+            WindowEvent::Focused(true) => state.last_frame = std::time::Instant::now(),
 
             WindowEvent::CursorMoved { position, .. } => {
                 state.cursor_pos = (position.x as f32, position.y as f32);
@@ -998,7 +989,7 @@ impl ApplicationHandler for App {
 
             WindowEvent::RedrawRequested => {
                 let now = std::time::Instant::now();
-                let dt = (now - state.last_frame).as_secs_f32();
+                let dt = (now - state.last_frame).as_secs_f32().min(0.1);
                 state.last_frame = now;
                 state.update_camera(dt);
                 state.render();
@@ -1031,6 +1022,41 @@ impl ApplicationHandler for App {
 // ─────────────────────────────────────────────────────────────────────────────
 
 impl AppState {
+    fn reset_transient_input(&mut self) {
+        self.keys.clear();
+        self.mouse_delta = (0.0, 0.0);
+        self.right_mouse_held = false;
+        self.editor.end_drag();
+        let _ = self.window.set_cursor_grab(CursorGrabMode::None);
+        self.window.set_cursor_visible(true);
+        self.last_frame = std::time::Instant::now();
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        // Native resize loops can swallow mouse/key release events. Cancel any
+        // capture before rebuilding size-dependent render targets so camera and
+        // gizmo input cannot remain latched after the resize completes.
+        self.reset_transient_input();
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        self.surface.configure(
+            &self.device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: self.surface_format,
+                width,
+                height,
+                present_mode: wgpu::PresentMode::AutoVsync,
+                alpha_mode: self.surface_alpha_mode,
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            },
+        );
+        self.renderer.set_render_size(width, height);
+    }
+
     fn build_ray(&self) -> (glam::Vec3, glam::Vec3) {
         let sz = self.window.inner_size();
         let width = sz.width as f32;

--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -80,6 +80,7 @@ struct AppState {
     cam_pitch: f32,
     keys: HashSet<KeyCode>,
     right_mouse_held: bool,
+    left_mouse_held: bool,
     mouse_delta: (f32, f32),
     cursor_pos: (f32, f32),
     cam_speed: f32,
@@ -772,6 +773,7 @@ impl ApplicationHandler for App {
             cam_pitch: -0.38,
             keys: HashSet::new(),
             right_mouse_held: false,
+            left_mouse_held: false,
             mouse_delta: (0.0, 0.0),
             cursor_pos: (640.0, 360.0),
             cam_speed: 18.0,
@@ -794,6 +796,7 @@ impl ApplicationHandler for App {
 
             WindowEvent::Focused(false) => state.reset_transient_input(),
             WindowEvent::Focused(true) => state.last_frame = std::time::Instant::now(),
+            WindowEvent::CursorLeft { .. } => state.reset_transient_input(),
 
             WindowEvent::CursorMoved { position, .. } => {
                 state.cursor_pos = (position.x as f32, position.y as f32);
@@ -802,10 +805,12 @@ impl ApplicationHandler for App {
                     state
                         .editor
                         .update_hover(ray_o, ray_d, &state.renderer);
-                    if state.editor.is_dragging() {
+                    if state.left_mouse_held && state.editor.is_dragging() {
                         state
                             .editor
                             .update_drag(ray_o, ray_d, &mut state.renderer);
+                    } else if state.editor.is_dragging() {
+                        state.editor.end_drag();
                     }
                 }
             }
@@ -926,6 +931,7 @@ impl ApplicationHandler for App {
                 button: MouseButton::Right,
                 ..
             } => {
+                state.left_mouse_held = true;
                 if !state.right_mouse_held {
                     let _ = state
                         .window
@@ -974,6 +980,7 @@ impl ApplicationHandler for App {
                 button: MouseButton::Left,
                 ..
             } => {
+                state.left_mouse_held = false;
                 state.editor.end_drag();
             }
 
@@ -1026,6 +1033,7 @@ impl AppState {
         self.keys.clear();
         self.mouse_delta = (0.0, 0.0);
         self.right_mouse_held = false;
+        self.left_mouse_held = false;
         self.editor.end_drag();
         let _ = self.window.set_cursor_grab(CursorGrabMode::None);
         self.window.set_cursor_visible(true);

--- a/crates/helio-default-graphs/src/lib.rs
+++ b/crates/helio-default-graphs/src/lib.rs
@@ -477,6 +477,7 @@ fn build_fxaa_graph_internal(
     let rebuilder: GraphRebuilder = Arc::new(move |device, queue, scene, config, debug_state, debug_camera_buf, cull_stats_buf| {
         build_fxaa_graph_internal(device, queue, scene, config, debug_state, debug_camera_buf, cull_stats_buf, owns_device, overlay_owned.as_ref())
     });
+    graph.set_graph_data(rebuilder);
 
     graph
 }


### PR DESCRIPTION
Closes #56.

## What changed

- Keep the startup-selected surface alpha mode across resize reconfiguration instead of switching to `Auto`.
- Route every resize, including zero-sized minimization events, through one handler in both `editor_demo` and `editor_demo_mini`.
- Cancel active gizmo drags, clear held keys/mouse deltas, release cursor capture, and restore cursor visibility on resize or focus loss.
- Reset frame timing at interaction boundaries and cap the first resumed frame delta at 100 ms to prevent camera jumps after native modal resize loops.
- Continue rebuilding Helio's size-dependent render targets for every valid non-zero window size.

## Validation

- `cargo check -p examples --bin editor_demo --bin editor_demo_mini`
- `git diff --check`

Runtime validation requested on Windows: resize repeatedly while using right-mouse camera capture and while dragging a light/object gizmo, then confirm projection, camera input, picking, and gizmo movement recover immediately.

This PR is intentionally independent from #55. F3/debug-view propagation remains on the meshlet branch and will compose after both PRs merge.