### PR TITLE
Add bounded planetary voxel residency core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,6 +3225,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "helio-planet-voxel-core"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "thiserror 2.0.18",
+ "wgpu 28.0.0",
+]
+
+[[package]]
 name = "helio-voxel-core"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ helio = { path = "crates/helio" }
 libhelio = { path = "crates/libhelio" }
 helio-asset-compat = { path = "crates/helio-asset-compat" }
 helio-voxel-core = { path = "crates/helio-voxel-core" }
+helio-planet-voxel-core = { path = "crates/helio-planet-voxel-core" }
 helio-pass-corona = { path = "crates/helio-pass-corona" }
 helio-pass-sdf = { path = "crates/helio-pass-sdf" }
 helio-pass-voxel-mesh = { path = "crates/helio-pass-voxel-mesh" }

--- a/crates/helio-planet-voxel-core/Cargo.toml
+++ b/crates/helio-planet-voxel-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "helio-planet-voxel-core"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded renderer-facing contracts for Helio planetary voxels"
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+wgpu = { workspace = true }

--- a/crates/helio-planet-voxel-core/src/cache.rs
+++ b/crates/helio-planet-voxel-core/src/cache.rs
@@ -1,0 +1,690 @@
+use crate::{
+    CellWord, ContractError, PageEvict, PageUpload, PlanetPageKey, VisiblePageSet, PAGE_CELL_BYTES,
+};
+use std::collections::BTreeMap;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ResidencyConfig {
+    pub max_resident_pages: usize,
+    pub max_cell_bytes: usize,
+    pub max_eviction_watermarks: usize,
+}
+
+impl ResidencyConfig {
+    pub fn new(
+        max_resident_pages: usize,
+        max_cell_bytes: usize,
+        max_eviction_watermarks: usize,
+    ) -> Result<Self, ResidencyConfigError> {
+        if max_resident_pages == 0 {
+            return Err(ResidencyConfigError::ZeroResidentPages);
+        }
+        if u32::try_from(max_resident_pages).is_err() {
+            return Err(ResidencyConfigError::ResidentPageSlotsExceedGpuIndex);
+        }
+        if max_cell_bytes == 0 {
+            return Err(ResidencyConfigError::ZeroCellBytes);
+        }
+        if max_eviction_watermarks == 0 {
+            return Err(ResidencyConfigError::ZeroEvictionWatermarks);
+        }
+        Ok(Self {
+            max_resident_pages,
+            max_cell_bytes,
+            max_eviction_watermarks,
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ResidencyConfigError {
+    #[error("planetary residency must provide at least one page slot")]
+    ZeroResidentPages,
+    #[error("planetary residency page slots exceed the GPU u32 slot address space")]
+    ResidentPageSlotsExceedGpuIndex,
+    #[error("planetary residency cell-byte budget must be non-zero")]
+    ZeroCellBytes,
+    #[error("planetary residency must provide at least one eviction watermark")]
+    ZeroEvictionWatermarks,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ResidentPage {
+    pub slot: u32,
+    pub generation: u64,
+    pub cells: Box<[CellWord]>,
+    last_access: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct EvictedPage {
+    pub key: PlanetPageKey,
+    pub slot: u32,
+    pub generation: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UploadOutcome {
+    Inserted {
+        slot: u32,
+        evicted: Vec<EvictedPage>,
+    },
+    Replaced {
+        slot: u32,
+        previous_generation: u64,
+    },
+    Duplicate {
+        slot: u32,
+    },
+    Stale {
+        newest_generation: u64,
+    },
+    GenerationConflict {
+        slot: u32,
+    },
+    Backpressure(BackpressureReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum BackpressureReason {
+    PageExceedsCellByteBudget,
+    AllEvictionCandidatesVisible,
+    EvictionWatermarkCapacity,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EvictOutcome {
+    Recorded { removed: Option<EvictedPage> },
+    Stale { newest_generation: u64 },
+    Backpressure(BackpressureReason),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VisibilityOutcome {
+    Applied {
+        resident: usize,
+        missing: usize,
+        generation_mismatches: usize,
+    },
+    Duplicate,
+    Stale {
+        newest_frame: u64,
+    },
+    FrameConflict,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ResidencyCounters {
+    pub uploads_inserted: u64,
+    pub uploads_replaced: u64,
+    pub uploads_duplicate: u64,
+    pub uploads_stale: u64,
+    pub generation_conflicts: u64,
+    pub local_evictions: u64,
+    pub authoritative_evictions: u64,
+    pub backpressure_events: u64,
+    pub invalid_messages: u64,
+    pub resident_pages: usize,
+    pub resident_cell_bytes: usize,
+    pub peak_resident_pages: usize,
+    pub peak_resident_cell_bytes: usize,
+    pub eviction_watermarks: usize,
+}
+
+pub struct ResidentPageCache {
+    config: ResidencyConfig,
+    occupied_slots: BTreeMap<u32, PlanetPageKey>,
+    pages: BTreeMap<PlanetPageKey, ResidentPage>,
+    eviction_watermarks: BTreeMap<PlanetPageKey, u64>,
+    visible: BTreeMap<PlanetPageKey, (u64, u8)>,
+    last_visible_frame: Option<u64>,
+    access_clock: u64,
+    counters: ResidencyCounters,
+}
+
+impl ResidentPageCache {
+    pub fn new(config: ResidencyConfig) -> Self {
+        Self {
+            config,
+            occupied_slots: BTreeMap::new(),
+            pages: BTreeMap::new(),
+            eviction_watermarks: BTreeMap::new(),
+            visible: BTreeMap::new(),
+            last_visible_frame: None,
+            access_clock: 0,
+            counters: ResidencyCounters::default(),
+        }
+    }
+
+    pub fn config(&self) -> ResidencyConfig {
+        self.config
+    }
+
+    pub fn counters(&self) -> ResidencyCounters {
+        self.counters
+    }
+
+    pub fn resident(&self, key: PlanetPageKey) -> Option<&ResidentPage> {
+        self.pages.get(&key)
+    }
+
+    pub fn eviction_watermark(&self, key: PlanetPageKey) -> Option<u64> {
+        self.eviction_watermarks.get(&key).copied()
+    }
+
+    pub fn apply_upload(&mut self, upload: PageUpload) -> Result<UploadOutcome, ContractError> {
+        if let Err(error) = upload.validate() {
+            self.counters.invalid_messages += 1;
+            return Err(error);
+        }
+
+        if let Some(watermark) = self.eviction_watermarks.get(&upload.key).copied() {
+            if upload.generation <= watermark {
+                self.counters.uploads_stale += 1;
+                return Ok(UploadOutcome::Stale {
+                    newest_generation: watermark,
+                });
+            }
+        }
+
+        if let Some(existing) = self.pages.get(&upload.key) {
+            if upload.generation < existing.generation {
+                let newest_generation = existing.generation;
+                self.counters.uploads_stale += 1;
+                return Ok(UploadOutcome::Stale { newest_generation });
+            }
+            if upload.generation == existing.generation {
+                if upload.cells == existing.cells {
+                    let slot = existing.slot;
+                    self.counters.uploads_duplicate += 1;
+                    return Ok(UploadOutcome::Duplicate { slot });
+                }
+                let slot = existing.slot;
+                self.counters.generation_conflicts += 1;
+                return Ok(UploadOutcome::GenerationConflict { slot });
+            }
+
+            let access = self.next_access();
+            let existing = self
+                .pages
+                .get_mut(&upload.key)
+                .expect("resident page was just found");
+            let previous_generation = existing.generation;
+            let slot = existing.slot;
+            existing.generation = upload.generation;
+            existing.cells = upload.cells;
+            existing.last_access = access;
+            self.counters.uploads_replaced += 1;
+            return Ok(UploadOutcome::Replaced {
+                slot,
+                previous_generation,
+            });
+        }
+
+        if PAGE_CELL_BYTES > self.config.max_cell_bytes {
+            self.counters.backpressure_events += 1;
+            return Ok(UploadOutcome::Backpressure(
+                BackpressureReason::PageExceedsCellByteBudget,
+            ));
+        }
+
+        let pages_for_slot = self
+            .pages
+            .len()
+            .saturating_add(1)
+            .saturating_sub(self.config.max_resident_pages);
+        let bytes_after = self
+            .pages
+            .len()
+            .saturating_add(1)
+            .saturating_mul(PAGE_CELL_BYTES);
+        let bytes_over = bytes_after.saturating_sub(self.config.max_cell_bytes);
+        let pages_for_bytes = bytes_over.div_ceil(PAGE_CELL_BYTES);
+        let eviction_count = pages_for_slot.max(pages_for_bytes);
+
+        let mut candidates: Vec<_> = self
+            .pages
+            .iter()
+            .filter(|(key, page)| !self.is_visible(**key, page.generation))
+            .map(|(key, page)| (page.last_access, *key))
+            .collect();
+        candidates.sort_unstable();
+        if candidates.len() < eviction_count {
+            self.counters.backpressure_events += 1;
+            return Ok(UploadOutcome::Backpressure(
+                BackpressureReason::AllEvictionCandidatesVisible,
+            ));
+        }
+
+        let mut evicted = Vec::with_capacity(eviction_count);
+        for (_, key) in candidates.into_iter().take(eviction_count) {
+            evicted.push(self.remove_resident(key));
+            self.counters.local_evictions += 1;
+        }
+
+        let slot = (0..self.config.max_resident_pages as u32)
+            .find(|slot| !self.occupied_slots.contains_key(slot))
+            .expect("budget planning guarantees a free page slot");
+        self.occupied_slots.insert(slot, upload.key);
+        let access = self.next_access();
+        self.pages.insert(
+            upload.key,
+            ResidentPage {
+                slot,
+                generation: upload.generation,
+                cells: upload.cells,
+                last_access: access,
+            },
+        );
+        self.counters.uploads_inserted += 1;
+        self.refresh_resident_counters();
+        Ok(UploadOutcome::Inserted { slot, evicted })
+    }
+
+    pub fn apply_evict(&mut self, evict: PageEvict) -> Result<EvictOutcome, ContractError> {
+        if let Err(error) = evict.validate() {
+            self.counters.invalid_messages += 1;
+            return Err(error);
+        }
+
+        if let Some(watermark) = self.eviction_watermarks.get(&evict.key).copied() {
+            if evict.generation <= watermark {
+                self.counters.uploads_stale += 1;
+                return Ok(EvictOutcome::Stale {
+                    newest_generation: watermark,
+                });
+            }
+        } else if self.eviction_watermarks.len() == self.config.max_eviction_watermarks {
+            self.counters.backpressure_events += 1;
+            return Ok(EvictOutcome::Backpressure(
+                BackpressureReason::EvictionWatermarkCapacity,
+            ));
+        }
+
+        self.eviction_watermarks.insert(evict.key, evict.generation);
+        let should_remove = self
+            .pages
+            .get(&evict.key)
+            .is_some_and(|page| page.generation <= evict.generation);
+        let removed = should_remove.then(|| self.remove_resident(evict.key));
+        self.counters.authoritative_evictions += 1;
+        self.refresh_resident_counters();
+        Ok(EvictOutcome::Recorded { removed })
+    }
+
+    /// Retires a generation watermark only after the producer has established
+    /// that no upload or eviction at or below `through_generation` can still
+    /// arrive (normally by draining the relevant queue/fence).
+    pub fn retire_eviction_watermark(
+        &mut self,
+        key: PlanetPageKey,
+        through_generation: u64,
+    ) -> bool {
+        let can_retire = self
+            .eviction_watermarks
+            .get(&key)
+            .is_some_and(|watermark| *watermark <= through_generation);
+        if can_retire {
+            self.eviction_watermarks.remove(&key);
+            self.refresh_resident_counters();
+        }
+        can_retire
+    }
+
+    pub fn apply_visible_set(
+        &mut self,
+        set: VisiblePageSet,
+    ) -> Result<VisibilityOutcome, ContractError> {
+        if let Err(error) = set.validate(self.config.max_resident_pages) {
+            self.counters.invalid_messages += 1;
+            return Err(error);
+        }
+        let canonical: BTreeMap<_, _> = set
+            .pages
+            .iter()
+            .map(|page| (page.key, (page.generation, page.transition_mask)))
+            .collect();
+
+        if let Some(newest_frame) = self.last_visible_frame {
+            if set.frame_index < newest_frame {
+                return Ok(VisibilityOutcome::Stale { newest_frame });
+            }
+            if set.frame_index == newest_frame {
+                return Ok(if canonical == self.visible {
+                    VisibilityOutcome::Duplicate
+                } else {
+                    VisibilityOutcome::FrameConflict
+                });
+            }
+        }
+
+        self.visible = canonical;
+        self.last_visible_frame = Some(set.frame_index);
+        let access = self.next_access();
+        let mut resident = 0;
+        let mut missing = 0;
+        let mut generation_mismatches = 0;
+        for (key, (generation, _)) in &self.visible {
+            match self.pages.get_mut(key) {
+                Some(page) if page.generation == *generation => {
+                    page.last_access = access;
+                    resident += 1;
+                }
+                Some(_) => generation_mismatches += 1,
+                None => missing += 1,
+            }
+        }
+        Ok(VisibilityOutcome::Applied {
+            resident,
+            missing,
+            generation_mismatches,
+        })
+    }
+
+    fn is_visible(&self, key: PlanetPageKey, generation: u64) -> bool {
+        self.visible
+            .get(&key)
+            .is_some_and(|(visible_generation, _)| *visible_generation == generation)
+    }
+
+    fn next_access(&mut self) -> u64 {
+        self.access_clock = self.access_clock.saturating_add(1);
+        self.access_clock
+    }
+
+    fn remove_resident(&mut self, key: PlanetPageKey) -> EvictedPage {
+        let page = self
+            .pages
+            .remove(&key)
+            .expect("evicted page must be resident");
+        let removed_slot = self.occupied_slots.remove(&page.slot);
+        debug_assert_eq!(removed_slot, Some(key));
+        EvictedPage {
+            key,
+            slot: page.slot,
+            generation: page.generation,
+        }
+    }
+
+    fn refresh_resident_counters(&mut self) {
+        self.counters.resident_pages = self.pages.len();
+        self.counters.resident_cell_bytes = self.pages.len().saturating_mul(PAGE_CELL_BYTES);
+        self.counters.peak_resident_pages = self
+            .counters
+            .peak_resident_pages
+            .max(self.counters.resident_pages);
+        self.counters.peak_resident_cell_bytes = self
+            .counters
+            .peak_resident_cell_bytes
+            .max(self.counters.resident_cell_bytes);
+        self.counters.eviction_watermarks = self.eviction_watermarks.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PageKey, PlanetId, VisiblePage};
+
+    fn key(index: i64) -> PlanetPageKey {
+        PlanetPageKey::new(PlanetId([1; 16]), PageKey::new(0, [index, 0, 0]))
+    }
+
+    fn upload(index: i64, generation: u64, cell: CellWord) -> PageUpload {
+        PageUpload::new(key(index), generation, vec![cell; crate::PAGE_CELL_COUNT]).unwrap()
+    }
+
+    fn cache(pages: usize, byte_pages: usize, watermarks: usize) -> ResidentPageCache {
+        ResidentPageCache::new(
+            ResidencyConfig::new(pages, byte_pages * PAGE_CELL_BYTES, watermarks).unwrap(),
+        )
+    }
+
+    #[test]
+    fn configuration_rejects_slots_that_cannot_be_gpu_indexed() {
+        let too_many = usize::try_from(u64::from(u32::MAX) + 1);
+        if let Ok(too_many) = too_many {
+            assert_eq!(
+                ResidencyConfig::new(too_many, PAGE_CELL_BYTES, 1),
+                Err(ResidencyConfigError::ResidentPageSlotsExceedGpuIndex)
+            );
+        }
+    }
+
+    #[test]
+    fn lowest_slot_is_reused_after_deterministic_lru_eviction() {
+        let mut cache = cache(2, 2, 2);
+        assert!(matches!(
+            cache.apply_upload(upload(1, 1, CellWord::AIR)).unwrap(),
+            UploadOutcome::Inserted { slot: 0, .. }
+        ));
+        assert!(matches!(
+            cache.apply_upload(upload(2, 1, CellWord::AIR)).unwrap(),
+            UploadOutcome::Inserted { slot: 1, .. }
+        ));
+        let outcome = cache
+            .apply_upload(upload(3, 1, CellWord::new(-1, 1, 0)))
+            .unwrap();
+        assert_eq!(
+            outcome,
+            UploadOutcome::Inserted {
+                slot: 0,
+                evicted: vec![EvictedPage {
+                    key: key(1),
+                    slot: 0,
+                    generation: 1,
+                }],
+            }
+        );
+        assert_eq!(cache.counters().resident_pages, 2);
+        assert_eq!(cache.counters().resident_cell_bytes, 2 * PAGE_CELL_BYTES);
+    }
+
+    #[test]
+    fn visible_pages_are_never_evicted_to_hide_capacity_failure() {
+        let mut cache = cache(1, 1, 1);
+        cache.apply_upload(upload(1, 4, CellWord::AIR)).unwrap();
+        cache
+            .apply_visible_set(VisiblePageSet {
+                frame_index: 1,
+                pages: vec![VisiblePage {
+                    key: key(1),
+                    generation: 4,
+                    transition_mask: 0,
+                }],
+            })
+            .unwrap();
+        assert_eq!(
+            cache.apply_upload(upload(2, 1, CellWord::AIR)).unwrap(),
+            UploadOutcome::Backpressure(BackpressureReason::AllEvictionCandidatesVisible)
+        );
+        assert!(cache.resident(key(1)).is_some());
+    }
+
+    #[test]
+    fn pending_visibility_protects_a_matching_late_upload() {
+        let mut cache = cache(1, 1, 1);
+        assert_eq!(
+            cache
+                .apply_visible_set(VisiblePageSet {
+                    frame_index: 1,
+                    pages: vec![VisiblePage {
+                        key: key(1),
+                        generation: 4,
+                        transition_mask: 0,
+                    }],
+                })
+                .unwrap(),
+            VisibilityOutcome::Applied {
+                resident: 0,
+                missing: 1,
+                generation_mismatches: 0,
+            }
+        );
+        cache.apply_upload(upload(1, 4, CellWord::AIR)).unwrap();
+        assert_eq!(
+            cache.apply_upload(upload(2, 1, CellWord::AIR)).unwrap(),
+            UploadOutcome::Backpressure(BackpressureReason::AllEvictionCandidatesVisible)
+        );
+    }
+
+    #[test]
+    fn byte_budget_can_reject_a_page_without_allocating_or_panicking() {
+        let config = ResidencyConfig::new(8, PAGE_CELL_BYTES - 1, 1).unwrap();
+        let mut cache = ResidentPageCache::new(config);
+        assert_eq!(
+            cache.apply_upload(upload(0, 0, CellWord::AIR)).unwrap(),
+            UploadOutcome::Backpressure(BackpressureReason::PageExceedsCellByteBudget)
+        );
+        assert_eq!(cache.counters().resident_pages, 0);
+    }
+
+    #[test]
+    fn same_generation_with_different_data_is_a_conflict() {
+        let mut cache = cache(1, 1, 1);
+        cache.apply_upload(upload(0, 3, CellWord::AIR)).unwrap();
+        assert!(matches!(
+            cache
+                .apply_upload(upload(0, 3, CellWord::new(-1, 1, 0)))
+                .unwrap(),
+            UploadOutcome::GenerationConflict { slot: 0 }
+        ));
+        assert_eq!(cache.resident(key(0)).unwrap().cells[0], CellWord::AIR);
+    }
+
+    #[test]
+    fn eviction_before_upload_blocks_late_generation() {
+        let mut cache = cache(1, 1, 1);
+        assert_eq!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(7),
+                    generation: 9,
+                })
+                .unwrap(),
+            EvictOutcome::Recorded { removed: None }
+        );
+        assert_eq!(
+            cache.apply_upload(upload(7, 9, CellWord::AIR)).unwrap(),
+            UploadOutcome::Stale {
+                newest_generation: 9,
+            }
+        );
+        assert!(matches!(
+            cache.apply_upload(upload(7, 10, CellWord::AIR)).unwrap(),
+            UploadOutcome::Inserted { slot: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn authoritative_eviction_only_removes_covered_generations() {
+        let mut cache = cache(1, 1, 2);
+        cache.apply_upload(upload(1, 10, CellWord::AIR)).unwrap();
+        assert_eq!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(1),
+                    generation: 9,
+                })
+                .unwrap(),
+            EvictOutcome::Recorded { removed: None }
+        );
+        assert_eq!(cache.resident(key(1)).unwrap().generation, 10);
+        assert!(matches!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(1),
+                    generation: 10,
+                })
+                .unwrap(),
+            EvictOutcome::Recorded {
+                removed: Some(EvictedPage { generation: 10, .. })
+            }
+        ));
+        assert!(cache.resident(key(1)).is_none());
+    }
+
+    #[test]
+    fn local_budget_eviction_allows_same_generation_rebuild() {
+        let mut cache = cache(1, 1, 1);
+        cache.apply_upload(upload(1, 3, CellWord::AIR)).unwrap();
+        cache.apply_upload(upload(2, 1, CellWord::AIR)).unwrap();
+        assert!(matches!(
+            cache.apply_upload(upload(1, 3, CellWord::AIR)).unwrap(),
+            UploadOutcome::Inserted { .. }
+        ));
+        assert_eq!(cache.eviction_watermark(key(1)), None);
+    }
+
+    #[test]
+    fn eviction_watermarks_are_bounded_and_explicitly_retired() {
+        let mut cache = cache(1, 1, 1);
+        cache
+            .apply_evict(PageEvict {
+                key: key(1),
+                generation: 2,
+            })
+            .unwrap();
+        assert_eq!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(2),
+                    generation: 1,
+                })
+                .unwrap(),
+            EvictOutcome::Backpressure(BackpressureReason::EvictionWatermarkCapacity)
+        );
+        assert!(!cache.retire_eviction_watermark(key(1), 1));
+        assert!(cache.retire_eviction_watermark(key(1), 2));
+        assert!(matches!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(2),
+                    generation: 1,
+                })
+                .unwrap(),
+            EvictOutcome::Recorded { .. }
+        ));
+        assert_eq!(cache.counters().eviction_watermarks, 1);
+    }
+
+    #[test]
+    fn visibility_frames_cannot_roll_back_or_change_in_place() {
+        let mut cache = cache(2, 2, 1);
+        let page = VisiblePage {
+            key: key(0),
+            generation: 1,
+            transition_mask: 0,
+        };
+        let set = VisiblePageSet {
+            frame_index: 5,
+            pages: vec![page],
+        };
+        assert!(matches!(
+            cache.apply_visible_set(set.clone()).unwrap(),
+            VisibilityOutcome::Applied { .. }
+        ));
+        assert_eq!(
+            cache.apply_visible_set(set).unwrap(),
+            VisibilityOutcome::Duplicate
+        );
+        assert_eq!(
+            cache
+                .apply_visible_set(VisiblePageSet {
+                    frame_index: 5,
+                    pages: Vec::new(),
+                })
+                .unwrap(),
+            VisibilityOutcome::FrameConflict
+        );
+        assert_eq!(
+            cache
+                .apply_visible_set(VisiblePageSet {
+                    frame_index: 4,
+                    pages: Vec::new(),
+                })
+                .unwrap(),
+            VisibilityOutcome::Stale { newest_frame: 5 }
+        );
+    }
+}

--- a/crates/helio-planet-voxel-core/src/contract.rs
+++ b/crates/helio-planet-voxel-core/src/contract.rs
@@ -1,0 +1,219 @@
+use crate::{
+    CellWord, GpuVoxelMaterial, PlanetId, PlanetPageKey, PAGE_CELL_COUNT, TRANSITION_FACE_MASK,
+};
+use std::collections::BTreeSet;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PageUpload {
+    pub key: PlanetPageKey,
+    pub generation: u64,
+    pub cells: Box<[CellWord]>,
+}
+
+impl PageUpload {
+    pub fn new(
+        key: PlanetPageKey,
+        generation: u64,
+        cells: Vec<CellWord>,
+    ) -> Result<Self, ContractError> {
+        let upload = Self {
+            key,
+            generation,
+            cells: cells.into_boxed_slice(),
+        };
+        upload.validate()?;
+        Ok(upload)
+    }
+
+    pub fn validate(&self) -> Result<(), ContractError> {
+        self.key.validate()?;
+        if self.cells.len() != PAGE_CELL_COUNT {
+            return Err(ContractError::CellCount(self.cells.len()));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PageEvict {
+    pub key: PlanetPageKey,
+    pub generation: u64,
+}
+
+impl PageEvict {
+    pub fn validate(self) -> Result<(), ContractError> {
+        self.key.validate()?;
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct VisiblePage {
+    pub key: PlanetPageKey,
+    pub generation: u64,
+    pub transition_mask: u8,
+}
+
+impl VisiblePage {
+    pub fn validate(self) -> Result<(), ContractError> {
+        self.key.validate()?;
+        if self.transition_mask & !TRANSITION_FACE_MASK != 0 {
+            return Err(ContractError::TransitionMask(self.transition_mask));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VisiblePageSet {
+    pub frame_index: u64,
+    pub pages: Vec<VisiblePage>,
+}
+
+impl VisiblePageSet {
+    pub fn validate(&self, max_pages: usize) -> Result<(), ContractError> {
+        if self.pages.len() > max_pages {
+            return Err(ContractError::VisiblePageCount {
+                actual: self.pages.len(),
+                maximum: max_pages,
+            });
+        }
+        let mut keys = BTreeSet::new();
+        for page in &self.pages {
+            page.validate()?;
+            if !keys.insert(page.key) {
+                return Err(ContractError::DuplicateVisiblePage(page.key));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct MaterialPaletteDelta {
+    pub planet: PlanetId,
+    pub generation: u64,
+    pub first_material: u16,
+    pub materials: Vec<GpuVoxelMaterial>,
+}
+
+impl MaterialPaletteDelta {
+    pub fn validate(&self) -> Result<(), ContractError> {
+        let end = usize::from(self.first_material)
+            .checked_add(self.materials.len())
+            .ok_or(ContractError::PaletteRange)?;
+        if end > usize::from(u8::MAX) + 1 {
+            return Err(ContractError::PaletteRange);
+        }
+        if self.materials.iter().any(|material| {
+            material
+                .base_color_roughness
+                .iter()
+                .chain(material.emissive_metalness.iter())
+                .any(|value| !value.is_finite())
+        }) {
+            return Err(ContractError::NonFiniteMaterial);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum ContractError {
+    #[error(transparent)]
+    Address(#[from] crate::AddressError),
+    #[error("planetary page has {0} cells; exactly {PAGE_CELL_COUNT} are required")]
+    CellCount(usize),
+    #[error("transition mask {0:#010b} uses bits outside the six page faces")]
+    TransitionMask(u8),
+    #[error("visible page set has {actual} entries; the configured maximum is {maximum}")]
+    VisiblePageCount { actual: usize, maximum: usize },
+    #[error("visible page set contains duplicate key {0:?}")]
+    DuplicateVisiblePage(PlanetPageKey),
+    #[error("material palette delta exceeds the 256-entry material address space")]
+    PaletteRange,
+    #[error("material palette delta contains a non-finite value")]
+    NonFiniteMaterial,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PageKey, PlanetId};
+
+    fn key(index: i64) -> PlanetPageKey {
+        PlanetPageKey::new(PlanetId([1; 16]), PageKey::new(0, [index, 0, 0]))
+    }
+
+    #[test]
+    fn page_upload_requires_one_complete_page() {
+        assert_eq!(
+            PageUpload::new(key(0), 0, vec![CellWord::AIR; 3]),
+            Err(ContractError::CellCount(3))
+        );
+    }
+
+    #[test]
+    fn visible_sets_reject_duplicate_keys_and_invalid_face_bits() {
+        let page = VisiblePage {
+            key: key(0),
+            generation: 1,
+            transition_mask: 0,
+        };
+        assert_eq!(
+            VisiblePageSet {
+                frame_index: 1,
+                pages: vec![page, page],
+            }
+            .validate(2),
+            Err(ContractError::DuplicateVisiblePage(key(0)))
+        );
+        assert_eq!(
+            VisiblePage {
+                transition_mask: 0x80,
+                ..page
+            }
+            .validate(),
+            Err(ContractError::TransitionMask(0x80))
+        );
+    }
+
+    #[test]
+    fn palette_deltas_are_finite_and_stay_in_the_material_id_range() {
+        let material = GpuVoxelMaterial {
+            base_color_roughness: [1.0; 4],
+            emissive_metalness: [0.0; 4],
+        };
+        assert!(MaterialPaletteDelta {
+            planet: PlanetId::default(),
+            generation: 1,
+            first_material: 255,
+            materials: vec![material],
+        }
+        .validate()
+        .is_ok());
+        assert_eq!(
+            MaterialPaletteDelta {
+                planet: PlanetId::default(),
+                generation: 1,
+                first_material: 255,
+                materials: vec![material, material],
+            }
+            .validate(),
+            Err(ContractError::PaletteRange)
+        );
+        assert_eq!(
+            MaterialPaletteDelta {
+                planet: PlanetId::default(),
+                generation: 1,
+                first_material: 0,
+                materials: vec![GpuVoxelMaterial {
+                    base_color_roughness: [f32::NAN; 4],
+                    emissive_metalness: [0.0; 4],
+                }],
+            }
+            .validate(),
+            Err(ContractError::NonFiniteMaterial)
+        );
+    }
+}

--- a/crates/helio-planet-voxel-core/src/gpu.rs
+++ b/crates/helio-planet-voxel-core/src/gpu.rs
@@ -1,0 +1,170 @@
+use crate::{
+    AddressError, PageKey, PlanetId, LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS, TRANSITION_FACE_MASK,
+};
+use bytemuck::{Pod, Zeroable};
+
+/// Frame-stable values consumed only by the planetary pass. Absolute canonical
+/// values are split into integer words; existing Helio transforms and camera
+/// uniforms remain camera-local `f32` data.
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, PartialEq, Pod, Zeroable)]
+pub struct PlanetFrameUniform {
+    pub planet_id: [u32; 4],
+    pub origin_x: [u32; 2],
+    pub origin_y: [u32; 2],
+    pub origin_z: [u32; 2],
+    pub frame_index: [u32; 2],
+    pub camera_relative_m: [f32; 3],
+    pub lod0_cell_size_m: f32,
+    pub page_edge_cells: u32,
+    pub _pad: [u32; 3],
+}
+
+impl PlanetFrameUniform {
+    pub fn new(
+        planet: PlanetId,
+        frame_origin_lod0_cell: [i64; 3],
+        camera_relative_m: [f32; 3],
+        frame_index: u64,
+    ) -> Result<Self, FrameError> {
+        if frame_origin_lod0_cell
+            .iter()
+            .any(|axis| axis.rem_euclid(PAGE_EDGE_CELLS) != 0)
+        {
+            return Err(FrameError::UnsnappedOrigin);
+        }
+        if camera_relative_m.iter().any(|value| !value.is_finite()) {
+            return Err(FrameError::NonFiniteCameraOffset);
+        }
+
+        Ok(Self {
+            planet_id: planet_words(planet),
+            origin_x: split_i64(frame_origin_lod0_cell[0]),
+            origin_y: split_i64(frame_origin_lod0_cell[1]),
+            origin_z: split_i64(frame_origin_lod0_cell[2]),
+            frame_index: split_u64(frame_index),
+            camera_relative_m,
+            lod0_cell_size_m: LOD0_CELL_SIZE_METERS as f32,
+            page_edge_cells: PAGE_EDGE_CELLS as u32,
+            _pad: [0; 3],
+        })
+    }
+
+    pub fn frame_origin_lod0_cell(self) -> [i64; 3] {
+        [
+            join_i64(self.origin_x),
+            join_i64(self.origin_y),
+            join_i64(self.origin_z),
+        ]
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuPageMeta {
+    pub relative_lod0_cell_min: [i32; 3],
+    pub lod: u32,
+    pub slot: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub transition_mask: u32,
+}
+
+impl GpuPageMeta {
+    pub fn new(
+        page: PageKey,
+        frame_origin_lod0_cell: [i64; 3],
+        slot: u32,
+        generation: u64,
+        transition_mask: u8,
+    ) -> Result<Self, GpuPageMetaError> {
+        if transition_mask & !TRANSITION_FACE_MASK != 0 {
+            return Err(GpuPageMetaError::TransitionMask(transition_mask));
+        }
+        let generation = split_u64(generation);
+        Ok(Self {
+            relative_lod0_cell_min: page
+                .relative_lod0_cell_min(frame_origin_lod0_cell)
+                .map_err(GpuPageMetaError::Address)?,
+            lod: u32::from(page.lod),
+            slot,
+            generation_low: generation[0],
+            generation_high: generation[1],
+            transition_mask: u32::from(transition_mask),
+        })
+    }
+
+    pub const fn generation(self) -> u64 {
+        (self.generation_low as u64) | ((self.generation_high as u64) << 32)
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Pod, Zeroable)]
+pub struct GpuVoxelMaterial {
+    pub base_color_roughness: [f32; 4],
+    pub emissive_metalness: [f32; 4],
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum FrameError {
+    #[error("planet frame origin must be snapped to an LOD0 page boundary")]
+    UnsnappedOrigin,
+    #[error("planet frame camera offset must contain only finite values")]
+    NonFiniteCameraOffset,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum GpuPageMetaError {
+    #[error(transparent)]
+    Address(AddressError),
+    #[error("transition mask {0:#010b} uses bits outside the six page faces")]
+    TransitionMask(u8),
+}
+
+const fn split_u64(value: u64) -> [u32; 2] {
+    [value as u32, (value >> 32) as u32]
+}
+
+const fn split_i64(value: i64) -> [u32; 2] {
+    split_u64(value as u64)
+}
+
+const fn join_i64(words: [u32; 2]) -> i64 {
+    ((words[0] as u64) | ((words[1] as u64) << 32)) as i64
+}
+
+fn planet_words(planet: PlanetId) -> [u32; 4] {
+    let mut words = [0_u32; 4];
+    for (word, bytes) in words.iter_mut().zip(planet.0.chunks_exact(4)) {
+        *word = u32::from_le_bytes(bytes.try_into().expect("chunks_exact yields four bytes"));
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frame_round_trips_signed_canonical_origin() {
+        let origin = [-64_i64, 32, i64::from(i32::MAX) * 32];
+        let uniform =
+            PlanetFrameUniform::new(PlanetId([7; 16]), origin, [1.0, 2.0, 3.0], 9).unwrap();
+        assert_eq!(uniform.frame_origin_lod0_cell(), origin);
+        assert_eq!(uniform.frame_index, [9, 0]);
+        assert_eq!(uniform.page_edge_cells, 32);
+    }
+
+    #[test]
+    fn frame_rejects_unsnapped_and_non_finite_values() {
+        assert_eq!(
+            PlanetFrameUniform::new(PlanetId::default(), [1, 0, 0], [0.0; 3], 0),
+            Err(FrameError::UnsnappedOrigin)
+        );
+        assert_eq!(
+            PlanetFrameUniform::new(PlanetId::default(), [0; 3], [f32::INFINITY, 0.0, 0.0], 0,),
+            Err(FrameError::NonFiniteCameraOffset)
+        );
+    }
+}

--- a/crates/helio-planet-voxel-core/src/lib.rs
+++ b/crates/helio-planet-voxel-core/src/lib.rs
@@ -1,0 +1,20 @@
+//! Renderer-facing contracts for the production planetary voxel path.
+//!
+//! Pulsar owns canonical terrain state. This crate deliberately owns only the
+//! bounded messages, GPU layouts, and residency model consumed by Helio. It has
+//! no renderer, scene, persistence, physics, or dependency on the retained
+//! fixed-volume voxel implementation.
+
+mod cache;
+mod contract;
+mod gpu;
+mod types;
+
+pub use cache::*;
+pub use contract::*;
+pub use gpu::*;
+pub use types::*;
+
+/// WGSL declarations that must remain byte-compatible with the public GPU POD
+/// types in this crate.
+pub const PLANET_VOXEL_LAYOUT_WGSL: &str = include_str!("planet_voxel_layout.wgsl");

--- a/crates/helio-planet-voxel-core/src/planet_voxel_layout.wgsl
+++ b/crates/helio-planet-voxel-core/src/planet_voxel_layout.wgsl
@@ -1,0 +1,42 @@
+// Shared storage/uniform declarations for the planetary voxel pass.
+// CellWord: density i16 in bits 0..15, material u8 in 16..23, flags u8 in 24..31.
+
+alias CellWord = u32;
+
+struct PlanetFrameUniform {
+    planet_id: vec4<u32>,
+    origin_x: vec2<u32>,
+    origin_y: vec2<u32>,
+    origin_z: vec2<u32>,
+    frame_index: vec2<u32>,
+    camera_relative_m: vec3<f32>,
+    lod0_cell_size_m: f32,
+    page_edge_cells: u32,
+    _pad: array<u32, 3>,
+}
+
+struct GpuPageMeta {
+    relative_lod0_cell_min: vec3<i32>,
+    lod: u32,
+    slot: u32,
+    generation_low: u32,
+    generation_high: u32,
+    transition_mask: u32,
+}
+
+struct GpuVoxelMaterial {
+    base_color_roughness: vec4<f32>,
+    emissive_metalness: vec4<f32>,
+}
+
+fn cell_density(cell: CellWord) -> i32 {
+    return bitcast<i32>(cell << 16u) >> 16u;
+}
+
+fn cell_material(cell: CellWord) -> u32 {
+    return (cell >> 16u) & 0xffu;
+}
+
+fn cell_flags(cell: CellWord) -> u32 {
+    return cell >> 24u;
+}

--- a/crates/helio-planet-voxel-core/src/types.rs
+++ b/crates/helio-planet-voxel-core/src/types.rs
@@ -1,0 +1,202 @@
+use bytemuck::{Pod, Zeroable};
+
+pub type MaterialId = u8;
+
+pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
+pub const PAGE_EDGE_CELLS: i64 = 32;
+pub const PAGE_EDGE: usize = PAGE_EDGE_CELLS as usize;
+pub const PAGE_CELL_COUNT: usize = PAGE_EDGE * PAGE_EDGE * PAGE_EDGE;
+pub const PAGE_CELL_BYTES: usize = PAGE_CELL_COUNT * core::mem::size_of::<CellWord>();
+pub const MICROBRICK_EDGE: usize = 8;
+pub const MICROBRICKS_PER_AXIS: usize = PAGE_EDGE / MICROBRICK_EDGE;
+pub const MICROBRICK_COUNT: usize =
+    MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS * MICROBRICKS_PER_AXIS;
+pub const MAX_ADDRESSABLE_LOD: u8 = 57;
+pub const TRANSITION_FACE_MASK: u8 = 0b00_111111;
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
+pub struct PlanetId(pub [u8; 16]);
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PageKey {
+    pub lod: u8,
+    pub page_xyz: [i64; 3],
+}
+
+impl PageKey {
+    pub const fn new(lod: u8, page_xyz: [i64; 3]) -> Self {
+        Self { lod, page_xyz }
+    }
+
+    pub fn validate(self) -> Result<(), AddressError> {
+        if self.lod > MAX_ADDRESSABLE_LOD {
+            return Err(AddressError::UnsupportedLod(self.lod));
+        }
+        self.lod0_cell_min()?;
+        Ok(())
+    }
+
+    pub fn parent(self) -> Option<Self> {
+        let lod = self.lod.checked_add(1)?;
+        (lod <= MAX_ADDRESSABLE_LOD).then(|| Self {
+            lod,
+            page_xyz: self.page_xyz.map(|axis| axis.div_euclid(2)),
+        })
+    }
+
+    pub fn lod0_cell_span(self) -> Result<i64, AddressError> {
+        if self.lod > MAX_ADDRESSABLE_LOD {
+            return Err(AddressError::UnsupportedLod(self.lod));
+        }
+        PAGE_EDGE_CELLS
+            .checked_shl(u32::from(self.lod))
+            .ok_or(AddressError::CoordinateOverflow)
+    }
+
+    pub fn lod0_cell_min(self) -> Result<[i64; 3], AddressError> {
+        let span = self.lod0_cell_span()?;
+        Ok([
+            self.page_xyz[0]
+                .checked_mul(span)
+                .ok_or(AddressError::CoordinateOverflow)?,
+            self.page_xyz[1]
+                .checked_mul(span)
+                .ok_or(AddressError::CoordinateOverflow)?,
+            self.page_xyz[2]
+                .checked_mul(span)
+                .ok_or(AddressError::CoordinateOverflow)?,
+        ])
+    }
+
+    /// Converts an absolute page address into a bounded camera-local GPU
+    /// address. The subtraction happens in canonical integer space before the
+    /// checked narrowing to `i32`.
+    pub fn relative_lod0_cell_min(
+        self,
+        frame_origin_lod0_cell: [i64; 3],
+    ) -> Result<[i32; 3], AddressError> {
+        let absolute = self.lod0_cell_min()?;
+        let mut relative = [0_i32; 3];
+        for axis in 0..3 {
+            let delta = absolute[axis]
+                .checked_sub(frame_origin_lod0_cell[axis])
+                .ok_or(AddressError::CoordinateOverflow)?;
+            relative[axis] = i32::try_from(delta).map_err(|_| AddressError::OutsideRenderFrame)?;
+        }
+        Ok(relative)
+    }
+
+    pub fn address_lod0_cell(lod: u8, cell_xyz: [i64; 3]) -> Result<(Self, [u8; 3]), AddressError> {
+        let key = Self::new(lod, [0; 3]);
+        let scale = key.lod0_cell_span()? / PAGE_EDGE_CELLS;
+        let span = PAGE_EDGE_CELLS
+            .checked_mul(scale)
+            .ok_or(AddressError::CoordinateOverflow)?;
+        let page_xyz = cell_xyz.map(|axis| axis.div_euclid(span));
+        let local = cell_xyz.map(|axis| (axis.rem_euclid(span) / scale) as u8);
+        Ok((Self { lod, page_xyz }, local))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PlanetPageKey {
+    pub planet: PlanetId,
+    pub page: PageKey,
+}
+
+impl PlanetPageKey {
+    pub const fn new(planet: PlanetId, page: PageKey) -> Self {
+        Self { planet, page }
+    }
+
+    pub fn validate(self) -> Result<(), AddressError> {
+        self.page.validate()
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Pod, Zeroable)]
+pub struct CellWord(pub u32);
+
+impl CellWord {
+    pub const AIR: Self = Self::new(i16::MAX, 0, 0);
+
+    pub const fn new(density: i16, material: MaterialId, flags: u8) -> Self {
+        Self((density as u16 as u32) | ((material as u32) << 16) | ((flags as u32) << 24))
+    }
+
+    pub const fn density(self) -> i16 {
+        self.0 as u16 as i16
+    }
+
+    pub const fn material(self) -> MaterialId {
+        (self.0 >> 16) as u8
+    }
+
+    pub const fn flags(self) -> u8 {
+        (self.0 >> 24) as u8
+    }
+
+    pub const fn is_solid(self) -> bool {
+        self.density() <= 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum AddressError {
+    #[error("planetary page LOD {0} exceeds the addressable maximum")]
+    UnsupportedLod(u8),
+    #[error("planetary page coordinate arithmetic overflowed")]
+    CoordinateOverflow,
+    #[error("planetary page lies outside the current camera-local render frame")]
+    OutsideRenderFrame,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cell_word_matches_the_authoritative_four_byte_layout() {
+        assert_eq!(core::mem::size_of::<CellWord>(), 4);
+        let word = CellWord::new(-123, 17, 9);
+        assert_eq!(word.0, 0x0911_ff85);
+        assert_eq!(word.density(), -123);
+        assert_eq!(word.material(), 17);
+        assert_eq!(word.flags(), 9);
+        assert!(word.is_solid());
+        assert!(!CellWord::AIR.is_solid());
+    }
+
+    #[test]
+    fn negative_page_boundaries_use_euclidean_division() {
+        for lod in 0..=30 {
+            let scale = 1_i64 << lod;
+            let span = PAGE_EDGE_CELLS * scale;
+            for coordinate in [-span - 1, -span, -span + 1, -1, 0, 1, span - 1, span] {
+                let (key, local) = PageKey::address_lod0_cell(lod, [coordinate; 3]).unwrap();
+                let minimum = key.lod0_cell_min().unwrap();
+                for axis in 0..3 {
+                    assert!(usize::from(local[axis]) < PAGE_EDGE);
+                    let reconstructed = minimum[axis] + i64::from(local[axis]) * scale;
+                    assert!(reconstructed <= coordinate);
+                    assert!(coordinate < reconstructed + scale);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn camera_local_narrowing_is_checked() {
+        let page = PageKey::new(0, [4, -2, 1]);
+        assert_eq!(
+            page.relative_lod0_cell_min([64, -64, 0]).unwrap(),
+            [64, 0, 32]
+        );
+        assert_eq!(
+            PageKey::new(0, [i64::from(i32::MAX), 0, 0]).relative_lod0_cell_min([0; 3]),
+            Err(AddressError::OutsideRenderFrame)
+        );
+    }
+}

--- a/crates/helio-planet-voxel-core/tests/wgsl_layout.rs
+++ b/crates/helio-planet-voxel-core/tests/wgsl_layout.rs
@@ -1,0 +1,138 @@
+use helio_planet_voxel_core::{
+    GpuPageMeta, GpuVoxelMaterial, PlanetFrameUniform, PLANET_VOXEL_LAYOUT_WGSL,
+};
+use std::mem::{align_of, offset_of, size_of};
+use wgpu::naga::{
+    front::wgsl,
+    valid::{Capabilities, ValidationFlags, Validator},
+    TypeInner,
+};
+
+fn wgsl_struct(name: &str) -> (u32, Vec<(String, u32)>) {
+    let module = wgsl::parse_str(PLANET_VOXEL_LAYOUT_WGSL)
+        .unwrap_or_else(|error| panic!("planetary layout WGSL must parse: {error}"));
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .unwrap_or_else(|error| panic!("planetary layout WGSL must validate: {error}"));
+    let (_, ty) = module
+        .types
+        .iter()
+        .find(|(_, ty)| ty.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("missing WGSL struct {name}"));
+    let TypeInner::Struct { members, span } = &ty.inner else {
+        panic!("WGSL type {name} is not a struct");
+    };
+    (
+        *span,
+        members
+            .iter()
+            .map(|member| {
+                (
+                    member.name.clone().expect("every contract field is named"),
+                    member.offset,
+                )
+            })
+            .collect(),
+    )
+}
+
+#[test]
+fn planet_frame_uniform_matches_wgsl_offsets_exactly() {
+    assert_eq!(align_of::<PlanetFrameUniform>(), 16);
+    assert_eq!(size_of::<PlanetFrameUniform>(), 80);
+    assert_eq!(
+        wgsl_struct("PlanetFrameUniform"),
+        (
+            size_of::<PlanetFrameUniform>() as u32,
+            vec![
+                (
+                    "planet_id".into(),
+                    offset_of!(PlanetFrameUniform, planet_id) as u32
+                ),
+                (
+                    "origin_x".into(),
+                    offset_of!(PlanetFrameUniform, origin_x) as u32
+                ),
+                (
+                    "origin_y".into(),
+                    offset_of!(PlanetFrameUniform, origin_y) as u32
+                ),
+                (
+                    "origin_z".into(),
+                    offset_of!(PlanetFrameUniform, origin_z) as u32
+                ),
+                (
+                    "frame_index".into(),
+                    offset_of!(PlanetFrameUniform, frame_index) as u32
+                ),
+                (
+                    "camera_relative_m".into(),
+                    offset_of!(PlanetFrameUniform, camera_relative_m) as u32,
+                ),
+                (
+                    "lod0_cell_size_m".into(),
+                    offset_of!(PlanetFrameUniform, lod0_cell_size_m) as u32,
+                ),
+                (
+                    "page_edge_cells".into(),
+                    offset_of!(PlanetFrameUniform, page_edge_cells) as u32,
+                ),
+                ("_pad".into(), offset_of!(PlanetFrameUniform, _pad) as u32),
+            ],
+        )
+    );
+}
+
+#[test]
+fn page_meta_matches_wgsl_offsets_exactly() {
+    assert_eq!(align_of::<GpuPageMeta>(), 16);
+    assert_eq!(size_of::<GpuPageMeta>(), 32);
+    assert_eq!(
+        wgsl_struct("GpuPageMeta"),
+        (
+            size_of::<GpuPageMeta>() as u32,
+            vec![
+                (
+                    "relative_lod0_cell_min".into(),
+                    offset_of!(GpuPageMeta, relative_lod0_cell_min) as u32,
+                ),
+                ("lod".into(), offset_of!(GpuPageMeta, lod) as u32),
+                ("slot".into(), offset_of!(GpuPageMeta, slot) as u32),
+                (
+                    "generation_low".into(),
+                    offset_of!(GpuPageMeta, generation_low) as u32,
+                ),
+                (
+                    "generation_high".into(),
+                    offset_of!(GpuPageMeta, generation_high) as u32,
+                ),
+                (
+                    "transition_mask".into(),
+                    offset_of!(GpuPageMeta, transition_mask) as u32,
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn voxel_material_matches_wgsl_offsets_exactly() {
+    assert_eq!(align_of::<GpuVoxelMaterial>(), 16);
+    assert_eq!(size_of::<GpuVoxelMaterial>(), 32);
+    assert_eq!(
+        wgsl_struct("GpuVoxelMaterial"),
+        (
+            size_of::<GpuVoxelMaterial>() as u32,
+            vec![
+                (
+                    "base_color_roughness".into(),
+                    offset_of!(GpuVoxelMaterial, base_color_roughness) as u32,
+                ),
+                (
+                    "emissive_metalness".into(),
+                    offset_of!(GpuVoxelMaterial, emissive_metalness) as u32,
+                ),
+            ],
+        )
+    );
+}

--- a/docs/planetary_voxel_progress.md
+++ b/docs/planetary_voxel_progress.md
@@ -23,7 +23,7 @@ and `helio-voxel-core` remain unchanged regression baselines.
 
 ## Active milestone
 
-- [ ] Helio bounded renderer-facing residency contract: [Helio#59](https://github.com/Far-Beyond-Pulsar/Helio/issues/59)
+- [ ] Helio bounded renderer-facing residency contract: [Helio#62](https://github.com/Far-Beyond-Pulsar/Helio/pull/62) ([issue #59](https://github.com/Far-Beyond-Pulsar/Helio/issues/59))
 
 ## Implementation milestones
 


### PR DESCRIPTION
## Parent

Child of umbrella #60. Resolves #59 when this planet-only milestone is accepted.

## What this adds

- Independent `helio-planet-voxel-core` crate; no renderer, scene, persistence, physics, or retained voxel-core dependency.
- Pulsar-compatible signed planet/page keys, exact 10 cm LOD0 constants, and checked camera-local address narrowing.
- Exact four-byte density/material/flags `CellWord` contract.
- Versioned page upload, authoritative eviction, visible-page, palette, and snapped planet-frame contracts.
- Rust/WGSL POD parity tests using Helio's pinned WGPU/Naga revision.
- Fixed slot and byte budgets with deterministic LRU eviction.
- Visible-page protection and explicit backpressure instead of unbounded growth or panic.
- Bounded authoritative-eviction watermarks and explicit retirement.
- Sparse slot bookkeeping and detailed residency counters.

## Safety properties exercised

- Signed negative page boundaries use Euclidean division.
- Absolute `i64` coordinates narrow only after camera-origin subtraction.
- Same-generation/different-content uploads are conflicts.
- Older uploads and evictions cannot overwrite/remove newer generations.
- Local cache eviction permits a legitimate same-generation rebuild.
- Visibility sets cannot roll back or mutate within one frame index.
- All-visible exhaustion returns backpressure and preserves current pages.
- Palette ranges, finite values, transition bits, page sizes, LODs, and GPU slot ranges are checked.

## Current-base validation

Rebased through umbrella #60 onto current `v4` `847ab2f4`.

- `cargo metadata --locked --no-deps --format-version 1`: pass
- `cargo test -p helio-planet-voxel-core --locked`: 22 passed
- strict all-target no-deps clippy with `-D warnings`: pass
- top-of-stack `cargo build --workspace --all-targets --locked`: pass
- top-of-stack `cargo test --workspace --lib --bins --tests --locked`: pass
- retained `voxel_demo` and `voxel_demo_raymarch` targets: pass through the workspace gate
- diff audit: retained voxel implementation and demo source unchanged

The previously exposed retained-octree termination defect is resolved by merged PR #63; the full workspace test suite now completes.

## Out of scope

GPU buffers, extraction, meshlet publication, render-graph hooks, resize/device-loss handling, and the planet demo. Those remain later measured milestones in #60.