### PR TITLE
Fix voxel octree depth termination

### DIFF
--- a/crates/helio-voxel-core/src/octree.rs
+++ b/crates/helio-voxel-core/src/octree.rs
@@ -1,4 +1,37 @@
 use crate::constants::*;
+use std::fmt;
+
+/// Six complete octree subdivisions produce 8^6 = 262,144 terminal bricks,
+/// exactly the existing per-volume brick limit. A deeper complete tree cannot
+/// be represented by the retained voxel path's GPU budget.
+pub const MAX_OCTREE_DEPTH: u32 = max_complete_depth(MAX_BRICKS_PER_VOLUME);
+
+const fn max_complete_depth(mut leaf_budget: u32) -> u32 {
+    let mut depth = 0;
+    while leaf_budget >= 8 {
+        leaf_budget /= 8;
+        depth += 1;
+    }
+    depth
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct OctreeDepthError {
+    pub requested: u32,
+    pub maximum: u32,
+}
+
+impl fmt::Display for OctreeDepthError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "requested voxel octree depth {} exceeds the supported maximum {}",
+            self.requested, self.maximum
+        )
+    }
+}
+
+impl std::error::Error for OctreeDepthError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeState {
@@ -62,7 +95,7 @@ impl OctreeNode {
             (self.aabb_min[2] + self.aabb_max[2]) * 0.5,
         ];
         let mut children: [Option<Box<OctreeNode>>; 8] = Default::default();
-        for i in 0..8 {
+        for (i, child) in children.iter_mut().enumerate() {
             let (lx, ly, lz) = ((i & 1) != 0, (i & 2) != 0, (i & 4) != 0);
             let min = [
                 if lx { mid[0] } else { self.aabb_min[0] },
@@ -74,31 +107,27 @@ impl OctreeNode {
                 if ly { self.aabb_max[1] } else { mid[1] },
                 if lz { self.aabb_max[2] } else { mid[2] },
             ];
-            children[i] = Some(Box::new(OctreeNode::new_empty(min, max)));
+            *child = Some(Box::new(OctreeNode::new_empty(min, max)));
         }
         self.children = Some(Box::new(children));
         self.state = NodeState::Branch;
     }
 
     pub fn collect_leaves<'a>(&'a self, leaves: &mut Vec<&'a OctreeNode>) {
-        match self.state {
-            NodeState::Leaf => leaves.push(self),
-            NodeState::Branch => {
-                if let Some(ref children) = self.children {
-                    for child in children.iter().flatten() {
-                        child.collect_leaves(leaves);
-                    }
-                }
+        if let Some(ref children) = self.children {
+            for child in children.iter().flatten() {
+                child.collect_leaves(leaves);
             }
-            _ => {}
+        } else {
+            // "Leaf" here is structural: constant Empty/Solid regions and
+            // allocated GPU Leaf nodes are all terminal octree nodes.
+            leaves.push(self);
         }
     }
 
     pub fn collect_dirty_leaves<'a>(&'a self, leaves: &mut Vec<&'a OctreeNode>) {
-        if self.dirty {
-            if matches!(self.state, NodeState::Leaf) {
-                leaves.push(self);
-            }
+        if self.dirty && matches!(self.state, NodeState::Leaf) {
+            leaves.push(self);
         }
         if let Some(ref children) = self.children {
             for child in children.iter().flatten() {
@@ -131,11 +160,45 @@ impl OctreeNode {
                     for child in children.iter_mut().flatten() {
                         any |= child.mark_sphere_dirty(center, radius);
                     }
-                    if any { self.dirty = true; }
+                    if any {
+                        self.dirty = true;
+                    }
                     any
-                } else { false }
+                } else {
+                    false
+                }
             }
             NodeState::Empty | NodeState::Solid(_) => false,
+        }
+    }
+
+    pub fn node_count(&self) -> usize {
+        1 + self
+            .children
+            .iter()
+            .flat_map(|children| children.iter().flatten())
+            .map(|child| child.node_count())
+            .sum::<usize>()
+    }
+
+    fn ensure_empty_depth(&mut self, remaining_depth: u32) {
+        if remaining_depth == 0 {
+            return;
+        }
+
+        match self.state {
+            NodeState::Empty => self.subdivide(),
+            NodeState::Branch => {}
+            // Constant solid regions and materialized GPU leaves are already
+            // valid sparse terminals. Expanding them as Empty would destroy
+            // terrain or discard their GPU slot.
+            NodeState::Solid(_) | NodeState::Leaf => return,
+        }
+
+        if let Some(children) = self.children.as_mut() {
+            for child in children.iter_mut().flatten() {
+                child.ensure_empty_depth(remaining_depth - 1);
+            }
         }
     }
 }
@@ -160,7 +223,18 @@ impl VoxelOctree {
     }
 
     pub fn needed_depth(world_size: f32, voxel_size: f32, brick_size: u32) -> u32 {
+        if !world_size.is_finite()
+            || !voxel_size.is_finite()
+            || world_size <= 0.0
+            || voxel_size <= 0.0
+            || brick_size == 0
+        {
+            return 0;
+        }
         let brick_world = brick_size as f32 * voxel_size;
+        if !brick_world.is_finite() || world_size <= brick_world {
+            return 0;
+        }
         let mut depth = 0;
         let mut size = world_size;
         while size > brick_world {
@@ -170,17 +244,33 @@ impl VoxelOctree {
         depth
     }
 
+    /// Ensure `target_depth` subdivision levels below the root.
+    ///
+    /// The retained voxel path can represent at most `MAX_OCTREE_DEPTH`
+    /// complete levels. Call [`Self::try_ensure_depth`] when the requested
+    /// depth is derived from untrusted or runtime data.
     pub fn ensure_depth(&mut self, target_depth: u32) {
-        while self.level_count < target_depth {
-            self.subdivide_root();
-        }
+        self.try_ensure_depth(target_depth)
+            .unwrap_or_else(|error| panic!("{error}"));
     }
 
-    fn subdivide_root(&mut self) {
-        if !matches!(self.root.state, NodeState::Branch) {
-            self.root.subdivide();
-            self.level_count += 1;
+    pub fn try_ensure_depth(&mut self, target_depth: u32) -> Result<(), OctreeDepthError> {
+        if target_depth > MAX_OCTREE_DEPTH {
+            return Err(OctreeDepthError {
+                requested: target_depth,
+                maximum: MAX_OCTREE_DEPTH,
+            });
         }
+        let current_depth = self.level_count.saturating_sub(1);
+        if target_depth > current_depth {
+            self.root.ensure_empty_depth(target_depth);
+            self.level_count = target_depth + 1;
+        }
+        Ok(())
+    }
+
+    pub fn node_count(&self) -> usize {
+        self.root.node_count()
     }
 }
 
@@ -190,17 +280,20 @@ mod tests {
 
     #[test]
     fn test_octree_basic() {
-        let mut octree = VoxelOctree::new(1.0, 256.0);
+        let octree = VoxelOctree::new(1.0, 256.0);
         assert_eq!(octree.level_count, 1);
         assert!(matches!(octree.root.state, NodeState::Empty));
+        assert_eq!(octree.node_count(), 1);
     }
 
     #[test]
-    fn test_subdivide() {
-        let mut octree = VoxelOctree::new(1.0, 256.0);
-        octree.ensure_depth(4);
-        assert!(octree.level_count >= 4);
-        assert!(matches!(octree.root.state, NodeState::Branch));
+    fn needed_depth_is_exact_and_rejects_invalid_sizes_without_looping() {
+        assert_eq!(VoxelOctree::needed_depth(256.0, 1.0, 8), 5);
+        assert_eq!(VoxelOctree::needed_depth(8.0, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(7.0, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(f32::INFINITY, 1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(256.0, -1.0, 8), 0);
+        assert_eq!(VoxelOctree::needed_depth(256.0, 1.0, 0), 0);
     }
 
     #[test]
@@ -215,10 +308,73 @@ mod tests {
 
     #[test]
     fn test_collect_leaves() {
+        for depth in 0..=4 {
+            let mut octree = VoxelOctree::new(1.0, 256.0);
+            octree.ensure_depth(depth);
+            let mut leaves = vec![];
+            octree.root.collect_leaves(&mut leaves);
+            assert_eq!(leaves.len(), 8_usize.pow(depth));
+            assert_eq!(octree.level_count, depth + 1);
+        }
+    }
+
+    #[test]
+    fn ensure_depth_is_idempotent() {
         let mut octree = VoxelOctree::new(1.0, 256.0);
         octree.ensure_depth(3);
-        let mut leaves = vec![];
-        octree.root.collect_leaves(&mut leaves);
-        assert_eq!(leaves.len(), 512);
+        let node_count = octree.node_count();
+        octree.ensure_depth(3);
+        octree.ensure_depth(2);
+        assert_eq!(octree.node_count(), node_count);
+        assert_eq!(octree.level_count, 4);
+    }
+
+    #[test]
+    fn ensure_depth_preserves_sparse_solid_and_gpu_leaf_terminals() {
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        octree.root.subdivide();
+        let children = octree.root.children.as_mut().unwrap();
+        children[0] = Some(Box::new(OctreeNode::new_solid(7, [-128.0; 3], [0.0; 3])));
+        children[1] = Some(Box::new(OctreeNode::new_leaf(
+            42,
+            [0.0, -128.0, -128.0],
+            [128.0, 0.0, 0.0],
+        )));
+
+        octree.try_ensure_depth(3).unwrap();
+
+        let children = octree.root.children.as_ref().unwrap();
+        assert!(matches!(
+            children[0].as_deref().unwrap().state,
+            NodeState::Solid(7)
+        ));
+        assert!(children[0].as_deref().unwrap().children.is_none());
+        assert!(matches!(
+            children[1].as_deref().unwrap().state,
+            NodeState::Leaf
+        ));
+        assert_eq!(children[1].as_deref().unwrap().gpu_slot, 42);
+        assert!(children[1].as_deref().unwrap().children.is_none());
+    }
+
+    #[test]
+    fn checked_depth_rejects_exponential_over_budget_growth() {
+        assert_eq!(8_u32.pow(MAX_OCTREE_DEPTH), MAX_BRICKS_PER_VOLUME);
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        assert_eq!(
+            octree.try_ensure_depth(MAX_OCTREE_DEPTH + 1),
+            Err(OctreeDepthError {
+                requested: MAX_OCTREE_DEPTH + 1,
+                maximum: MAX_OCTREE_DEPTH,
+            })
+        );
+        assert_eq!(octree.node_count(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "exceeds the supported maximum")]
+    fn compatibility_depth_api_panics_before_over_budget_allocation() {
+        let mut octree = VoxelOctree::new(1.0, 256.0);
+        octree.ensure_depth(MAX_OCTREE_DEPTH + 1);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #61.

`VoxelOctree::ensure_depth` previously subdivided only the root. Once the root became a branch, `level_count` could no longer advance, so depth requests above one spun forever.

## Changes

- define requested depth as subdivision levels below the root
- recursively expand only Empty terminal regions to the requested depth
- preserve constant Solid regions and materialized GPU Leaf nodes/slots
- make structural leaf traversal include Empty, Solid, and GPU Leaf terminals
- add checked `try_ensure_depth` while retaining `ensure_depth` as the compatibility wrapper
- derive the maximum complete depth from the existing 262,144-brick per-volume budget
- reject deeper requests before exponential allocation
- validate invalid/non-finite sizing in `needed_depth` before its halving loop
- add termination, exact-count, idempotence, sparse-preservation, invalid-size, and over-budget tests

## Caller audit

Repository-wide search found no production callers of `ensure_depth`, `needed_depth`, or `collect_leaves`; their current callers are the retained crate tests. `VoxelVolumeRecord` constructs `VoxelOctree` but does not invoke these methods. Public compatibility is preserved.

The branch is rebased onto current `v4` at `9b517df0`. Its diff is limited to `crates/helio-voxel-core/src/octree.rs`.

## Validation

- `cargo test -p helio-voxel-core --locked`: 8 passed, 0 failed
- `cargo clippy -p helio-voxel-core --lib --tests --no-deps --locked -- -D warnings`: pass
- `cargo check -p helio --lib --locked`: pass
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked`: pass
- `cargo build --release -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked`: pass
- combined current-`v4` intended merge set, including PRs #93, #94, and #95: `cargo build --workspace --all-targets --locked`: pass
- same combined tree: `cargo test --workspace --lib --bins --tests --locked`: pass
- `git diff --check`: pass

Without this PR, the current-`v4` workspace test command spins in the existing `helio_voxel_core` test executable. With this PR included, the full executable-test suite completes.

## Manual validation

Validated on Windows from the rebased PR worktree:

- `cargo run --release -p examples --bin voxel_demo`: pass
- `cargo run --release -p examples --bin voxel_demo_raymarch`: pass
- rendering, camera controls, voxel interaction, resize behavior, and clean shutdown: pass

This is an engine fix and remains for maintainer review and merge.