### PR TITLE
Add bounded planetary voxel GPU residency atlas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3006,6 +3006,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "helio-pass-planetary-voxel"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "helio-planet-voxel-core",
+ "pollster 0.4.0",
+ "thiserror 2.0.18",
+ "wgpu 28.0.0",
+]
+
+[[package]]
 name = "helio-pass-postprocess"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3013,7 +3013,7 @@ dependencies = [
  "helio-planet-voxel-core",
  "pollster 0.4.0",
  "thiserror 2.0.18",
- "wgpu 28.0.0",
+ "wgpu 30.0.0",
 ]
 
 [[package]]
@@ -3241,7 +3241,7 @@ version = "0.1.0"
 dependencies = [
  "bytemuck",
  "thiserror 2.0.18",
- "wgpu 28.0.0",
+ "wgpu 30.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ libhelio = { path = "crates/libhelio" }
 helio-asset-compat = { path = "crates/helio-asset-compat" }
 helio-voxel-core = { path = "crates/helio-voxel-core" }
 helio-planet-voxel-core = { path = "crates/helio-planet-voxel-core" }
+helio-pass-planetary-voxel = { path = "crates/helio-pass-planetary-voxel" }
 helio-pass-corona = { path = "crates/helio-pass-corona" }
 helio-pass-sdf = { path = "crates/helio-pass-sdf" }
 helio-pass-voxel-mesh = { path = "crates/helio-pass-voxel-mesh" }

--- a/crates/helio-pass-planetary-voxel/Cargo.toml
+++ b/crates/helio-pass-planetary-voxel/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "helio-pass-planetary-voxel"
+version = "0.1.0"
+edition = "2021"
+description = "Bounded GPU residency and rendering path for Helio planetary voxels"
+
+[dependencies]
+bytemuck = { workspace = true, features = ["derive"] }
+helio-planet-voxel-core = { workspace = true }
+thiserror = { workspace = true }
+wgpu = { workspace = true }
+
+[dev-dependencies]
+pollster = { workspace = true }

--- a/crates/helio-pass-planetary-voxel/src/config.rs
+++ b/crates/helio-pass-planetary-voxel/src/config.rs
@@ -1,0 +1,356 @@
+use crate::{GpuPageTableEntry, GpuResidencyCounters, GpuResidencyUniform};
+use helio_planet_voxel_core::{GpuPageMeta, ResidencyConfig, PAGE_CELL_BYTES};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PlanetaryVoxelGpuConfig {
+    pub max_resident_pages: u32,
+    pub table_capacity: u32,
+    pub max_probe: u32,
+    pub max_batch_pages: u32,
+    pub max_eviction_watermarks: u32,
+    pub max_atlas_shards: u32,
+}
+
+impl PlanetaryVoxelGpuConfig {
+    pub fn new(
+        max_resident_pages: u32,
+        table_capacity: u32,
+        max_probe: u32,
+        max_batch_pages: u32,
+        max_eviction_watermarks: u32,
+        max_atlas_shards: u32,
+    ) -> Result<Self, GpuConfigError> {
+        if max_resident_pages == 0 {
+            return Err(GpuConfigError::ZeroResidentPages);
+        }
+        if !table_capacity.is_power_of_two() {
+            return Err(GpuConfigError::TableCapacityNotPowerOfTwo(table_capacity));
+        }
+        let transient_entries = max_resident_pages
+            .checked_add(1)
+            .ok_or(GpuConfigError::ArithmeticOverflow)?;
+        if transient_entries > table_capacity / 2 {
+            return Err(GpuConfigError::TableLoadFactor {
+                resident_pages: max_resident_pages,
+                table_capacity,
+            });
+        }
+        if max_probe == 0 || max_probe > table_capacity {
+            return Err(GpuConfigError::InvalidMaxProbe {
+                max_probe,
+                table_capacity,
+            });
+        }
+        if max_batch_pages == 0 || max_batch_pages > max_resident_pages {
+            return Err(GpuConfigError::InvalidBatchPages {
+                batch_pages: max_batch_pages,
+                resident_pages: max_resident_pages,
+            });
+        }
+        if max_eviction_watermarks == 0 {
+            return Err(GpuConfigError::ZeroEvictionWatermarks);
+        }
+        if max_atlas_shards == 0 {
+            return Err(GpuConfigError::ZeroAtlasShards);
+        }
+        let config = Self {
+            max_resident_pages,
+            table_capacity,
+            max_probe,
+            max_batch_pages,
+            max_eviction_watermarks,
+            max_atlas_shards,
+        };
+        config.total_gpu_bytes()?;
+        for bytes in [
+            config.cell_atlas_bytes()?,
+            config.metadata_bytes()?,
+            config.page_table_bytes()?,
+            config.staging_bytes()?,
+        ] {
+            usize::try_from(bytes).map_err(|_| GpuConfigError::ArithmeticOverflow)?;
+        }
+        Ok(config)
+    }
+
+    pub fn residency_config(self) -> Result<ResidencyConfig, GpuConfigError> {
+        let max_resident_pages = usize::try_from(self.max_resident_pages)
+            .map_err(|_| GpuConfigError::ArithmeticOverflow)?;
+        let max_cell_bytes = usize::try_from(self.cell_atlas_bytes()?)
+            .map_err(|_| GpuConfigError::ArithmeticOverflow)?;
+        let max_eviction_watermarks = usize::try_from(self.max_eviction_watermarks)
+            .map_err(|_| GpuConfigError::ArithmeticOverflow)?;
+        ResidencyConfig::new(max_resident_pages, max_cell_bytes, max_eviction_watermarks)
+            .map_err(|_| GpuConfigError::ArithmeticOverflow)
+    }
+
+    pub fn cell_atlas_bytes(self) -> Result<u64, GpuConfigError> {
+        u64::from(self.max_resident_pages)
+            .checked_mul(PAGE_CELL_BYTES as u64)
+            .ok_or(GpuConfigError::ArithmeticOverflow)
+    }
+
+    pub fn metadata_bytes(self) -> Result<u64, GpuConfigError> {
+        u64::from(self.max_resident_pages)
+            .checked_mul(core::mem::size_of::<GpuPageMeta>() as u64)
+            .ok_or(GpuConfigError::ArithmeticOverflow)
+    }
+
+    pub fn page_table_bytes(self) -> Result<u64, GpuConfigError> {
+        u64::from(self.table_capacity)
+            .checked_mul(core::mem::size_of::<GpuPageTableEntry>() as u64)
+            .ok_or(GpuConfigError::ArithmeticOverflow)
+    }
+
+    pub fn staging_bytes(self) -> Result<u64, GpuConfigError> {
+        u64::from(self.max_batch_pages)
+            .checked_mul(PAGE_CELL_BYTES as u64)
+            .ok_or(GpuConfigError::ArithmeticOverflow)
+    }
+
+    pub fn total_gpu_bytes(self) -> Result<u64, GpuConfigError> {
+        [
+            self.cell_atlas_bytes()?,
+            self.metadata_bytes()?,
+            self.page_table_bytes()?,
+            self.staging_bytes()?,
+            core::mem::size_of::<GpuResidencyUniform>() as u64,
+            core::mem::size_of::<GpuResidencyCounters>() as u64,
+        ]
+        .into_iter()
+        .try_fold(0_u64, |total, bytes| {
+            total
+                .checked_add(bytes)
+                .ok_or(GpuConfigError::ArithmeticOverflow)
+        })
+    }
+
+    pub fn allocation_plan(
+        self,
+        limits: &wgpu::Limits,
+    ) -> Result<GpuAllocationPlan, GpuConfigError> {
+        let page_bytes = PAGE_CELL_BYTES as u64;
+        let max_storage_bytes = limits.max_storage_buffer_binding_size as u64;
+        let max_shard_bytes = limits.max_buffer_size.min(max_storage_bytes);
+        let pages_per_shard = (max_shard_bytes / page_bytes).min(u64::from(u32::MAX));
+        if pages_per_shard == 0 {
+            return Err(GpuConfigError::DeviceCannotFitPage {
+                page_bytes,
+                max_buffer_bytes: limits.max_buffer_size,
+                max_storage_bytes,
+            });
+        }
+        let shard_count = u64::from(self.max_resident_pages).div_ceil(pages_per_shard);
+        if shard_count > u64::from(self.max_atlas_shards) {
+            return Err(GpuConfigError::AtlasShardLimit {
+                required: shard_count as u32,
+                maximum: self.max_atlas_shards,
+            });
+        }
+        let atlas_binding_limit = limits
+            .max_storage_buffers_per_shader_stage
+            .saturating_sub(2);
+        if shard_count > u64::from(atlas_binding_limit) {
+            return Err(GpuConfigError::AtlasBindingLimit {
+                required: shard_count as u32,
+                available: atlas_binding_limit,
+            });
+        }
+
+        for (name, bytes, storage) in [
+            ("metadata", self.metadata_bytes()?, true),
+            ("page table", self.page_table_bytes()?, true),
+            ("staging", self.staging_bytes()?, false),
+            (
+                "residency uniform",
+                core::mem::size_of::<GpuResidencyUniform>() as u64,
+                false,
+            ),
+            (
+                "residency counters",
+                core::mem::size_of::<GpuResidencyCounters>() as u64,
+                true,
+            ),
+        ] {
+            if bytes > limits.max_buffer_size || (storage && bytes > max_storage_bytes) {
+                return Err(GpuConfigError::DeviceBufferLimit {
+                    name,
+                    requested: bytes,
+                    max_buffer_bytes: limits.max_buffer_size,
+                    max_storage_bytes,
+                });
+            }
+        }
+        let uniform_bytes = core::mem::size_of::<GpuResidencyUniform>() as u64;
+        if uniform_bytes > u64::from(limits.max_uniform_buffer_binding_size) {
+            return Err(GpuConfigError::UniformBindingLimit {
+                requested: uniform_bytes,
+                maximum: limits.max_uniform_buffer_binding_size,
+            });
+        }
+
+        let mut shards = Vec::with_capacity(shard_count as usize);
+        let mut page_start = 0_u32;
+        while page_start < self.max_resident_pages {
+            let remaining = self.max_resident_pages - page_start;
+            let page_count = remaining.min(pages_per_shard as u32);
+            shards.push(GpuAtlasShardPlan {
+                page_start,
+                page_count,
+                size_bytes: u64::from(page_count) * page_bytes,
+            });
+            page_start += page_count;
+        }
+        Ok(GpuAllocationPlan {
+            shards,
+            metadata_bytes: self.metadata_bytes()?,
+            page_table_bytes: self.page_table_bytes()?,
+            staging_bytes: self.staging_bytes()?,
+            total_bytes: self.total_gpu_bytes()?,
+        })
+    }
+}
+
+impl Default for PlanetaryVoxelGpuConfig {
+    fn default() -> Self {
+        Self::new(256, 1024, 32, 16, 512, 16)
+            .expect("default planetary GPU residency budget is valid")
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpuAllocationPlan {
+    pub shards: Vec<GpuAtlasShardPlan>,
+    pub metadata_bytes: u64,
+    pub page_table_bytes: u64,
+    pub staging_bytes: u64,
+    pub total_bytes: u64,
+}
+
+impl GpuAllocationPlan {
+    pub fn shard_for_slot(&self, slot: u32) -> Option<(usize, u64)> {
+        self.shards.iter().enumerate().find_map(|(index, shard)| {
+            let local = slot.checked_sub(shard.page_start)?;
+            (local < shard.page_count).then_some((index, u64::from(local) * PAGE_CELL_BYTES as u64))
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GpuAtlasShardPlan {
+    pub page_start: u32,
+    pub page_count: u32,
+    pub size_bytes: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum GpuConfigError {
+    #[error("planetary GPU residency needs at least one page")]
+    ZeroResidentPages,
+    #[error("page-table capacity {0} must be a non-zero power of two")]
+    TableCapacityNotPowerOfTwo(u32),
+    #[error(
+        "page-table capacity {table_capacity} must keep resident page count {resident_pages} plus one transactional entry at or below 50% load"
+    )]
+    TableLoadFactor {
+        resident_pages: u32,
+        table_capacity: u32,
+    },
+    #[error("maximum probe count {max_probe} must be within 1..={table_capacity}")]
+    InvalidMaxProbe { max_probe: u32, table_capacity: u32 },
+    #[error("batch page count {batch_pages} must be within 1..={resident_pages}")]
+    InvalidBatchPages {
+        batch_pages: u32,
+        resident_pages: u32,
+    },
+    #[error("planetary GPU residency needs at least one eviction watermark")]
+    ZeroEvictionWatermarks,
+    #[error("planetary GPU residency needs at least one atlas shard")]
+    ZeroAtlasShards,
+    #[error("planetary GPU residency byte arithmetic overflowed")]
+    ArithmeticOverflow,
+    #[error(
+        "device cannot fit one {page_bytes}-byte page (buffer {max_buffer_bytes}, storage binding {max_storage_bytes})"
+    )]
+    DeviceCannotFitPage {
+        page_bytes: u64,
+        max_buffer_bytes: u64,
+        max_storage_bytes: u64,
+    },
+    #[error("cell atlas needs {required} shards, exceeding configured maximum {maximum}")]
+    AtlasShardLimit { required: u32, maximum: u32 },
+    #[error(
+        "cell atlas needs {required} storage bindings, but the device has {available} after reserving metadata and page-table bindings"
+    )]
+    AtlasBindingLimit { required: u32, available: u32 },
+    #[error(
+        "{name} buffer requests {requested} bytes (buffer limit {max_buffer_bytes}, storage binding limit {max_storage_bytes})"
+    )]
+    DeviceBufferLimit {
+        name: &'static str,
+        requested: u64,
+        max_buffer_bytes: u64,
+        max_storage_bytes: u64,
+    },
+    #[error("residency uniform requests {requested} bytes; device binding limit is {maximum}")]
+    UniformBindingLimit { requested: u64, maximum: u32 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn budgets_use_checked_exact_bytes() {
+        let config = PlanetaryVoxelGpuConfig::new(4, 16, 8, 2, 8, 4).unwrap();
+        assert_eq!(config.cell_atlas_bytes().unwrap(), 4 * 131_072);
+        assert_eq!(config.metadata_bytes().unwrap(), 4 * 32);
+        assert_eq!(config.page_table_bytes().unwrap(), 16 * 48);
+        assert_eq!(config.staging_bytes().unwrap(), 2 * 131_072);
+    }
+
+    #[test]
+    fn table_load_and_probe_limits_are_explicit() {
+        assert!(matches!(
+            PlanetaryVoxelGpuConfig::new(8, 16, 8, 1, 1, 1),
+            Err(GpuConfigError::TableLoadFactor { .. })
+        ));
+        assert!(matches!(
+            PlanetaryVoxelGpuConfig::new(4, 16, 17, 1, 1, 1),
+            Err(GpuConfigError::InvalidMaxProbe { .. })
+        ));
+    }
+
+    #[test]
+    fn allocation_plan_shards_at_storage_binding_limit() {
+        let config = PlanetaryVoxelGpuConfig::new(4, 16, 8, 2, 8, 4).unwrap();
+        let limits = wgpu::Limits {
+            max_buffer_size: 2 * PAGE_CELL_BYTES as u64,
+            max_storage_buffer_binding_size: (2 * PAGE_CELL_BYTES) as u32,
+            ..wgpu::Limits::downlevel_defaults()
+        };
+        let plan = config.allocation_plan(&limits).unwrap();
+        assert_eq!(plan.shards.len(), 2);
+        assert_eq!(plan.shard_for_slot(0), Some((0, 0)));
+        assert_eq!(plan.shard_for_slot(2), Some((1, 0)));
+        assert_eq!(plan.shard_for_slot(4), None);
+    }
+
+    #[test]
+    fn allocation_plan_rejects_unbindable_atlas_shards() {
+        let config = PlanetaryVoxelGpuConfig::new(4, 16, 8, 2, 8, 4).unwrap();
+        let limits = wgpu::Limits {
+            max_buffer_size: PAGE_CELL_BYTES as u64,
+            max_storage_buffer_binding_size: PAGE_CELL_BYTES as u32,
+            max_storage_buffers_per_shader_stage: 4,
+            ..wgpu::Limits::downlevel_defaults()
+        };
+        assert_eq!(
+            config.allocation_plan(&limits),
+            Err(GpuConfigError::AtlasBindingLimit {
+                required: 4,
+                available: 2,
+            })
+        );
+    }
+}

--- a/crates/helio-pass-planetary-voxel/src/config.rs
+++ b/crates/helio-pass-planetary-voxel/src/config.rs
@@ -130,7 +130,7 @@ impl PlanetaryVoxelGpuConfig {
         limits: &wgpu::Limits,
     ) -> Result<GpuAllocationPlan, GpuConfigError> {
         let page_bytes = PAGE_CELL_BYTES as u64;
-        let max_storage_bytes = limits.max_storage_buffer_binding_size as u64;
+        let max_storage_bytes = limits.max_storage_buffer_binding_size;
         let max_shard_bytes = limits.max_buffer_size.min(max_storage_bytes);
         let pages_per_shard = (max_shard_bytes / page_bytes).min(u64::from(u32::MAX));
         if pages_per_shard == 0 {
@@ -182,7 +182,7 @@ impl PlanetaryVoxelGpuConfig {
             }
         }
         let uniform_bytes = core::mem::size_of::<GpuResidencyUniform>() as u64;
-        if uniform_bytes > u64::from(limits.max_uniform_buffer_binding_size) {
+        if uniform_bytes > limits.max_uniform_buffer_binding_size {
             return Err(GpuConfigError::UniformBindingLimit {
                 requested: uniform_bytes,
                 maximum: limits.max_uniform_buffer_binding_size,
@@ -293,7 +293,7 @@ pub enum GpuConfigError {
         max_storage_bytes: u64,
     },
     #[error("residency uniform requests {requested} bytes; device binding limit is {maximum}")]
-    UniformBindingLimit { requested: u64, maximum: u32 },
+    UniformBindingLimit { requested: u64, maximum: u64 },
 }
 
 #[cfg(test)]
@@ -326,7 +326,7 @@ mod tests {
         let config = PlanetaryVoxelGpuConfig::new(4, 16, 8, 2, 8, 4).unwrap();
         let limits = wgpu::Limits {
             max_buffer_size: 2 * PAGE_CELL_BYTES as u64,
-            max_storage_buffer_binding_size: (2 * PAGE_CELL_BYTES) as u32,
+            max_storage_buffer_binding_size: (2 * PAGE_CELL_BYTES) as u64,
             ..wgpu::Limits::downlevel_defaults()
         };
         let plan = config.allocation_plan(&limits).unwrap();
@@ -341,7 +341,7 @@ mod tests {
         let config = PlanetaryVoxelGpuConfig::new(4, 16, 8, 2, 8, 4).unwrap();
         let limits = wgpu::Limits {
             max_buffer_size: PAGE_CELL_BYTES as u64,
-            max_storage_buffer_binding_size: PAGE_CELL_BYTES as u32,
+            max_storage_buffer_binding_size: PAGE_CELL_BYTES as u64,
             max_storage_buffers_per_shader_stage: 4,
             ..wgpu::Limits::downlevel_defaults()
         };

--- a/crates/helio-pass-planetary-voxel/src/gpu.rs
+++ b/crates/helio-pass-planetary-voxel/src/gpu.rs
@@ -1,0 +1,760 @@
+use crate::{
+    GpuAllocationPlan, GpuConfigError, GpuLookupKey, GpuPageTableEntry, GpuResidencyCounters,
+    GpuResidencyUniform, PageTable, PageTableError, PlanetaryVoxelGpuConfig,
+};
+use helio_planet_voxel_core::{
+    AddressError, CellWord, ContractError, EvictOutcome, GpuPageMeta, GpuPageMetaError, PageEvict,
+    PageUpload, PlanetFrameUniform, PlanetId, PlanetPageKey, ResidentPageCache, UploadOutcome,
+    VisibilityOutcome, VisiblePageSet, PAGE_CELL_BYTES, PAGE_CELL_COUNT,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FrameUpdateOutcome {
+    Applied { previous_frame: Option<u64> },
+    Duplicate,
+    Stale { newest_frame: u64 },
+    FrameConflict,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum GpuUploadOutcome {
+    Residency(UploadOutcome),
+    PageTableBackpressure,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct GpuResourceStats {
+    pub buffers: u32,
+    pub atlas_shards: u32,
+    pub allocated_bytes: u64,
+}
+
+pub struct PlanetaryVoxelResidency {
+    config: PlanetaryVoxelGpuConfig,
+    plan: GpuAllocationPlan,
+    cache: ResidentPageCache,
+    frames: BTreeMap<PlanetId, PlanetFrameUniform>,
+    visible: BTreeMap<PlanetPageKey, (u64, u8)>,
+    table: PageTable,
+    published_table: Vec<GpuPageTableEntry>,
+    published_metadata: Vec<GpuPageMeta>,
+    resources: GpuResidencyResources,
+    counters: GpuResidencyCounters,
+    cell_bytes_uploaded: u64,
+}
+
+impl PlanetaryVoxelResidency {
+    pub fn new(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        config: PlanetaryVoxelGpuConfig,
+    ) -> Result<Self, GpuResidencyError> {
+        let plan = config.allocation_plan(&device.limits())?;
+        let cache = ResidentPageCache::new(config.residency_config()?);
+        let table = PageTable::new(config.table_capacity, config.max_probe)?;
+        let resources = GpuResidencyResources::new(device, &plan);
+        let mut residency = Self {
+            config,
+            plan,
+            cache,
+            frames: BTreeMap::new(),
+            visible: BTreeMap::new(),
+            table,
+            published_table: vec![GpuPageTableEntry::default(); config.table_capacity as usize],
+            published_metadata: vec![GpuPageMeta::default(); config.max_resident_pages as usize],
+            resources,
+            counters: GpuResidencyCounters::default(),
+            cell_bytes_uploaded: 0,
+        };
+        residency.publish_state(queue, true)?;
+        Ok(residency)
+    }
+
+    pub fn config(&self) -> PlanetaryVoxelGpuConfig {
+        self.config
+    }
+
+    pub fn allocation_plan(&self) -> &GpuAllocationPlan {
+        &self.plan
+    }
+
+    pub fn cache(&self) -> &ResidentPageCache {
+        &self.cache
+    }
+
+    pub fn counters(&self) -> GpuResidencyCounters {
+        self.counters
+    }
+
+    pub fn page_table(&self) -> &PageTable {
+        &self.table
+    }
+
+    pub fn planet_frame_count(&self) -> usize {
+        self.frames.len()
+    }
+
+    pub fn resource_stats(&self) -> GpuResourceStats {
+        GpuResourceStats {
+            buffers: self.resources.atlas_shards.len() as u32 + 5,
+            atlas_shards: self.resources.atlas_shards.len() as u32,
+            allocated_bytes: self.plan.total_bytes,
+        }
+    }
+
+    pub fn atlas_buffers(&self) -> impl ExactSizeIterator<Item = &wgpu::Buffer> {
+        self.resources.atlas_shards.iter()
+    }
+
+    pub fn metadata_buffer(&self) -> &wgpu::Buffer {
+        &self.resources.metadata
+    }
+
+    pub fn page_table_buffer(&self) -> &wgpu::Buffer {
+        &self.resources.page_table
+    }
+
+    pub fn residency_uniform_buffer(&self) -> &wgpu::Buffer {
+        &self.resources.uniform
+    }
+
+    pub fn counters_buffer(&self) -> &wgpu::Buffer {
+        &self.resources.counters
+    }
+
+    /// Residency has no size-dependent resources. A surface resize therefore
+    /// deliberately leaves every allocation and generation untouched.
+    pub fn resize(&mut self, _width: u32, _height: u32) {}
+
+    pub fn set_planet_frame(
+        &mut self,
+        queue: &wgpu::Queue,
+        frame: PlanetFrameUniform,
+    ) -> Result<FrameUpdateOutcome, GpuResidencyError> {
+        let planet = frame.planet_id();
+        let frame_number = frame.frame_number();
+        if !self.frames.contains_key(&planet)
+            && self.frames.len() == self.config.max_resident_pages as usize
+        {
+            return Err(GpuResidencyError::PlanetFrameCapacity {
+                maximum: self.config.max_resident_pages,
+            });
+        }
+        if let Some(current) = self.frames.get(&planet).copied() {
+            let current_number = current.frame_number();
+            if frame_number < current_number {
+                return Ok(FrameUpdateOutcome::Stale {
+                    newest_frame: current_number,
+                });
+            }
+            if frame_number == current_number {
+                return Ok(if current == frame {
+                    FrameUpdateOutcome::Duplicate
+                } else {
+                    FrameUpdateOutcome::FrameConflict
+                });
+            }
+        }
+
+        let previous_frame = self.frames.get(&planet).map(|value| value.frame_number());
+        let mut candidate_frames = self.frames.clone();
+        candidate_frames.insert(planet, frame);
+        let candidate_table = self.build_table(&candidate_frames)?;
+        let candidate_metadata = self.build_metadata(&candidate_frames)?;
+        self.frames = candidate_frames;
+        self.table = candidate_table;
+        self.publish_metadata(queue, &candidate_metadata, false);
+        self.publish_table(queue, false);
+        self.refresh_and_publish_counters(queue);
+        Ok(FrameUpdateOutcome::Applied { previous_frame })
+    }
+
+    /// Releases a frame only when no resident or visible page can still refer
+    /// to it. This keeps multi-planet churn bounded without invalidating GPU
+    /// addresses that are already published.
+    pub fn remove_planet_frame(&mut self, planet: PlanetId) -> Result<bool, GpuResidencyError> {
+        if self
+            .cache
+            .resident_pages()
+            .any(|(key, _)| key.planet == planet)
+            || self.visible.keys().any(|key| key.planet == planet)
+        {
+            return Err(GpuResidencyError::PlanetFrameInUse(planet));
+        }
+        Ok(self.frames.remove(&planet).is_some())
+    }
+
+    pub fn apply_upload_batch(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        uploads: Vec<PageUpload>,
+    ) -> Result<Vec<GpuUploadOutcome>, GpuResidencyError> {
+        self.check_batch_capacity(uploads.len())?;
+        let mut lookup_keys = Vec::with_capacity(uploads.len());
+        for upload in &uploads {
+            upload.validate()?;
+            lookup_keys.push(self.lookup_key(upload.key)?);
+        }
+
+        let mut dirty_slots = BTreeSet::new();
+        let mut outcomes = Vec::with_capacity(uploads.len());
+        for (upload, lookup_key) in uploads.into_iter().zip(lookup_keys) {
+            let page_key = upload.key;
+            let mut candidate_table = self.table.clone();
+            let placeholder = GpuPageTableEntry::occupied(lookup_key, 0, upload.generation);
+            if candidate_table.insert(placeholder).is_err() {
+                candidate_table.compact()?;
+                if candidate_table.insert(placeholder).is_err() {
+                    self.counters.table_saturation_events =
+                        self.counters.table_saturation_events.saturating_add(1);
+                    self.counters.backpressure_events =
+                        self.counters.backpressure_events.saturating_add(1);
+                    outcomes.push(GpuUploadOutcome::PageTableBackpressure);
+                    continue;
+                }
+            }
+
+            let outcome = self.cache.apply_upload(upload)?;
+            match &outcome {
+                UploadOutcome::Inserted { slot, evicted } => {
+                    for removed in evicted {
+                        candidate_table.remove(self.lookup_key(removed.key)?);
+                        dirty_slots.insert(removed.slot);
+                    }
+                    candidate_table.insert(GpuPageTableEntry::occupied(
+                        lookup_key,
+                        *slot,
+                        self.cache
+                            .resident(page_key)
+                            .map(|page| page.generation)
+                            .ok_or(GpuResidencyError::ResidentPageMissing)?,
+                    ))?;
+                    dirty_slots.insert(*slot);
+                    self.table = candidate_table;
+                    self.counters.uploads_published =
+                        self.counters.uploads_published.saturating_add(1);
+                }
+                UploadOutcome::Replaced { slot, .. } => {
+                    let generation = self
+                        .cache
+                        .resident(page_key)
+                        .map(|page| page.generation)
+                        .ok_or(GpuResidencyError::ResidentPageMissing)?;
+                    candidate_table
+                        .insert(GpuPageTableEntry::occupied(lookup_key, *slot, generation))?;
+                    dirty_slots.insert(*slot);
+                    self.table = candidate_table;
+                    self.counters.uploads_published =
+                        self.counters.uploads_published.saturating_add(1);
+                }
+                UploadOutcome::Stale { .. } => {
+                    self.counters.stale_rejections =
+                        self.counters.stale_rejections.saturating_add(1);
+                }
+                UploadOutcome::GenerationConflict { .. } => {
+                    self.counters.generation_conflicts =
+                        self.counters.generation_conflicts.saturating_add(1);
+                }
+                UploadOutcome::Backpressure(_) => {
+                    self.counters.backpressure_events =
+                        self.counters.backpressure_events.saturating_add(1);
+                }
+                UploadOutcome::Duplicate { .. } => {}
+            }
+            outcomes.push(GpuUploadOutcome::Residency(outcome));
+        }
+
+        // The cell-copy submission is placed on the queue before any table or
+        // metadata writes below. A later consumer submission therefore cannot
+        // observe a generation whose complete cell page is not already ahead
+        // of it on the same queue timeline.
+        self.publish_dirty_slots(device, queue, &dirty_slots)?;
+        let metadata = self.build_metadata(&self.frames)?;
+        self.publish_metadata(queue, &metadata, false);
+        self.publish_table(queue, false);
+        self.refresh_and_publish_counters(queue);
+        Ok(outcomes)
+    }
+
+    pub fn apply_evict_batch(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        evictions: Vec<PageEvict>,
+    ) -> Result<Vec<EvictOutcome>, GpuResidencyError> {
+        self.check_batch_capacity(evictions.len())?;
+        for eviction in &evictions {
+            eviction.validate()?;
+        }
+        let mut dirty_slots = BTreeSet::new();
+        let mut outcomes = Vec::with_capacity(evictions.len());
+        for eviction in evictions {
+            let outcome = self.cache.apply_evict(eviction)?;
+            match outcome {
+                EvictOutcome::Recorded { removed } => {
+                    if let Some(removed) = removed {
+                        self.table.remove(self.lookup_key(removed.key)?);
+                        dirty_slots.insert(removed.slot);
+                        self.counters.evictions_published =
+                            self.counters.evictions_published.saturating_add(1);
+                    }
+                }
+                EvictOutcome::Stale { .. } => {
+                    self.counters.stale_rejections =
+                        self.counters.stale_rejections.saturating_add(1);
+                }
+                EvictOutcome::Backpressure(_) => {
+                    self.counters.backpressure_events =
+                        self.counters.backpressure_events.saturating_add(1);
+                }
+            }
+            outcomes.push(outcome);
+        }
+        if self.table.tombstones() > self.table.occupied()
+            || self.table.tombstones() > self.table.capacity() / 4
+        {
+            self.table.compact()?;
+        }
+        // Poisoning removed slots precedes removing their discoverable table
+        // entries on the queue timeline, matching the upload publication rule.
+        self.publish_dirty_slots(device, queue, &dirty_slots)?;
+        let metadata = self.build_metadata(&self.frames)?;
+        self.publish_metadata(queue, &metadata, false);
+        self.publish_table(queue, false);
+        self.refresh_and_publish_counters(queue);
+        Ok(outcomes)
+    }
+
+    pub fn apply_visible_set(
+        &mut self,
+        queue: &wgpu::Queue,
+        set: VisiblePageSet,
+    ) -> Result<VisibilityOutcome, GpuResidencyError> {
+        set.validate(self.cache.config().max_resident_pages)?;
+        let canonical: BTreeMap<_, _> = set
+            .pages
+            .iter()
+            .map(|page| (page.key, (page.generation, page.transition_mask)))
+            .collect();
+        let outcome = self.cache.apply_visible_set(set)?;
+        if matches!(outcome, VisibilityOutcome::Applied { .. }) {
+            self.visible = canonical;
+            let metadata = self.build_metadata(&self.frames)?;
+            self.publish_metadata(queue, &metadata, false);
+        }
+        self.refresh_and_publish_counters(queue);
+        Ok(outcome)
+    }
+
+    pub fn retire_eviction_watermark(
+        &mut self,
+        key: PlanetPageKey,
+        through_generation: u64,
+    ) -> bool {
+        self.cache
+            .retire_eviction_watermark(key, through_generation)
+    }
+
+    pub fn compact_page_table(&mut self, queue: &wgpu::Queue) -> Result<(), GpuResidencyError> {
+        self.table.compact()?;
+        self.publish_table(queue, false);
+        self.refresh_and_publish_counters(queue);
+        Ok(())
+    }
+
+    pub fn recreate_gpu_resources(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+    ) -> Result<(), GpuResidencyError> {
+        let plan = self.config.allocation_plan(&device.limits())?;
+        let resources = GpuResidencyResources::new(device, &plan);
+        self.plan = plan;
+        self.resources = resources;
+        self.published_table.fill(GpuPageTableEntry::default());
+        self.published_metadata.fill(GpuPageMeta::default());
+
+        let slots: Vec<_> = self
+            .cache
+            .resident_pages()
+            .map(|(_, page)| page.slot)
+            .collect();
+        for chunk in slots.chunks(self.config.max_batch_pages as usize) {
+            let dirty_slots = chunk.iter().copied().collect();
+            self.publish_dirty_slots(device, queue, &dirty_slots)?;
+        }
+        self.counters.device_rebuilds = self.counters.device_rebuilds.saturating_add(1);
+        let metadata = self.build_metadata(&self.frames)?;
+        self.publish_metadata(queue, &metadata, true);
+        self.publish_table(queue, true);
+        self.refresh_and_publish_counters(queue);
+        Ok(())
+    }
+
+    fn check_batch_capacity(&self, actual: usize) -> Result<(), GpuResidencyError> {
+        if actual > self.config.max_batch_pages as usize {
+            return Err(GpuResidencyError::BatchCapacity {
+                actual,
+                maximum: self.config.max_batch_pages,
+            });
+        }
+        Ok(())
+    }
+
+    fn lookup_key(&self, key: PlanetPageKey) -> Result<GpuLookupKey, GpuResidencyError> {
+        let frame = self
+            .frames
+            .get(&key.planet)
+            .ok_or(GpuResidencyError::MissingPlanetFrame(key.planet))?;
+        Ok(GpuLookupKey::from_planet_page(
+            key,
+            frame.frame_origin_lod0_cell(),
+        )?)
+    }
+
+    fn build_table(
+        &self,
+        frames: &BTreeMap<PlanetId, PlanetFrameUniform>,
+    ) -> Result<PageTable, GpuResidencyError> {
+        let mut table = PageTable::new(self.config.table_capacity, self.config.max_probe)?;
+        for (key, page) in self.cache.resident_pages() {
+            let frame = frames
+                .get(&key.planet)
+                .ok_or(GpuResidencyError::MissingPlanetFrame(key.planet))?;
+            let lookup = GpuLookupKey::from_planet_page(key, frame.frame_origin_lod0_cell())?;
+            table.insert(GpuPageTableEntry::occupied(
+                lookup,
+                page.slot,
+                page.generation,
+            ))?;
+        }
+        Ok(table)
+    }
+
+    fn build_metadata(
+        &self,
+        frames: &BTreeMap<PlanetId, PlanetFrameUniform>,
+    ) -> Result<Vec<GpuPageMeta>, GpuResidencyError> {
+        let mut metadata = vec![GpuPageMeta::default(); self.config.max_resident_pages as usize];
+        for (key, page) in self.cache.resident_pages() {
+            let frame = frames
+                .get(&key.planet)
+                .ok_or(GpuResidencyError::MissingPlanetFrame(key.planet))?;
+            let transition_mask = self
+                .visible
+                .get(&key)
+                .filter(|(generation, _)| *generation == page.generation)
+                .map_or(0, |(_, mask)| *mask);
+            metadata[page.slot as usize] = GpuPageMeta::new(
+                key.page,
+                frame.frame_origin_lod0_cell(),
+                page.slot,
+                page.generation,
+                transition_mask,
+            )?;
+        }
+        Ok(metadata)
+    }
+
+    fn publish_dirty_slots(
+        &mut self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        dirty_slots: &BTreeSet<u32>,
+    ) -> Result<(), GpuResidencyError> {
+        if dirty_slots.is_empty() {
+            return Ok(());
+        }
+        if dirty_slots.len() > self.config.max_batch_pages as usize {
+            return Err(GpuResidencyError::DirtySlotCapacity {
+                actual: dirty_slots.len(),
+                maximum: self.config.max_batch_pages,
+            });
+        }
+
+        let mut cells = Vec::with_capacity(dirty_slots.len() * PAGE_CELL_COUNT);
+        let pages_by_slot: BTreeMap<_, _> = self
+            .cache
+            .resident_pages()
+            .map(|(_, page)| (page.slot, page.cells.as_ref()))
+            .collect();
+        for slot in dirty_slots {
+            if let Some(page_cells) = pages_by_slot.get(slot) {
+                cells.extend_from_slice(page_cells);
+            } else {
+                cells.resize(cells.len() + PAGE_CELL_COUNT, CellWord::AIR);
+            }
+        }
+        queue.write_buffer(&self.resources.staging, 0, bytemuck::cast_slice(&cells));
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Planetary Voxel Cell Publish"),
+        });
+        for (staging_page, slot) in dirty_slots.iter().enumerate() {
+            let (shard, destination_offset) = self
+                .plan
+                .shard_for_slot(*slot)
+                .ok_or(GpuResidencyError::InvalidSlot(*slot))?;
+            encoder.copy_buffer_to_buffer(
+                &self.resources.staging,
+                staging_page as u64 * PAGE_CELL_BYTES as u64,
+                &self.resources.atlas_shards[shard],
+                destination_offset,
+                PAGE_CELL_BYTES as u64,
+            );
+        }
+        queue.submit([encoder.finish()]);
+        self.counters.batches_submitted = self.counters.batches_submitted.saturating_add(1);
+        self.cell_bytes_uploaded = self
+            .cell_bytes_uploaded
+            .saturating_add((dirty_slots.len() as u64).saturating_mul(PAGE_CELL_BYTES as u64));
+        Ok(())
+    }
+
+    fn publish_state(
+        &mut self,
+        queue: &wgpu::Queue,
+        force_all: bool,
+    ) -> Result<(), GpuResidencyError> {
+        let metadata = self.build_metadata(&self.frames)?;
+        self.publish_metadata(queue, &metadata, force_all);
+        self.publish_table(queue, force_all);
+        self.refresh_and_publish_counters(queue);
+        Ok(())
+    }
+
+    fn publish_metadata(&mut self, queue: &wgpu::Queue, new: &[GpuPageMeta], force_all: bool) {
+        write_changed_ranges(
+            queue,
+            &self.resources.metadata,
+            &mut self.published_metadata,
+            new,
+            force_all,
+        );
+    }
+
+    fn publish_table(&mut self, queue: &wgpu::Queue, force_all: bool) {
+        write_changed_ranges(
+            queue,
+            &self.resources.page_table,
+            &mut self.published_table,
+            self.table.entries(),
+            force_all,
+        );
+    }
+
+    fn refresh_and_publish_counters(&mut self, queue: &wgpu::Queue) {
+        let cache = self.cache.counters();
+        self.counters.resident_pages = saturating_u32(cache.resident_pages as u64);
+        let resident_bytes = cache.resident_cell_bytes as u64;
+        self.counters.resident_cell_bytes_low = resident_bytes as u32;
+        self.counters.resident_cell_bytes_high = (resident_bytes >> 32) as u32;
+        self.counters.table_occupied = self.table.occupied();
+        self.counters.table_tombstones = self.table.tombstones();
+        self.counters.cell_bytes_uploaded_low = self.cell_bytes_uploaded as u32;
+        self.counters.cell_bytes_uploaded_high = (self.cell_bytes_uploaded >> 32) as u32;
+        self.counters.peak_resident_pages = saturating_u32(cache.peak_resident_pages as u64);
+        let peak_bytes = cache.peak_resident_cell_bytes as u64;
+        self.counters.peak_resident_cell_bytes_low = peak_bytes as u32;
+        self.counters.peak_resident_cell_bytes_high = (peak_bytes >> 32) as u32;
+        self.counters.allocated_gpu_bytes_low = self.plan.total_bytes as u32;
+        self.counters.allocated_gpu_bytes_high = (self.plan.total_bytes >> 32) as u32;
+        self.counters.resource_buffers = self.resources.atlas_shards.len() as u32 + 5;
+        self.counters.atlas_shards = self.resources.atlas_shards.len() as u32;
+
+        let uniform = GpuResidencyUniform {
+            table_mask: self.table.capacity() - 1,
+            max_probe: self.table.max_probe(),
+            resident_pages: self.counters.resident_pages,
+            _pad: 0,
+        };
+        queue.write_buffer(&self.resources.uniform, 0, bytemuck::bytes_of(&uniform));
+        queue.write_buffer(
+            &self.resources.counters,
+            0,
+            bytemuck::bytes_of(&self.counters),
+        );
+    }
+}
+
+struct GpuResidencyResources {
+    atlas_shards: Vec<wgpu::Buffer>,
+    metadata: wgpu::Buffer,
+    page_table: wgpu::Buffer,
+    staging: wgpu::Buffer,
+    uniform: wgpu::Buffer,
+    counters: wgpu::Buffer,
+}
+
+impl GpuResidencyResources {
+    fn new(device: &wgpu::Device, plan: &GpuAllocationPlan) -> Self {
+        let atlas_shards = plan
+            .shards
+            .iter()
+            .enumerate()
+            .map(|(index, shard)| {
+                device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some(&format!("Planetary Voxel Cell Atlas Shard {index}")),
+                    size: shard.size_bytes,
+                    usage: wgpu::BufferUsages::STORAGE
+                        | wgpu::BufferUsages::COPY_DST
+                        | wgpu::BufferUsages::COPY_SRC,
+                    mapped_at_creation: false,
+                })
+            })
+            .collect();
+        Self {
+            atlas_shards,
+            metadata: create_buffer(
+                device,
+                "Planetary Voxel Page Metadata",
+                plan.metadata_bytes,
+                wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+            ),
+            page_table: create_buffer(
+                device,
+                "Planetary Voxel Page Table",
+                plan.page_table_bytes,
+                wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+            ),
+            staging: create_buffer(
+                device,
+                "Planetary Voxel Upload Staging",
+                plan.staging_bytes,
+                wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            ),
+            uniform: create_buffer(
+                device,
+                "Planetary Voxel Residency Uniform",
+                core::mem::size_of::<GpuResidencyUniform>() as u64,
+                wgpu::BufferUsages::UNIFORM
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+            ),
+            counters: create_buffer(
+                device,
+                "Planetary Voxel Residency Counters",
+                core::mem::size_of::<GpuResidencyCounters>() as u64,
+                wgpu::BufferUsages::STORAGE
+                    | wgpu::BufferUsages::COPY_DST
+                    | wgpu::BufferUsages::COPY_SRC,
+            ),
+        }
+    }
+}
+
+fn create_buffer(
+    device: &wgpu::Device,
+    label: &'static str,
+    size: u64,
+    usage: wgpu::BufferUsages,
+) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some(label),
+        size,
+        usage,
+        mapped_at_creation: false,
+    })
+}
+
+fn write_changed_ranges<T: bytemuck::Pod + PartialEq + Copy>(
+    queue: &wgpu::Queue,
+    buffer: &wgpu::Buffer,
+    published: &mut [T],
+    current: &[T],
+    force_all: bool,
+) {
+    debug_assert_eq!(published.len(), current.len());
+    if current.is_empty() {
+        return;
+    }
+    if force_all {
+        queue.write_buffer(buffer, 0, bytemuck::cast_slice(current));
+        published.copy_from_slice(current);
+        return;
+    }
+
+    let element_bytes = core::mem::size_of::<T>() as u64;
+    let mut start = 0;
+    while start < current.len() {
+        while start < current.len() && published[start] == current[start] {
+            start += 1;
+        }
+        if start == current.len() {
+            break;
+        }
+        let mut end = start + 1;
+        while end < current.len() && published[end] != current[end] {
+            end += 1;
+        }
+        queue.write_buffer(
+            buffer,
+            start as u64 * element_bytes,
+            bytemuck::cast_slice(&current[start..end]),
+        );
+        published[start..end].copy_from_slice(&current[start..end]);
+        start = end;
+    }
+}
+
+fn saturating_u32(value: u64) -> u32 {
+    u32::try_from(value).unwrap_or(u32::MAX)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum GpuResidencyError {
+    #[error(transparent)]
+    Config(#[from] GpuConfigError),
+    #[error(transparent)]
+    PageTable(#[from] PageTableError),
+    #[error(transparent)]
+    Contract(#[from] ContractError),
+    #[error(transparent)]
+    Address(#[from] AddressError),
+    #[error(transparent)]
+    Metadata(#[from] GpuPageMetaError),
+    #[error("planet {0:?} has no registered camera-local frame")]
+    MissingPlanetFrame(PlanetId),
+    #[error("planet-frame registry reached its bounded capacity of {maximum}")]
+    PlanetFrameCapacity { maximum: u32 },
+    #[error("planet frame {0:?} is still referenced by resident or visible pages")]
+    PlanetFrameInUse(PlanetId),
+    #[error("batch has {actual} pages; staging capacity is {maximum}")]
+    BatchCapacity { actual: usize, maximum: u32 },
+    #[error("batch dirtied {actual} slots; staging capacity is {maximum}")]
+    DirtySlotCapacity { actual: usize, maximum: u32 },
+    #[error("page slot {0} is outside the configured atlas")]
+    InvalidSlot(u32),
+    #[error("resident page disappeared while publishing a validated update")]
+    ResidentPageMissing,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_narrowing_saturates() {
+        assert_eq!(saturating_u32(u64::MAX), u32::MAX);
+        assert_eq!(saturating_u32(7), 7);
+    }
+
+    #[test]
+    fn upload_outcome_keeps_core_backpressure_reason_typed() {
+        let outcome = GpuUploadOutcome::Residency(UploadOutcome::Backpressure(
+            helio_planet_voxel_core::BackpressureReason::AllEvictionCandidatesVisible,
+        ));
+        assert!(matches!(
+            outcome,
+            GpuUploadOutcome::Residency(UploadOutcome::Backpressure(
+                helio_planet_voxel_core::BackpressureReason::AllEvictionCandidatesVisible
+            ))
+        ));
+    }
+}

--- a/crates/helio-pass-planetary-voxel/src/lib.rs
+++ b/crates/helio-pass-planetary-voxel/src/lib.rs
@@ -1,0 +1,16 @@
+//! Bounded GPU residency for the production planetary voxel path.
+//!
+//! This crate is opt-in and is not registered in Helio's default graph. The
+//! current milestone owns only shared page buffers, lookup tables, update
+//! ordering, lifecycle rebuilds, and validation. Surface extraction and draws
+//! are deliberately separate promotion gates.
+
+mod config;
+mod gpu;
+mod table;
+
+pub use config::*;
+pub use gpu::*;
+pub use table::*;
+
+pub const RESIDENCY_WGSL: &str = include_str!("residency.wgsl");

--- a/crates/helio-pass-planetary-voxel/src/residency.wgsl
+++ b/crates/helio-pass-planetary-voxel/src/residency.wgsl
@@ -1,0 +1,123 @@
+const PAGE_TABLE_EMPTY: u32 = 0u;
+const PAGE_TABLE_OCCUPIED: u32 = 1u;
+
+struct GpuPageTableEntry {
+    planet_id: vec4<u32>,
+    relative_lod0_cell_min: vec3<i32>,
+    lod: u32,
+    slot: u32,
+    generation_low: u32,
+    generation_high: u32,
+    state: u32,
+};
+
+struct GpuResidencyUniform {
+    table_mask: u32,
+    max_probe: u32,
+    resident_pages: u32,
+    _pad: u32,
+};
+
+struct GpuResidencyCounters {
+    resident_pages: u32,
+    resident_cell_bytes_low: u32,
+    resident_cell_bytes_high: u32,
+    table_occupied: u32,
+    table_tombstones: u32,
+    uploads_published: u32,
+    evictions_published: u32,
+    stale_rejections: u32,
+    generation_conflicts: u32,
+    backpressure_events: u32,
+    table_saturation_events: u32,
+    batches_submitted: u32,
+    cell_bytes_uploaded_low: u32,
+    cell_bytes_uploaded_high: u32,
+    peak_resident_pages: u32,
+    peak_resident_cell_bytes_low: u32,
+    peak_resident_cell_bytes_high: u32,
+    allocated_gpu_bytes_low: u32,
+    allocated_gpu_bytes_high: u32,
+    resource_buffers: u32,
+    atlas_shards: u32,
+    device_rebuilds: u32,
+    _pad: vec2<u32>,
+};
+
+struct GpuLookupQuery {
+    planet_id: vec4<u32>,
+    relative_lod0_cell_min: vec3<i32>,
+    lod: u32,
+};
+
+struct GpuLookupResult {
+    slot: u32,
+    generation_low: u32,
+    generation_high: u32,
+    probes_and_found: u32,
+};
+
+@group(0) @binding(0)
+var<storage, read> page_table: array<GpuPageTableEntry>;
+@group(0) @binding(1)
+var<uniform> residency: GpuResidencyUniform;
+@group(0) @binding(2)
+var<storage, read> queries: array<GpuLookupQuery>;
+@group(0) @binding(3)
+var<storage, read_write> results: array<GpuLookupResult>;
+
+fn mix_hash(hash: u32, value: u32) -> u32 {
+    let mixed = (hash ^ value) * 0x045d9f3bu;
+    return mixed ^ (mixed >> 16u);
+}
+
+fn page_hash(query: GpuLookupQuery) -> u32 {
+    var hash = 0x811c9dc5u;
+    hash = mix_hash(hash, query.planet_id.x);
+    hash = mix_hash(hash, query.planet_id.y);
+    hash = mix_hash(hash, query.planet_id.z);
+    hash = mix_hash(hash, query.planet_id.w);
+    hash = mix_hash(hash, bitcast<u32>(query.relative_lod0_cell_min.x));
+    hash = mix_hash(hash, bitcast<u32>(query.relative_lod0_cell_min.y));
+    hash = mix_hash(hash, bitcast<u32>(query.relative_lod0_cell_min.z));
+    return mix_hash(hash, query.lod);
+}
+
+fn keys_equal(entry: GpuPageTableEntry, query: GpuLookupQuery) -> bool {
+    return all(entry.planet_id == query.planet_id)
+        && all(entry.relative_lod0_cell_min == query.relative_lod0_cell_min)
+        && entry.lod == query.lod;
+}
+
+fn lookup_page(query: GpuLookupQuery) -> GpuLookupResult {
+    let start = page_hash(query) & residency.table_mask;
+    var probe = 0u;
+    loop {
+        if (probe >= residency.max_probe) {
+            break;
+        }
+        let entry = page_table[(start + probe) & residency.table_mask];
+        if (entry.state == PAGE_TABLE_EMPTY) {
+            return GpuLookupResult(0u, 0u, 0u, probe + 1u);
+        }
+        if (entry.state == PAGE_TABLE_OCCUPIED && keys_equal(entry, query)) {
+            return GpuLookupResult(
+                entry.slot,
+                entry.generation_low,
+                entry.generation_high,
+                0x80000000u | (probe + 1u),
+            );
+        }
+        probe += 1u;
+    }
+    return GpuLookupResult(0u, 0u, 0u, probe);
+}
+
+@compute @workgroup_size(64)
+fn validate_lookup(@builtin(global_invocation_id) invocation: vec3<u32>) {
+    let index = invocation.x;
+    if (index >= arrayLength(&queries) || index >= arrayLength(&results)) {
+        return;
+    }
+    results[index] = lookup_page(queries[index]);
+}

--- a/crates/helio-pass-planetary-voxel/src/table.rs
+++ b/crates/helio-pass-planetary-voxel/src/table.rs
@@ -1,0 +1,456 @@
+use bytemuck::{Pod, Zeroable};
+use helio_planet_voxel_core::{AddressError, PageKey, PlanetId, PlanetPageKey};
+
+pub const PAGE_TABLE_EMPTY: u32 = 0;
+pub const PAGE_TABLE_OCCUPIED: u32 = 1;
+pub const PAGE_TABLE_TOMBSTONE: u32 = 2;
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuPageTableEntry {
+    pub planet_id: [u32; 4],
+    pub relative_lod0_cell_min: [i32; 3],
+    pub lod: u32,
+    pub slot: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub state: u32,
+}
+
+impl GpuPageTableEntry {
+    pub fn occupied(key: GpuLookupKey, slot: u32, generation: u64) -> GpuPageTableEntry {
+        Self {
+            planet_id: key.planet_id,
+            relative_lod0_cell_min: key.relative_lod0_cell_min,
+            lod: key.lod,
+            slot,
+            generation_low: generation as u32,
+            generation_high: (generation >> 32) as u32,
+            state: PAGE_TABLE_OCCUPIED,
+        }
+    }
+
+    pub const fn tombstone() -> Self {
+        Self {
+            planet_id: [0; 4],
+            relative_lod0_cell_min: [0; 3],
+            lod: 0,
+            slot: 0,
+            generation_low: 0,
+            generation_high: 0,
+            state: PAGE_TABLE_TOMBSTONE,
+        }
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+
+    pub const fn key(self) -> GpuLookupKey {
+        GpuLookupKey {
+            planet_id: self.planet_id,
+            relative_lod0_cell_min: self.relative_lod0_cell_min,
+            lod: self.lod,
+        }
+    }
+
+    pub const fn is_occupied(self) -> bool {
+        self.state == PAGE_TABLE_OCCUPIED
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuResidencyUniform {
+    pub table_mask: u32,
+    pub max_probe: u32,
+    pub resident_pages: u32,
+    pub _pad: u32,
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuResidencyCounters {
+    pub resident_pages: u32,
+    pub resident_cell_bytes_low: u32,
+    pub resident_cell_bytes_high: u32,
+    pub table_occupied: u32,
+    pub table_tombstones: u32,
+    pub uploads_published: u32,
+    pub evictions_published: u32,
+    pub stale_rejections: u32,
+    pub generation_conflicts: u32,
+    pub backpressure_events: u32,
+    pub table_saturation_events: u32,
+    pub batches_submitted: u32,
+    pub cell_bytes_uploaded_low: u32,
+    pub cell_bytes_uploaded_high: u32,
+    pub peak_resident_pages: u32,
+    pub peak_resident_cell_bytes_low: u32,
+    pub peak_resident_cell_bytes_high: u32,
+    pub allocated_gpu_bytes_low: u32,
+    pub allocated_gpu_bytes_high: u32,
+    pub resource_buffers: u32,
+    pub atlas_shards: u32,
+    pub device_rebuilds: u32,
+    pub _pad: [u32; 2],
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuLookupQuery {
+    pub planet_id: [u32; 4],
+    pub relative_lod0_cell_min: [i32; 3],
+    pub lod: u32,
+}
+
+impl From<GpuLookupKey> for GpuLookupQuery {
+    fn from(key: GpuLookupKey) -> Self {
+        Self {
+            planet_id: key.planet_id,
+            relative_lod0_cell_min: key.relative_lod0_cell_min,
+            lod: key.lod,
+        }
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuLookupResult {
+    pub slot: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub probes_and_found: u32,
+}
+
+impl GpuLookupResult {
+    pub const fn found(self) -> bool {
+        self.probes_and_found & 0x8000_0000 != 0
+    }
+
+    pub const fn probes(self) -> u32 {
+        self.probes_and_found & 0x7fff_ffff
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct GpuLookupKey {
+    pub planet_id: [u32; 4],
+    pub relative_lod0_cell_min: [i32; 3],
+    pub lod: u32,
+}
+
+impl GpuLookupKey {
+    pub fn from_planet_page(
+        key: PlanetPageKey,
+        frame_origin_lod0_cell: [i64; 3],
+    ) -> Result<Self, AddressError> {
+        Ok(Self {
+            planet_id: planet_words(key.planet),
+            relative_lod0_cell_min: key.page.relative_lod0_cell_min(frame_origin_lod0_cell)?,
+            lod: u32::from(key.page.lod),
+        })
+    }
+
+    pub fn from_parts(
+        planet: PlanetId,
+        page: PageKey,
+        frame_origin_lod0_cell: [i64; 3],
+    ) -> Result<Self, AddressError> {
+        Self::from_planet_page(PlanetPageKey::new(planet, page), frame_origin_lod0_cell)
+    }
+
+    pub fn hash(self) -> u32 {
+        let mut hash = 0x811c_9dc5;
+        for value in self
+            .planet_id
+            .into_iter()
+            .chain(self.relative_lod0_cell_min.map(|value| value as u32))
+            .chain([self.lod])
+        {
+            hash = mix_hash(hash, value);
+        }
+        hash
+    }
+}
+
+pub const fn mix_hash(hash: u32, value: u32) -> u32 {
+    let mut mixed = hash ^ value;
+    mixed = mixed.wrapping_mul(0x045d_9f3b);
+    mixed ^ (mixed >> 16)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PageTable {
+    entries: Vec<GpuPageTableEntry>,
+    max_probe: u32,
+    occupied: u32,
+    tombstones: u32,
+}
+
+impl PageTable {
+    pub fn new(capacity: u32, max_probe: u32) -> Result<Self, PageTableError> {
+        if !capacity.is_power_of_two() {
+            return Err(PageTableError::CapacityNotPowerOfTwo(capacity));
+        }
+        if max_probe == 0 || max_probe > capacity {
+            return Err(PageTableError::InvalidMaxProbe {
+                max_probe,
+                capacity,
+            });
+        }
+        Ok(Self {
+            entries: vec![GpuPageTableEntry::default(); capacity as usize],
+            max_probe,
+            occupied: 0,
+            tombstones: 0,
+        })
+    }
+
+    pub fn entries(&self) -> &[GpuPageTableEntry] {
+        &self.entries
+    }
+
+    pub fn capacity(&self) -> u32 {
+        self.entries.len() as u32
+    }
+
+    pub fn max_probe(&self) -> u32 {
+        self.max_probe
+    }
+
+    pub fn occupied(&self) -> u32 {
+        self.occupied
+    }
+
+    pub fn tombstones(&self) -> u32 {
+        self.tombstones
+    }
+
+    pub fn can_insert(&self, key: GpuLookupKey) -> bool {
+        matches!(
+            self.find_slot(key),
+            ProbeResult::Found(_) | ProbeResult::Vacant(_)
+        )
+    }
+
+    pub fn insert(&mut self, entry: GpuPageTableEntry) -> Result<u32, PageTableError> {
+        if !entry.is_occupied() {
+            return Err(PageTableError::EntryNotOccupied(entry.state));
+        }
+        match self.find_slot(entry.key()) {
+            ProbeResult::Found(index) => {
+                self.entries[index as usize] = entry;
+                Ok(index)
+            }
+            ProbeResult::Vacant(index) => {
+                if self.entries[index as usize].state == PAGE_TABLE_TOMBSTONE {
+                    self.tombstones -= 1;
+                }
+                self.entries[index as usize] = entry;
+                self.occupied += 1;
+                Ok(index)
+            }
+            ProbeResult::Saturated => Err(PageTableError::ProbeSaturated {
+                hash: entry.key().hash(),
+                max_probe: self.max_probe,
+            }),
+        }
+    }
+
+    pub fn remove(&mut self, key: GpuLookupKey) -> Option<GpuPageTableEntry> {
+        let ProbeResult::Found(index) = self.find_slot(key) else {
+            return None;
+        };
+        let removed = self.entries[index as usize];
+        self.entries[index as usize] = GpuPageTableEntry::tombstone();
+        self.occupied -= 1;
+        self.tombstones += 1;
+        Some(removed)
+    }
+
+    pub fn lookup(&self, key: GpuLookupKey) -> Option<(u32, GpuPageTableEntry)> {
+        let ProbeResult::Found(index) = self.find_slot(key) else {
+            return None;
+        };
+        Some((index, self.entries[index as usize]))
+    }
+
+    pub fn compact(&mut self) -> Result<(), PageTableError> {
+        let occupied: Vec<_> = self
+            .entries
+            .iter()
+            .copied()
+            .filter(|entry| entry.is_occupied())
+            .collect();
+        let mut rebuilt = Self::new(self.capacity(), self.max_probe)?;
+        for entry in occupied {
+            rebuilt.insert(entry)?;
+        }
+        *self = rebuilt;
+        Ok(())
+    }
+
+    fn find_slot(&self, key: GpuLookupKey) -> ProbeResult {
+        let mask = self.capacity() - 1;
+        let start = key.hash() & mask;
+        let mut first_tombstone = None;
+        for probe in 0..self.max_probe {
+            let index = start.wrapping_add(probe) & mask;
+            let entry = self.entries[index as usize];
+            match entry.state {
+                PAGE_TABLE_EMPTY => {
+                    return ProbeResult::Vacant(first_tombstone.unwrap_or(index));
+                }
+                PAGE_TABLE_TOMBSTONE if first_tombstone.is_none() => {
+                    first_tombstone = Some(index);
+                }
+                PAGE_TABLE_OCCUPIED if entry.key() == key => {
+                    return ProbeResult::Found(index);
+                }
+                _ => {}
+            }
+        }
+        first_tombstone.map_or(ProbeResult::Saturated, ProbeResult::Vacant)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProbeResult {
+    Found(u32),
+    Vacant(u32),
+    Saturated,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PageTableError {
+    #[error("page table capacity {0} must be a non-zero power of two")]
+    CapacityNotPowerOfTwo(u32),
+    #[error("maximum probe count {max_probe} must be within 1..={capacity}")]
+    InvalidMaxProbe { max_probe: u32, capacity: u32 },
+    #[error("page table insertion requires occupied state, got {0}")]
+    EntryNotOccupied(u32),
+    #[error("page table probe saturated for hash {hash:#010x} after {max_probe} probes")]
+    ProbeSaturated { hash: u32, max_probe: u32 },
+}
+
+fn planet_words(planet: PlanetId) -> [u32; 4] {
+    let mut words = [0_u32; 4];
+    for (word, bytes) in words.iter_mut().zip(planet.0.chunks_exact(4)) {
+        *word = u32::from_le_bytes(bytes.try_into().expect("four-byte chunk"));
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(index: i32) -> GpuLookupKey {
+        GpuLookupKey {
+            planet_id: [1, 2, 3, 4],
+            relative_lod0_cell_min: [index, -index, index.wrapping_mul(17)],
+            lod: index.unsigned_abs() % 8,
+        }
+    }
+
+    #[test]
+    fn signed_multi_planet_keys_do_not_false_hit() {
+        let mut table = PageTable::new(32, 32).unwrap();
+        for index in -8..8 {
+            let lookup = key(index);
+            table
+                .insert(GpuPageTableEntry::occupied(
+                    lookup,
+                    (index + 8) as u32,
+                    index.unsigned_abs() as u64 + 10,
+                ))
+                .unwrap();
+        }
+        for index in -8..8 {
+            let (_, entry) = table.lookup(key(index)).unwrap();
+            assert_eq!(entry.slot, (index + 8) as u32);
+        }
+        let mut other_planet = key(2);
+        other_planet.planet_id[3] ^= 1;
+        assert_eq!(table.lookup(other_planet), None);
+    }
+
+    #[test]
+    fn tombstones_keep_probe_chains_and_are_reused() {
+        let mut collision = None;
+        'outer: for first in -200..200 {
+            for second in first + 1..200 {
+                if key(first).hash() & 7 == key(second).hash() & 7 {
+                    collision = Some((key(first), key(second)));
+                    break 'outer;
+                }
+            }
+        }
+        let (first, second) = collision.unwrap();
+        let mut table = PageTable::new(8, 8).unwrap();
+        table
+            .insert(GpuPageTableEntry::occupied(first, 1, 1))
+            .unwrap();
+        table
+            .insert(GpuPageTableEntry::occupied(second, 2, 2))
+            .unwrap();
+        table.remove(first).unwrap();
+        assert_eq!(table.lookup(second).unwrap().1.slot, 2);
+        table
+            .insert(GpuPageTableEntry::occupied(first, 3, 3))
+            .unwrap();
+        assert_eq!(table.tombstones(), 0);
+        assert_eq!(table.lookup(first).unwrap().1.slot, 3);
+    }
+
+    #[test]
+    fn bounded_probe_reports_saturation_without_mutation() {
+        let mut same_bucket = Vec::new();
+        for index in -10_000..10_000 {
+            let candidate = key(index);
+            if candidate.hash() & 15 == 0 {
+                same_bucket.push(candidate);
+                if same_bucket.len() == 3 {
+                    break;
+                }
+            }
+        }
+        let mut table = PageTable::new(16, 2).unwrap();
+        for (slot, lookup) in same_bucket.iter().take(2).enumerate() {
+            table
+                .insert(GpuPageTableEntry::occupied(*lookup, slot as u32, 1))
+                .unwrap();
+        }
+        assert!(!table.can_insert(same_bucket[2]));
+        let before = table.clone();
+        assert!(matches!(
+            table.insert(GpuPageTableEntry::occupied(same_bucket[2], 9, 1)),
+            Err(PageTableError::ProbeSaturated { .. })
+        ));
+        assert_eq!(table, before);
+    }
+
+    #[test]
+    fn compaction_removes_tombstones_without_losing_entries() {
+        let mut table = PageTable::new(32, 32).unwrap();
+        for index in 0..12 {
+            table
+                .insert(GpuPageTableEntry::occupied(key(index), index as u32, 4))
+                .unwrap();
+        }
+        for index in [1, 3, 5, 7] {
+            table.remove(key(index)).unwrap();
+        }
+        assert_eq!(table.tombstones(), 4);
+        table.compact().unwrap();
+        assert_eq!(table.tombstones(), 0);
+        for index in [0, 2, 4, 6, 8, 9, 10, 11] {
+            assert!(table.lookup(key(index)).is_some());
+        }
+    }
+}

--- a/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
@@ -15,7 +15,9 @@ use wgpu::util::DeviceExt;
 #[test]
 fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
     pollster::block_on(async {
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let instance = wgpu::Instance::new(
+            wgpu::InstanceDescriptor::new_without_display_handle(),
+        );
         let adapter = request_test_adapter(&instance).await;
         let Some(adapter) = adapter else {
             eprintln!(
@@ -352,6 +354,7 @@ async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter
                 power_preference: wgpu::PowerPreference::HighPerformance,
                 compatible_surface: None,
                 force_fallback_adapter,
+                apply_limit_buckets: false,
             })
             .await
         {
@@ -463,7 +466,9 @@ fn read_buffer_range<T: Pod + Copy>(
     rx.recv()
         .expect("GPU readback callback must run")
         .expect("GPU readback mapping must succeed");
-    let mapped = slice.get_mapped_range();
+    let mapped = slice
+        .get_mapped_range()
+        .expect("GPU readback range must be available");
     let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
     drop(mapped);
     readback.unmap();

--- a/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
@@ -1,0 +1,475 @@
+use bytemuck::Pod;
+use helio_pass_planetary_voxel::{
+    FrameUpdateOutcome, GpuLookupKey, GpuLookupQuery, GpuLookupResult, GpuResidencyCounters,
+    GpuResidencyError, GpuUploadOutcome, PlanetaryVoxelGpuConfig, PlanetaryVoxelResidency,
+    RESIDENCY_WGSL,
+};
+use helio_planet_voxel_core::{
+    CellWord, EvictOutcome, GpuPageMeta, PageEvict, PageKey, PageUpload, PlanetFrameUniform,
+    PlanetId, PlanetPageKey, UploadOutcome, VisiblePage, VisiblePageSet, PAGE_CELL_BYTES,
+    PAGE_CELL_COUNT,
+};
+use std::sync::mpsc;
+use wgpu::util::DeviceExt;
+
+#[test]
+fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::default());
+        let adapter = request_test_adapter(&instance).await;
+        let Some(adapter) = adapter else {
+            eprintln!(
+                "GPU_VALIDATION_SKIPPED_NO_ADAPTER: no primary or fallback adapter available"
+            );
+            return;
+        };
+        let adapter_info = adapter.get_info();
+        eprintln!(
+            "GPU_VALIDATION_ADAPTER: name={:?} backend={:?} device_type={:?}",
+            adapter_info.name, adapter_info.backend, adapter_info.device_type
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planetary Voxel Residency Test Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a validation device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("planetary voxel GPU validation error: {error:?}");
+        }));
+
+        let config = PlanetaryVoxelGpuConfig::new(4, 16, 16, 4, 8, 4).unwrap();
+        let mut residency = PlanetaryVoxelResidency::new(&device, &queue, config).unwrap();
+        let initial_resources = residency.resource_stats();
+        assert_eq!(
+            initial_resources.buffers,
+            initial_resources.atlas_shards + 5
+        );
+
+        let planet_a = PlanetId([0x11; 16]);
+        let planet_b = PlanetId([0x82; 16]);
+        let key_a = PlanetPageKey::new(planet_a, PageKey::new(0, [-2, 1, -3]));
+        let key_b = PlanetPageKey::new(planet_b, PageKey::new(2, [3, -4, 5]));
+        residency
+            .set_planet_frame(
+                &queue,
+                PlanetFrameUniform::new(planet_a, [0; 3], [0.25, -1.0, 2.0], 1).unwrap(),
+            )
+            .unwrap();
+        residency
+            .set_planet_frame(
+                &queue,
+                PlanetFrameUniform::new(planet_b, [0; 3], [-2.0, 3.0, 1.0], 1).unwrap(),
+            )
+            .unwrap();
+
+        let cell_a = CellWord::new(-120, 7, 3);
+        let cell_b = CellWord::new(-8, 19, 1);
+        let outcomes = residency
+            .apply_upload_batch(
+                &device,
+                &queue,
+                vec![upload(key_a, 9, cell_a), upload(key_b, 11, cell_b)],
+            )
+            .unwrap();
+        assert!(matches!(
+            outcomes.as_slice(),
+            [
+                GpuUploadOutcome::Residency(UploadOutcome::Inserted { slot: 0, .. }),
+                GpuUploadOutcome::Residency(UploadOutcome::Inserted { slot: 1, .. })
+            ]
+        ));
+
+        assert!(matches!(
+            residency
+                .apply_upload_batch(&device, &queue, vec![upload(key_a, 8, CellWord::AIR)])
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(UploadOutcome::Stale {
+                newest_generation: 9
+            })]
+        ));
+        assert_eq!(
+            residency
+                .apply_evict_batch(
+                    &device,
+                    &queue,
+                    vec![PageEvict {
+                        key: key_a,
+                        generation: 8,
+                    }],
+                )
+                .unwrap(),
+            vec![EvictOutcome::Recorded { removed: None }]
+        );
+        assert_eq!(residency.cache().resident(key_a).unwrap().generation, 9);
+
+        assert!(matches!(
+            residency.apply_upload_batch(
+                &device,
+                &queue,
+                (0..5)
+                    .map(|index| {
+                        upload(
+                            PlanetPageKey::new(planet_a, PageKey::new(0, [index, 0, 0])),
+                            1,
+                            CellWord::AIR,
+                        )
+                    })
+                    .collect(),
+            ),
+            Err(GpuResidencyError::BatchCapacity {
+                actual: 5,
+                maximum: 4
+            })
+        ));
+        assert_eq!(residency.cache().counters().resident_pages, 2);
+
+        assert!(matches!(
+            residency.set_planet_frame(
+                &queue,
+                PlanetFrameUniform::new(planet_a, [0; 3], [9.0, 0.0, 0.0], 1).unwrap(),
+            ),
+            Ok(FrameUpdateOutcome::FrameConflict)
+        ));
+        let outside_origin = [i64::from(i32::MAX).div_euclid(32) * 32 + 32, 0, 0];
+        assert!(matches!(
+            residency.set_planet_frame(
+                &queue,
+                PlanetFrameUniform::new(planet_a, outside_origin, [0.0; 3], 2).unwrap(),
+            ),
+            Err(GpuResidencyError::Address(_))
+        ));
+        assert!(matches!(
+            residency.set_planet_frame(
+                &queue,
+                PlanetFrameUniform::new(planet_a, [32, 0, 0], [0.0; 3], 2).unwrap(),
+            ),
+            Ok(FrameUpdateOutcome::Applied {
+                previous_frame: Some(1)
+            })
+        ));
+        residency
+            .apply_visible_set(
+                &queue,
+                VisiblePageSet {
+                    frame_index: 3,
+                    pages: vec![VisiblePage {
+                        key: key_a,
+                        generation: 9,
+                        transition_mask: 0b10_0101,
+                    }],
+                },
+            )
+            .unwrap();
+
+        residency.resize(1920, 1080);
+        assert_eq!(residency.resource_stats(), initial_resources);
+        residency.recreate_gpu_resources(&device, &queue).unwrap();
+        assert_eq!(residency.resource_stats(), initial_resources);
+
+        let frame_a = [32_i64, 0, 0];
+        let frame_b = [0_i64; 3];
+        let missing = PlanetPageKey::new(planet_a, PageKey::new(1, [-99, 4, 2]));
+        let queries = [
+            GpuLookupQuery::from(GpuLookupKey::from_planet_page(key_a, frame_a).unwrap()),
+            GpuLookupQuery::from(GpuLookupKey::from_planet_page(key_b, frame_b).unwrap()),
+            GpuLookupQuery::from(GpuLookupKey::from_planet_page(missing, frame_a).unwrap()),
+        ];
+        let results = dispatch_lookup(&device, &queue, &residency, &queries);
+        assert!(results[0].found());
+        assert_eq!(results[0].slot, 0);
+        assert_eq!(results[0].generation(), 9);
+        assert!(results[1].found());
+        assert_eq!(results[1].slot, 1);
+        assert_eq!(results[1].generation(), 11);
+        assert!(!results[2].found());
+
+        let first_cell: Vec<CellWord> = read_buffer_range(
+            &device,
+            &queue,
+            residency.atlas_buffers().next().unwrap(),
+            0,
+            size_of::<CellWord>() as u64,
+        );
+        assert_eq!(first_cell, vec![cell_a]);
+        let metadata: Vec<GpuPageMeta> = read_buffer_range(
+            &device,
+            &queue,
+            residency.metadata_buffer(),
+            0,
+            size_of::<GpuPageMeta>() as u64,
+        );
+        assert_eq!(metadata[0].slot, 0);
+        assert_eq!(metadata[0].generation(), 9);
+        assert_eq!(metadata[0].relative_lod0_cell_min, [-96, 32, -96]);
+        assert_eq!(metadata[0].transition_mask, 0b10_0101);
+        let counters: Vec<GpuResidencyCounters> = read_buffer_range(
+            &device,
+            &queue,
+            residency.counters_buffer(),
+            0,
+            size_of::<GpuResidencyCounters>() as u64,
+        );
+        assert_eq!(counters[0].resident_pages, 2);
+        assert_eq!(counters[0].peak_resident_pages, 2);
+        assert_eq!(counters[0].device_rebuilds, 1);
+        assert_eq!(counters[0].uploads_published, 2);
+        assert_eq!(counters[0].batches_submitted, 2);
+        assert_eq!(
+            u64::from(counters[0].cell_bytes_uploaded_low)
+                | (u64::from(counters[0].cell_bytes_uploaded_high) << 32),
+            4 * PAGE_CELL_BYTES as u64
+        );
+        assert_eq!(counters[0].resource_buffers, initial_resources.buffers);
+        assert_eq!(counters[0].atlas_shards, initial_resources.atlas_shards);
+        assert_eq!(
+            u64::from(counters[0].resident_cell_bytes_low)
+                | (u64::from(counters[0].resident_cell_bytes_high) << 32),
+            2 * PAGE_CELL_BYTES as u64
+        );
+        assert_eq!(
+            u64::from(counters[0].allocated_gpu_bytes_low)
+                | (u64::from(counters[0].allocated_gpu_bytes_high) << 32),
+            initial_resources.allocated_bytes
+        );
+
+        assert!(matches!(
+            residency
+                .apply_evict_batch(
+                    &device,
+                    &queue,
+                    vec![PageEvict {
+                        key: key_a,
+                        generation: 9,
+                    }],
+                )
+                .unwrap()
+                .as_slice(),
+            [EvictOutcome::Recorded { removed: Some(_) }]
+        ));
+        let result = dispatch_lookup(&device, &queue, &residency, &queries[..1]);
+        assert!(!result[0].found());
+        let cleared_cell: Vec<CellWord> = read_buffer_range(
+            &device,
+            &queue,
+            residency.atlas_buffers().next().unwrap(),
+            0,
+            size_of::<CellWord>() as u64,
+        );
+        assert_eq!(cleared_cell, vec![CellWord::AIR]);
+
+        let replacement = CellWord::new(-512, 33, 5);
+        assert!(matches!(
+            residency
+                .apply_upload_batch(&device, &queue, vec![upload(key_a, 9, cell_a)])
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(UploadOutcome::Stale {
+                newest_generation: 9
+            })]
+        ));
+        assert!(matches!(
+            residency
+                .apply_upload_batch(&device, &queue, vec![upload(key_a, 10, replacement)])
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(UploadOutcome::Inserted {
+                slot: 0,
+                ..
+            })]
+        ));
+        assert!(matches!(
+            residency
+                .apply_upload_batch(&device, &queue, vec![upload(key_a, 10, cell_a)])
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(
+                UploadOutcome::GenerationConflict { slot: 0 }
+            )]
+        ));
+        let replacement_result = dispatch_lookup(&device, &queue, &residency, &queries[..1]);
+        assert!(replacement_result[0].found());
+        assert_eq!(replacement_result[0].generation(), 10);
+        let replacement_cell: Vec<CellWord> = read_buffer_range(
+            &device,
+            &queue,
+            residency.atlas_buffers().next().unwrap(),
+            0,
+            size_of::<CellWord>() as u64,
+        );
+        assert_eq!(replacement_cell, vec![replacement]);
+
+        validate_table_probe_backpressure(&device, &queue, planet_a);
+    });
+}
+
+fn validate_table_probe_backpressure(device: &wgpu::Device, queue: &wgpu::Queue, planet: PlanetId) {
+    let mut residency = PlanetaryVoxelResidency::new(
+        device,
+        queue,
+        PlanetaryVoxelGpuConfig::new(3, 8, 1, 3, 4, 2).unwrap(),
+    )
+    .unwrap();
+    residency
+        .set_planet_frame(
+            queue,
+            PlanetFrameUniform::new(planet, [0; 3], [0.0; 3], 1).unwrap(),
+        )
+        .unwrap();
+    let mut collisions = Vec::new();
+    for x in -10_000..10_000 {
+        let key = PlanetPageKey::new(planet, PageKey::new(0, [x, 0, 0]));
+        let lookup = GpuLookupKey::from_planet_page(key, [0; 3]).unwrap();
+        if lookup.hash() & 7 == 0 {
+            collisions.push(key);
+            if collisions.len() == 2 {
+                break;
+            }
+        }
+    }
+    assert_eq!(collisions.len(), 2);
+    residency
+        .apply_upload_batch(device, queue, vec![upload(collisions[0], 1, CellWord::AIR)])
+        .unwrap();
+    assert_eq!(
+        residency
+            .apply_upload_batch(device, queue, vec![upload(collisions[1], 1, CellWord::AIR)])
+            .unwrap(),
+        vec![GpuUploadOutcome::PageTableBackpressure]
+    );
+    assert!(residency.cache().resident(collisions[1]).is_none());
+    assert_eq!(residency.counters().table_saturation_events, 1);
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}
+
+fn upload(key: PlanetPageKey, generation: u64, cell: CellWord) -> PageUpload {
+    PageUpload::new(key, generation, vec![cell; PAGE_CELL_COUNT]).unwrap()
+}
+
+fn dispatch_lookup(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    residency: &PlanetaryVoxelResidency,
+    queries: &[GpuLookupQuery],
+) -> Vec<GpuLookupResult> {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Planetary Voxel Lookup Validation Shader"),
+        source: wgpu::ShaderSource::Wgsl(RESIDENCY_WGSL.into()),
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("Planetary Voxel Lookup Validation Pipeline"),
+        layout: None,
+        module: &shader,
+        entry_point: Some("validate_lookup"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let query_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Planetary Voxel Lookup Queries"),
+        contents: bytemuck::cast_slice(queries),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+    let result_bytes = std::mem::size_of_val(queries) as u64 / size_of::<GpuLookupQuery>() as u64
+        * size_of::<GpuLookupResult>() as u64;
+    let result_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planetary Voxel Lookup Results"),
+        size: result_bytes,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let layout = pipeline.get_bind_group_layout(0);
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Planetary Voxel Lookup Validation Bind Group"),
+        layout: &layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: residency.page_table_buffer().as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: residency.residency_uniform_buffer().as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: query_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 3,
+                resource: result_buffer.as_entire_binding(),
+            },
+        ],
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planetary Voxel Lookup Validation Encoder"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("Planetary Voxel Lookup Validation Dispatch"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups((queries.len() as u32).div_ceil(64), 1, 1);
+    }
+    queue.submit([encoder.finish()]);
+    read_buffer_range(device, queue, &result_buffer, 0, result_bytes)
+}
+
+fn read_buffer_range<T: Pod + Copy>(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source: &wgpu::Buffer,
+    offset: u64,
+    size: u64,
+) -> Vec<T> {
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planetary Voxel Validation Readback"),
+        size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planetary Voxel Validation Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(source, offset, &readback, 0, size);
+    queue.submit([encoder.finish()]);
+
+    let slice = readback.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv()
+        .expect("GPU readback callback must run")
+        .expect("GPU readback mapping must succeed");
+    let mapped = slice.get_mapped_range();
+    let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
+    drop(mapped);
+    readback.unmap();
+    values
+}
+
+fn size_of<T>() -> usize {
+    core::mem::size_of::<T>()
+}

--- a/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
+++ b/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
@@ -1,0 +1,187 @@
+use helio_pass_planetary_voxel::{
+    GpuLookupQuery, GpuLookupResult, GpuPageTableEntry, GpuResidencyCounters, GpuResidencyUniform,
+    RESIDENCY_WGSL,
+};
+use std::mem::{align_of, offset_of, size_of};
+use wgpu::naga::{
+    front::wgsl,
+    valid::{Capabilities, ValidationFlags, Validator},
+    TypeInner,
+};
+
+fn wgsl_struct(name: &str) -> (u32, Vec<(String, u32)>) {
+    let module = wgsl::parse_str(RESIDENCY_WGSL)
+        .unwrap_or_else(|error| panic!("planetary residency WGSL must parse: {error}"));
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .unwrap_or_else(|error| panic!("planetary residency WGSL must validate: {error}"));
+    let (_, ty) = module
+        .types
+        .iter()
+        .find(|(_, ty)| ty.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("missing WGSL struct {name}"));
+    let TypeInner::Struct { members, span } = &ty.inner else {
+        panic!("WGSL type {name} is not a struct");
+    };
+    (
+        *span,
+        members
+            .iter()
+            .map(|member| {
+                (
+                    member.name.clone().expect("contract field must be named"),
+                    member.offset,
+                )
+            })
+            .collect(),
+    )
+}
+
+#[test]
+fn residency_shader_parses_and_validates() {
+    let module = wgsl::parse_str(RESIDENCY_WGSL).expect("residency WGSL parses");
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .expect("residency WGSL validates");
+}
+
+#[test]
+fn page_table_entry_matches_wgsl_exactly() {
+    assert_eq!(align_of::<GpuPageTableEntry>(), 16);
+    assert_eq!(size_of::<GpuPageTableEntry>(), 48);
+    assert_eq!(
+        wgsl_struct("GpuPageTableEntry"),
+        (
+            48,
+            vec![
+                (
+                    "planet_id".into(),
+                    offset_of!(GpuPageTableEntry, planet_id) as u32
+                ),
+                (
+                    "relative_lod0_cell_min".into(),
+                    offset_of!(GpuPageTableEntry, relative_lod0_cell_min) as u32,
+                ),
+                ("lod".into(), offset_of!(GpuPageTableEntry, lod) as u32),
+                ("slot".into(), offset_of!(GpuPageTableEntry, slot) as u32),
+                (
+                    "generation_low".into(),
+                    offset_of!(GpuPageTableEntry, generation_low) as u32,
+                ),
+                (
+                    "generation_high".into(),
+                    offset_of!(GpuPageTableEntry, generation_high) as u32,
+                ),
+                ("state".into(), offset_of!(GpuPageTableEntry, state) as u32),
+            ],
+        )
+    );
+}
+
+#[test]
+fn uniform_query_and_result_match_wgsl_exactly() {
+    assert_eq!(align_of::<GpuResidencyUniform>(), 16);
+    assert_eq!(size_of::<GpuResidencyUniform>(), 16);
+    assert_eq!(
+        wgsl_struct("GpuResidencyUniform"),
+        (
+            16,
+            vec![
+                (
+                    "table_mask".into(),
+                    offset_of!(GpuResidencyUniform, table_mask) as u32,
+                ),
+                (
+                    "max_probe".into(),
+                    offset_of!(GpuResidencyUniform, max_probe) as u32,
+                ),
+                (
+                    "resident_pages".into(),
+                    offset_of!(GpuResidencyUniform, resident_pages) as u32,
+                ),
+                ("_pad".into(), offset_of!(GpuResidencyUniform, _pad) as u32),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuLookupQuery>(), 16);
+    assert_eq!(size_of::<GpuLookupQuery>(), 32);
+    assert_eq!(
+        wgsl_struct("GpuLookupQuery"),
+        (
+            32,
+            vec![
+                (
+                    "planet_id".into(),
+                    offset_of!(GpuLookupQuery, planet_id) as u32
+                ),
+                (
+                    "relative_lod0_cell_min".into(),
+                    offset_of!(GpuLookupQuery, relative_lod0_cell_min) as u32,
+                ),
+                ("lod".into(), offset_of!(GpuLookupQuery, lod) as u32),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuLookupResult>(), 16);
+    assert_eq!(size_of::<GpuLookupResult>(), 16);
+    assert_eq!(
+        wgsl_struct("GpuLookupResult"),
+        (
+            16,
+            vec![
+                ("slot".into(), offset_of!(GpuLookupResult, slot) as u32),
+                (
+                    "generation_low".into(),
+                    offset_of!(GpuLookupResult, generation_low) as u32,
+                ),
+                (
+                    "generation_high".into(),
+                    offset_of!(GpuLookupResult, generation_high) as u32,
+                ),
+                (
+                    "probes_and_found".into(),
+                    offset_of!(GpuLookupResult, probes_and_found) as u32,
+                ),
+            ],
+        )
+    );
+}
+
+#[test]
+fn counters_are_explicitly_padded_and_pod_sized() {
+    assert_eq!(align_of::<GpuResidencyCounters>(), 16);
+    assert_eq!(size_of::<GpuResidencyCounters>(), 96);
+    assert_eq!(
+        wgsl_struct("GpuResidencyCounters"),
+        (
+            96,
+            vec![
+                ("resident_pages".into(), 0),
+                ("resident_cell_bytes_low".into(), 4),
+                ("resident_cell_bytes_high".into(), 8),
+                ("table_occupied".into(), 12),
+                ("table_tombstones".into(), 16),
+                ("uploads_published".into(), 20),
+                ("evictions_published".into(), 24),
+                ("stale_rejections".into(), 28),
+                ("generation_conflicts".into(), 32),
+                ("backpressure_events".into(), 36),
+                ("table_saturation_events".into(), 40),
+                ("batches_submitted".into(), 44),
+                ("cell_bytes_uploaded_low".into(), 48),
+                ("cell_bytes_uploaded_high".into(), 52),
+                ("peak_resident_pages".into(), 56),
+                ("peak_resident_cell_bytes_low".into(), 60),
+                ("peak_resident_cell_bytes_high".into(), 64),
+                ("allocated_gpu_bytes_low".into(), 68),
+                ("allocated_gpu_bytes_high".into(), 72),
+                ("resource_buffers".into(), 76),
+                ("atlas_shards".into(), 80),
+                ("device_rebuilds".into(), 84),
+                ("_pad".into(), 88),
+            ],
+        )
+    );
+}

--- a/crates/helio-planet-voxel-core/src/cache.rs
+++ b/crates/helio-planet-voxel-core/src/cache.rs
@@ -168,6 +168,12 @@ impl ResidentPageCache {
         self.pages.get(&key)
     }
 
+    pub fn resident_pages(
+        &self,
+    ) -> impl ExactSizeIterator<Item = (PlanetPageKey, &ResidentPage)> + '_ {
+        self.pages.iter().map(|(key, page)| (*key, page))
+    }
+
     pub fn eviction_watermark(&self, key: PlanetPageKey) -> Option<u64> {
         self.eviction_watermarks.get(&key).copied()
     }

--- a/crates/helio-planet-voxel-core/src/gpu.rs
+++ b/crates/helio-planet-voxel-core/src/gpu.rs
@@ -57,6 +57,18 @@ impl PlanetFrameUniform {
             join_i64(self.origin_z),
         ]
     }
+
+    pub fn planet_id(self) -> PlanetId {
+        let mut bytes = [0_u8; 16];
+        for (word, output) in self.planet_id.iter().zip(bytes.chunks_exact_mut(4)) {
+            output.copy_from_slice(&word.to_le_bytes());
+        }
+        PlanetId(bytes)
+    }
+
+    pub const fn frame_number(self) -> u64 {
+        (self.frame_index[0] as u64) | ((self.frame_index[1] as u64) << 32)
+    }
 }
 
 #[repr(C, align(16))]

--- a/docs/planetary_voxel_progress.md
+++ b/docs/planetary_voxel_progress.md
@@ -21,14 +21,15 @@ and `helio-voxel-core` remain unchanged regression baselines.
 - [x] Pulsar Helio-v4 integration and caller audit: [Pulsar-Native#305](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/305), [#308](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/308), and [#310](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/310)
 - [x] Pulsar deterministic sparse terrain core: [Pulsar-Native#311](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/311)
 
-## Active milestone
+## Active milestones
 
 - [ ] Helio bounded renderer-facing residency contract: [Helio#62](https://github.com/Far-Beyond-Pulsar/Helio/pull/62) ([issue #59](https://github.com/Far-Beyond-Pulsar/Helio/issues/59))
+- [ ] Helio bounded GPU residency atlas and page table: [Helio#65](https://github.com/Far-Beyond-Pulsar/Helio/pull/65) ([issue #64](https://github.com/Far-Beyond-Pulsar/Helio/issues/64))
 
 ## Implementation milestones
 
 - [ ] Pulsar terrain component/subsystem and asynchronous work queues
-- [ ] Helio bounded GPU page atlas, hash table, upload, eviction, and device-loss recovery
+- [ ] Helio bounded GPU page atlas, hash table, upload, eviction, and device-loss recovery ([Helio#65](https://github.com/Far-Beyond-Pulsar/Helio/pull/65))
 - [ ] Earth-radius camera-local coordinates and precision validation
 - [ ] View-driven page demand, streaming, and strict CPU/GPU/VRAM budgets
 - [ ] GPU Transvoxel versus manifold dual-contouring extraction bake-off


### PR DESCRIPTION
## Parent and dependency

- Tracks #64
- Child of umbrella #60
- Stacked on renderer contract/residency PR #62
- Base branch: `feat/planet-voxel-residency-core`

This is an additive planet-only renderer crate; it does not change shared engine/default-graph behavior.

## What this adds

- Opt-in `helio-pass-planetary-voxel` crate with no default-graph registration.
- Fixed-budget shared cell atlas, sharded only when device storage-binding limits require it.
- Fixed metadata, page-table, staging, uniform, and counter buffers; no per-page WGPU resources.
- Checked byte arithmetic against current WGPU 30 device/binding limits before allocation.
- Bounded open-addressed GPU page table with exact signed multi-planet keys, tombstones, compaction, deterministic hashing, probe saturation, and explicit backpressure.
- Generation-safe upload/eviction handling, visible transitions, bounded frame registry, camera-frame rebuilds, and resize no-op.
- Batched cell copies before metadata/table publication on the queue timeline.
- Evicted-slot poisoning, dirty-range writes, profiling/high-water counters, and deterministic device-resource reconstruction.
- WGSL lookup plus exact Rust/WGSL layout/hash validation.

## Current-base validation

Rebased through #62 and umbrella #60 onto current `v4` `847ab2f4`, with a separate WGPU 30 compatibility commit.

- `cargo metadata --locked --no-deps --format-version 1`: pass
- `cargo test -p helio-pass-planetary-voxel --locked`: 15 passed
  - headless GPU readback passed on the available primary adapter
- strict all-target no-deps clippy with `-D warnings`: pass
- `cargo test -p helio-planet-voxel-core --locked`: 22 passed
- strict core clippy: pass
- `cargo build --workspace --all-targets --locked`: pass
- `cargo test --workspace --lib --bins --tests --locked`: pass
- diff audit: no default-graph or retained voxel implementation/demo changes

## Out of scope

Surface extraction, meshlet publication, drawing, graph hooks, streaming policy, and the final planetary demo remain later measured milestones.