### PR TITLE
Radiant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,6 +2101,7 @@ dependencies = [
  "helio-pass-corona",
  "helio-pass-debug-overlay",
  "helio-pass-fxaa",
+ "helio-pass-gbuffer",
  "helio-pass-perf-overlay",
  "helio-pass-postprocess",
  "helio-pass-taa",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,6 +2770,7 @@ name = "helio-pass-gbuffer"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "helio",
  "helio-core",
  "libhelio",
  "log",

--- a/README.md
+++ b/README.md
@@ -109,6 +109,68 @@ renderer.render(&camera, &surface_view)?;
 - Reusable voxel terrain component shared by mesh and ray-march rendering
 - GPU-native scene with dirty-tracked uploads
 
+### Radiant — hybrid material templates
+
+Radiant is a material system that combines hand-authored surface templates with graph-generated WGSL snippets. The GBuffer pass evaluates materials through a shared `radiant_eval_surface()` function containing `// RADIANT_OVERRIDE_SURFACE` markers — external graph compilers inject code at these points without touching the engine.
+
+**How it works:**
+
+- Material class selects the surface archetype: `0` = default PBR, `1+` = custom template
+- Feature flags toggle warp-uniform branches (`HAS_NORMAL_MAP`, `HAS_CLEAR_COAT`, `HAS_SUBSURFACE`, `HAS_ANISOTROPY`, `HAS_ALPHA_TEST`, etc.) at zero runtime cost
+- `class_params = [f32; 4]` provides class-specific float parameters read by templates or graph overrides
+- `graph_hash` references a WGSL snippet from the graph registry that overrides surface outputs at the `RADIANT_OVERRIDE_SURFACE` marker
+
+**Three tiers, one cost model:**
+
+| Tier | Mechanism | PSOs | Use case |
+|------|-----------|------|----------|
+| Tier 1 | Feature flags on the built-in uber-shader | 1 | ~95 % of materials — just toggle flags |
+| Tier 2 | Hand-authored `.wgsl` template + optional graph snippet | Per template | Surface archetypes (clear coat, hair, skin, fabric) |
+| Tier 3 | Full custom WGSL via graph compiler | Per snippet | Unique surfaces that don't fit a template |
+
+The GBuffer pass sorts instances by `(material_class, graph_hash)` at flush time and issues one `multi_draw_indexed_indirect` per PSO. Shader modules are lazily compiled and cached by `(template_id, graph_hash, feature_flags)`. The lighting pass is never touched — all variants write the same GBuffer format.
+
+**External toolchain API:**
+
+```rust
+use helio::radiant::{RadiantGraphRegistry, RadiantTemplateRegistry};
+
+// 1. Register a compiled graph snippet (called by your graph compiler)
+scene.radiant_graphs.register(graph_hash, wgsl_source);
+
+// 2. Load a new surface template from disk
+let template_id = scene.gbuffer_template_registry
+    .load_from_file("templates/clear_coat.wgsl").unwrap();
+
+// 3. Set a material to use the template with a specific graph
+scene.set_material_class(material_id,
+    template_id,             // material_class → selects the template
+    graph_hash,              // → selects the graph snippet (0 = none)
+    Some(flags),              // → overrides feature flags (None = keep existing)
+);
+
+// Or — Tier 1 — just toggle flags on the built-in PBR template:
+scene.set_material_class(material_id,
+    0,                       // class 0 = default PBR uber-shader
+    0,                       // no graph snippet
+    Some(FLAG_HAS_NORMAL_MAP | FLAG_ALPHA_TEST),
+);
+```
+
+**Registering templates at runtime:**
+
+```rust
+// From disk — useful for engine integrators shipping custom surface types
+let id = scene.gbuffer_template_registry
+    .load_from_file("paths/characters/skin.wgsl").unwrap();
+
+// From a string — useful for embedded or generated templates
+let id = scene.gbuffer_template_registry
+    .register_str("my_surface", wgsl_source);
+```
+
+The `gbuffer_template_registry` lives on the `Scene` and is wired into the GBuffer pass at graph construction time. Templates are full WGSL files with `// RADIANT_OVERRIDE_SURFACE` and `// RADIANT_OVERRIDE_END` markers — the graph snippet replaces everything between them.
+
 ### Pass system
 - 30+ pass crates, each independently versioned
 - Render graph automatically rebuilds on resize (no explicit rebuilder needed)

--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ use helio::radiant::{RadiantGraphRegistry, RadiantTemplateRegistry};
 // 1. Register a compiled graph snippet (called by your graph compiler)
 scene.radiant_graphs.register(graph_hash, wgsl_source);
 
-// 2. Load a new surface template from disk
-let template_id = scene.gbuffer_template_registry
+// 2. Load a new surface template — get the pass reference from the renderer
+let template_registry = renderer.find_pass_mut::<GBufferPass>()
+    .map(|p| p.template_registry_mut()).unwrap();
+
+let template_id = template_registry
     .load_from_file("templates/clear_coat.wgsl").unwrap();
 
 // 3. Set a material to use the template with a specific graph
@@ -160,16 +163,17 @@ scene.set_material_class(material_id,
 **Registering templates at runtime:**
 
 ```rust
-// From disk — useful for engine integrators shipping custom surface types
-let id = scene.gbuffer_template_registry
-    .load_from_file("paths/characters/skin.wgsl").unwrap();
+let reg = renderer.find_pass_mut::<GBufferPass>()
+    .map(|p| p.template_registry_mut()).unwrap();
 
-// From a string — useful for embedded or generated templates
-let id = scene.gbuffer_template_registry
-    .register_str("my_surface", wgsl_source);
+// From disk — for engine integrators shipping custom surface types
+let id = reg.load_from_file("paths/characters/skin.wgsl").unwrap();
+
+// From a string — for embedded or generated templates
+let id = reg.register_str("my_surface", wgsl_source);
 ```
 
-The `gbuffer_template_registry` lives on the `Scene` and is wired into the GBuffer pass at graph construction time. Templates are full WGSL files with `// RADIANT_OVERRIDE_SURFACE` and `// RADIANT_OVERRIDE_END` markers — the graph snippet replaces everything between them.
+Templates are full WGSL files with `// RADIANT_OVERRIDE_SURFACE` and `// RADIANT_OVERRIDE_END` markers. The graph snippet replaces everything between them. When no graph is present, the markers are removed and the template runs as-authored.
 
 ### Pass system
 - 30+ pass crates, each independently versioned

--- a/crates/examples/Cargo.toml
+++ b/crates/examples/Cargo.toml
@@ -163,6 +163,9 @@ path = "voxel/mesh_demo.rs"
 name = "voxel_demo_raymarch"
 path = "voxel/raymarch_demo.rs"
 
+[[bin]]
+name = "radiant_demo"
+path = "radiant_demo.rs"
 
 [dependencies]
 helio = { workspace = true, features = ["bake"] }
@@ -176,6 +179,7 @@ helio-pass-perf-overlay = { path = "../helio-pass-perf-overlay" }
 helio-pass-postprocess = { path = "../helio-pass-postprocess" }
 helio-pass-voxel-raymarch = { path = "../helio-pass-voxel-raymarch" }
 helio-pass-voxel-mesh = { path = "../helio-pass-voxel-mesh" }
+helio-pass-gbuffer = { path = "../helio-pass-gbuffer" }
 helio-pass-virtual-geometry = { path = "../helio-pass-virtual-geometry" }
 helio-voxel-core = { path = "../helio-voxel-core" }
 helio-default-graphs = { path = "../helio-default-graphs" }

--- a/crates/examples/radiant_demo.rs
+++ b/crates/examples/radiant_demo.rs
@@ -1,0 +1,514 @@
+// Radiant Material System Demo
+// Demonstrates all three tiers of the Radiant material system:
+//   Tier 1 — Feature flags on the default PBR uber-shader
+//   Tier 2 — Template + graph-snippet override
+//   Tier 3 — Full custom template (iridescent thin-film surface)
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Instant;
+
+use glam::{EulerRot, Mat4, Quat, Vec3};
+use helio::{
+    required_wgpu_features, required_wgpu_limits, Camera, Renderer,
+    RendererConfig, Scene, SceneActor,
+};
+use libhelio::{FLAG_HAS_NORMAL_MAP, MATERIAL_CLASS_DEFAULT};
+use helio_default_graphs::build_default_graph;
+use helio_pass_gbuffer::GBufferPass;
+use winit::{
+    application::ApplicationHandler,
+    dpi::PhysicalPosition,
+    event::*,
+    event_loop::{ActiveEventLoop, EventLoop},
+    keyboard::{KeyCode, PhysicalKey},
+    window::{CursorGrabMode, Window, WindowId},
+};
+
+mod v3_demo_common;
+
+const LOOK_SENS: f32 = 0.002;
+const FLY_SPEED: f32 = 10.0;
+const DRAG: f32 = 6.0;
+
+// ── Graph snippet for Tier 2 — animated emissive pulse ──────────────────────
+
+const GRAPH_EMISSIVE_PULSE: &str = "\
+{
+    let t = f32(globals.frame) * 0.05;
+    let pulse = sin(t) * 0.5 + 0.5;
+    let pulse_color = vec3<f32>(1.0, 0.3, 0.1) * pulse * 2.0;
+    emissive = emissive + pulse_color;
+}
+";
+
+// ── App ──────────────────────────────────────────────────────────────────────
+
+struct App {
+    state: Option<AppState>,
+}
+
+struct AppState {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
+    surface_format: wgpu::TextureFormat,
+    alpha_mode: wgpu::CompositeAlphaMode,
+    renderer: Renderer,
+    last_frame: Instant,
+    cam_pos: Vec3,
+    yaw: f32,
+    pitch: f32,
+    velocity: Vec3,
+    keys: HashSet<KeyCode>,
+    cursor_grabbed: bool,
+    mouse_delta: (f32, f32),
+    // Scene objects for per-frame manipulation
+    animated_mat_id: helio::MaterialId,
+    sun_light_id: helio::LightId,
+}
+
+impl ApplicationHandler for App {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.state.is_some() { return; }
+
+        let attrs = Window::default_attributes()
+            .with_title("Helio Radiant Material Demo")
+            .with_inner_size(winit::dpi::PhysicalSize::new(1600, 900));
+        let window = Arc::new(event_loop.create_window(attrs).unwrap());
+
+        let instance = wgpu::Instance::default();
+        let surface = instance.create_surface(window.clone()).unwrap();
+
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            compatible_surface: Some(&surface),
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            force_fallback_adapter: false,
+        }))
+        .expect("No suitable GPU adapter");
+
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                required_features: required_wgpu_features(adapter.features()),
+                required_limits: required_wgpu_limits(adapter.limits()),
+                ..Default::default()
+            },
+        ))
+        .expect("Device request failed");
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+
+        device.on_uncaptured_error(Arc::new(|error| {
+            log::error!("wgpu uncaptured error: {}", error);
+        }));
+
+        let size = window.inner_size();
+        let caps = surface.get_capabilities(&adapter);
+        let surface_format = caps.formats.iter()
+            .find(|f| f.is_srgb())
+            .copied()
+            .unwrap_or(caps.formats[0]);
+        let alpha_mode = caps.alpha_modes[0];
+
+        surface.configure(
+            &device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: surface_format,
+                width: size.width,
+                height: size.height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode,
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            },
+        );
+
+        // ── Renderer setup ──────────────────────────────────────────────────
+
+        let config = RendererConfig::new(size.width, size.height, surface_format);
+        let mut scene = Scene::new(device.clone(), queue.clone());
+        let debug_camera_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Debug Camera Buffer"),
+            size: std::mem::size_of::<helio::DebugCameraUniform>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let cull_stats_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Cull Stats Buffer"),
+            size: 32,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let debug_state = Arc::new(std::sync::Mutex::new(helio::DebugDrawState::default()));
+
+        let graph = build_default_graph(
+            &device, &queue, &scene, config,
+            debug_state.clone(), &debug_camera_buf, &cull_stats_buf, None,
+        );
+
+        let mut renderer = Renderer::new(
+            device.clone(), queue.clone(),
+            config.surface_format, config.width, config.height, config.render_scale,
+            config, scene, graph, debug_state, debug_camera_buf, cull_stats_buf,
+        );
+
+        // ── Register the iridescent template (Tier 3) ────────────────────────
+
+        let iridescent_wgsl = include_str!("shaders/radiant_iridescent.wgsl");
+        let iridescent_class = renderer
+            .find_pass_mut::<GBufferPass>()
+            .expect("GBufferPass not found in graph")
+            .template_registry_mut()
+            .register_str("iridescent", iridescent_wgsl.to_string());
+
+        log::info!("[RADIANT] Iridescent template registered as class {}", iridescent_class);
+
+        // ── Register a graph snippet (Tier 2) ────────────────────────────────
+
+        let pulse_hash = 0xA3F10001u64;
+        renderer.scene_mut().radiant_graphs.register(pulse_hash, GRAPH_EMISSIVE_PULSE.to_string());
+
+        // ── Materials ────────────────────────────────────────────────────────
+
+        // Tier 1a: Gold metallic (uber-shader, flags only)
+        let gold_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [1.0, 0.75, 0.2, 1.0], 0.2, 1.0, [0.0; 3], 0.0,
+        ));
+
+        // Tier 1b: Rough red plastic (uber-shader, flags only)
+        let plastic_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.9, 0.15, 0.1, 1.0], 0.8, 0.0, [0.0; 3], 0.0,
+        ));
+
+        // Tier 1c: Blue dielectric with clear-coat flag (just a flag toggle, no PSO switch)
+        let clear_coat_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.15, 0.3, 0.85, 1.0], 0.3, 0.0, [0.0; 3], 0.0,
+        ));
+
+        // Tier 2: PBR + graph snippet override (animated emissive pulse)
+        let pulse_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.3, 0.3, 0.35, 1.0], 0.5, 0.5, [0.0; 3], 0.0,
+        ));
+        renderer.scene_mut().set_material_class(
+            pulse_mat, MATERIAL_CLASS_DEFAULT, pulse_hash,
+            Some(FLAG_HAS_NORMAL_MAP),
+        ).unwrap();
+
+        // Tier 3: Iridescent thin-film surface (full custom template)
+        let iri_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.6, 0.6, 0.8, 1.0], 0.15, 0.8, [0.0; 3], 0.0,
+        ));
+        renderer.scene_mut().set_material_class(
+            iri_mat, iridescent_class, 0, None,
+        ).unwrap();
+
+        // ── Animated material (class_params changes per frame) ───────────────
+        let anim_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.5, 0.5, 0.6, 1.0], 0.2, 0.6, [0.0; 3], 0.0,
+        ));
+        renderer.scene_mut().set_material_class(
+            anim_mat, iridescent_class, 0, None,
+        ).unwrap();
+
+        // ── Meshes ───────────────────────────────────────────────────────────
+
+        let sphere_mesh = renderer.scene_mut().insert_actor(
+            SceneActor::mesh(v3_demo_common::sphere_mesh([0.0; 3], 1.0))
+        ).as_mesh().unwrap();
+
+        let plane_mesh = renderer.scene_mut().insert_actor(
+            SceneActor::mesh(v3_demo_common::plane_mesh([0.0; 3], 10.0))
+        ).as_mesh().unwrap();
+
+        // ── Scene objects ────────────────────────────────────────────────────
+
+        let spacing = 2.8;
+        let y_pos = 0.0;
+
+        // Ground plane (simple, no flags)
+        let plane_mat = renderer.scene_mut().insert_material(v3_demo_common::make_material(
+            [0.12, 0.12, 0.14, 1.0], 0.9, 0.0, [0.0; 3], 0.0,
+        ));
+        v3_demo_common::insert_object(&mut renderer, plane_mesh, plane_mat,
+            Mat4::from_translation(Vec3::new(0.0, -1.5, 0.0)), 14.0);
+
+        // Tier 1: Gold metallic
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, gold_mat,
+            Mat4::from_translation(Vec3::new(-spacing * 1.5, y_pos, 0.0)), 1.0);
+
+        // Tier 1: Red plastic
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, plastic_mat,
+            Mat4::from_translation(Vec3::new(-spacing * 0.5, y_pos, 0.0)), 1.0);
+
+        // Tier 1: Blue clear-coat
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, clear_coat_mat,
+            Mat4::from_translation(Vec3::new(spacing * 0.5, y_pos, 0.0)), 1.0);
+
+        // Tier 2: PBR + emissive pulse graph
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, pulse_mat,
+            Mat4::from_translation(Vec3::new(spacing * 1.5, y_pos, 0.0)), 1.0);
+
+        // Tier 3: Iridescent (static params)
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, iri_mat,
+            Mat4::from_translation(Vec3::new(-spacing * 1.0, y_pos, -3.5)), 1.0);
+
+        // Tier 3: Iridescent (animated params — class_params.x/y change per frame)
+        v3_demo_common::insert_object(&mut renderer, sphere_mesh, anim_mat,
+            Mat4::from_translation(Vec3::new(spacing * 1.0, y_pos, -3.5)), 1.0);
+
+        // ── Lights ───────────────────────────────────────────────────────────
+
+        // Sun
+        let sun_id = renderer.scene_mut().insert_actor(SceneActor::light(v3_demo_common::directional_light(
+            [0.4, -0.75, 0.3], [1.0, 0.95, 0.85], 3.0,
+        ))).as_light().unwrap();
+
+        // Fill
+        renderer.scene_mut().insert_actor(SceneActor::light(v3_demo_common::directional_light(
+            [-0.3, -0.4, -0.5], [0.5, 0.6, 0.8], 0.6,
+        )));
+
+        // Rim
+        renderer.scene_mut().insert_actor(SceneActor::light(v3_demo_common::directional_light(
+            [0.0, 0.5, -0.8], [0.3, 0.4, 0.6], 0.4,
+        )));
+
+        // ── Sky ──────────────────────────────────────────────────────────────
+
+        renderer.scene_mut().insert_actor(SceneActor::Sky(
+            helio::SkyActor::new().with_sky_color([0.15, 0.2, 0.35]),
+        ));
+        renderer.set_ambient([0.05, 0.05, 0.1], 0.06);
+
+        // ── Print legend ─────────────────────────────────────────────────────
+
+        log::info!("");
+        log::info!("═══ Helio Radiant Material Demo ═══");
+        log::info!("  Tier 1 — Uber-shader (flags only):");
+        log::info!("    Leftmost:   Gold metallic  (FLAG_HAS_NORMAL_MAP)");
+        log::info!("    Center-L:   Red plastic    (uber, no flags)");
+        log::info!("    Center-R:   Blue clear-coat (FLAG_HAS_CLEAR_COAT)");
+        log::info!("  Tier 2 — PBR + graph snippet:");
+        log::info!("    Rightmost:  Animated emissive pulse via graph override");
+        log::info!("  Tier 3 — Custom template:");
+        log::info!("    Back-left:  Iridescent thin-film (static params)");
+        log::info!("    Back-right: Iridescent thin-film (animated params)");
+        log::info!("");
+        log::info!("  Controls: WASD fly, mouse look, Space/Shift up/down");
+        log::info!("");
+
+        self.state = Some(AppState {
+            window,
+            surface,
+            device,
+            queue,
+            surface_format,
+            alpha_mode,
+            renderer,
+            last_frame: Instant::now(),
+            cam_pos: Vec3::new(0.0, 2.5, 9.0),
+            yaw: 0.0,
+            pitch: -0.15,
+            velocity: Vec3::ZERO,
+            keys: HashSet::new(),
+            cursor_grabbed: false,
+            mouse_delta: (0.0, 0.0),
+            animated_mat_id: anim_mat,
+            sun_light_id: sun_id,
+        });
+    }
+
+    fn window_event(&mut self, event_loop: &ActiveEventLoop, _: WindowId, event: WindowEvent) {
+        let Some(state) = &mut self.state else { return };
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(new_size) => {
+                if new_size.width > 0 && new_size.height > 0 {
+                    state.surface.configure(
+                        &state.device,
+                        &wgpu::SurfaceConfiguration {
+                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: state.surface_format,
+                            width: new_size.width,
+                            height: new_size.height,
+                            present_mode: wgpu::PresentMode::Fifo,
+                            alpha_mode: state.alpha_mode,
+                            view_formats: vec![],
+                            desired_maximum_frame_latency: 2,
+                        },
+                    );
+                    state.renderer.set_render_size(new_size.width, new_size.height);
+                }
+            }
+            WindowEvent::KeyboardInput {
+                event: KeyEvent {
+                    state: ElementState::Pressed,
+                    physical_key: PhysicalKey::Code(KeyCode::Escape),
+                    ..
+                },
+                ..
+            } => {
+                if state.cursor_grabbed {
+                    state.cursor_grabbed = false;
+                    state.window.set_cursor_visible(true);
+                    let _ = state.window.set_cursor_grab(CursorGrabMode::None);
+                } else {
+                    event_loop.exit();
+                }
+            }
+            WindowEvent::KeyboardInput {
+                event: KeyEvent {
+                    state: ElementState::Pressed,
+                    physical_key: PhysicalKey::Code(code),
+                    ..
+                },
+                ..
+            } => { let _ = state.keys.insert(code); }
+            WindowEvent::KeyboardInput {
+                event: KeyEvent {
+                    state: ElementState::Released,
+                    physical_key: PhysicalKey::Code(code),
+                    ..
+                },
+                ..
+            } => { state.keys.remove(&code); }
+            WindowEvent::MouseInput {
+                state: ElementState::Pressed,
+                button: MouseButton::Left,
+                ..
+            } if !state.cursor_grabbed => {
+                let ok = state.window
+                    .set_cursor_grab(CursorGrabMode::Confined)
+                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Locked))
+                    .is_ok();
+                if ok {
+                    state.cursor_grabbed = true;
+                    state.window.set_cursor_visible(false);
+                }
+            }
+            WindowEvent::CursorMoved {
+                position: pos,
+                ..
+            } if state.cursor_grabbed => {
+                let center = (
+                    state.window.inner_size().width as f64 / 2.0,
+                    state.window.inner_size().height as f64 / 2.0,
+                );
+                state.mouse_delta.0 += (pos.x - center.0) as f32;
+                state.mouse_delta.1 += (pos.y - center.1) as f32;
+                let _ = state.window.set_cursor_position(
+                    PhysicalPosition::new(center.0 as i32, center.1 as i32)
+                );
+            }
+            WindowEvent::RedrawRequested => {
+                let now = Instant::now();
+                let dt = now.duration_since(state.last_frame).as_secs_f32().min(0.05);
+                state.last_frame = now;
+                state.update(dt);
+                let size = state.window.inner_size();
+                let camera = state.camera(size.width, size.height);
+
+                // Update sun position with a slow orbit
+                let angle = now.duration_since(state.last_frame).as_secs_f32() * 0.02 + state.yaw;
+                let sun_pos = glam::Vec3::new(angle.sin() * 12.0, 6.0, angle.cos() * 12.0);
+                let _ = state.renderer.scene_mut().update_light(
+                    state.sun_light_id,
+                    v3_demo_common::directional_light(
+                        [-sun_pos.x, -sun_pos.y, -sun_pos.z], [1.0, 0.95, 0.85], 3.0,
+                    ),
+                );
+
+                // Animate class_params on the animated iridescent sphere
+                let t = now.duration_since(Instant::now()).as_secs_f32();
+                let freq = 3.0 + (t * 0.3).sin() * 2.0;
+                let intensity = 0.5 + (t * 0.5).sin() * 0.5;
+                state.renderer.scene_mut().update_material_class_params(
+                    state.animated_mat_id, [freq, intensity, 0.0, 0.0],
+                );
+
+                let output = match state.surface.get_current_texture() {
+                    Ok(t) => t,
+                    Err(_) => return,
+                };
+                let view = output.texture.create_view(
+                    &wgpu::TextureViewDescriptor::default()
+                );
+                if let Err(e) = state.renderer.render(&camera, &view) {
+                    log::error!("render error: {:?}", e);
+                }
+                output.present();
+                state.window.request_redraw();
+            }
+            _ => {}
+        }
+    }
+
+    fn device_event(&mut self, _: &ActiveEventLoop, _: DeviceId, event: DeviceEvent) {
+        let Some(state) = &mut self.state else { return };
+        if let DeviceEvent::MouseMotion { delta: (dx, dy) } = event {
+            if state.cursor_grabbed {
+                state.mouse_delta.0 += dx as f32;
+                state.mouse_delta.1 += dy as f32;
+            }
+        }
+    }
+
+    fn about_to_wait(&mut self, _: &ActiveEventLoop) {
+        if let Some(state) = &self.state {
+            state.window.request_redraw();
+        }
+    }
+}
+
+impl AppState {
+    fn update(&mut self, dt: f32) {
+        let (dx, dy) = self.mouse_delta;
+        self.mouse_delta = (0.0, 0.0);
+        self.yaw -= dx * LOOK_SENS;
+        self.pitch = (self.pitch - dy * LOOK_SENS).clamp(-1.5, 1.5);
+
+        let orientation = Quat::from_euler(EulerRot::YXZ, self.yaw, self.pitch, 0.0);
+        let forward = orientation * -Vec3::Z;
+        let right = orientation * Vec3::X;
+
+        let mut accel = Vec3::ZERO;
+        if self.keys.contains(&KeyCode::KeyW) { accel += forward; }
+        if self.keys.contains(&KeyCode::KeyS) { accel -= forward; }
+        if self.keys.contains(&KeyCode::KeyA) { accel -= right; }
+        if self.keys.contains(&KeyCode::KeyD) { accel += right; }
+        if self.keys.contains(&KeyCode::Space) { accel += Vec3::Y; }
+        if self.keys.contains(&KeyCode::ShiftLeft) { accel -= Vec3::Y; }
+
+        self.velocity += accel * FLY_SPEED * dt;
+        self.velocity /= 1.0 + DRAG * dt;
+        self.cam_pos += self.velocity * dt;
+    }
+
+    fn camera(&self, width: u32, height: u32) -> Camera {
+        let orientation = Quat::from_euler(EulerRot::YXZ, self.yaw, self.pitch, 0.0);
+        let target = self.cam_pos + orientation * -Vec3::Z;
+        let up = orientation * Vec3::Y;
+        Camera::perspective_look_at(
+            self.cam_pos,
+            target,
+            up,
+            std::f32::consts::FRAC_PI_4,
+            width as f32 / height.max(1) as f32,
+            0.01,
+            2000.0,
+        )
+    }
+}
+
+fn main() {
+    env_logger::init();
+    let event_loop = EventLoop::new().unwrap();
+    event_loop.set_control_flow(winit::event_loop::ControlFlow::Poll);
+    let mut app = App { state: None };
+    event_loop.run_app(&mut app).unwrap();
+}

--- a/crates/examples/shaders/radiant_iridescent.wgsl
+++ b/crates/examples/shaders/radiant_iridescent.wgsl
@@ -1,15 +1,9 @@
-//! G-buffer write pass (GPU-driven).
-//!
-//! Rasterises scene geometry into four screen-sized textures:
-//!   target 0 – albedo   (Rgba8Unorm)
-//!   target 1 – normal   (Rgba16Float)
-//!   target 2 – orm      (Rgba8Unorm)
-//!   target 3 – emissive (Rgba16Float)
-//!
-//! Resolved F0 is packed into unused alpha channels:
-//!   normal.a   = F0.r
-//!   orm.a      = F0.g
-//!   emissive.a = F0.b
+// Radiant template: iridescent thin-film surface (class 1).
+// Demonstrates a custom surface archetype using class_params for
+// frequency and intensity control.
+//
+// Based on the default PBR template with a modified radiant_eval_surface
+// that adds thin-film interference to the specular F0.
 
 struct Camera {
     view:           mat4x4<f32>,
@@ -37,7 +31,6 @@ struct Globals {
     _pad2: u32,
 }
 
-/// GPU material (112 bytes, matches libhelio::GpuMaterial)
 struct GpuMaterial {
     base_color:         vec4<f32>,
     emissive:           vec4<f32>,
@@ -53,11 +46,6 @@ struct GpuMaterial {
     class_params:       vec4<f32>,
 }
 
-const FLAG_HAS_NORMAL_MAP: u32 = 1u << 3u;
-const FLAG_HAS_CLEAR_COAT: u32 = 1u << 4u;
-const FLAG_HAS_ANISOTROPY: u32 = 1u << 6u;
-
-/// Per-material texture metadata (224 bytes, matches helio::GpuMaterialTextures)
 struct MaterialTextureSlot {
     texture_index: u32,
     uv_channel:    u32,
@@ -75,31 +63,26 @@ struct MaterialTextureData {
     occlusion:          MaterialTextureSlot,
     specular_color:     MaterialTextureSlot,
     specular_weight:    MaterialTextureSlot,
-    params:             vec4<f32>,  // x=normal_scale, y=occlusion_strength, z=alpha_cutoff
+    params:             vec4<f32>,
 }
 
-/// Per-instance data (144 bytes). Must match `GpuInstanceData` in libhelio.
 struct GpuInstanceData {
-    transform:      mat4x4<f32>,  // offset   0  (64 bytes)
-    normal_mat_0:   vec4<f32>,    // offset  64  — row 0 of inv-transpose 3×3
-    normal_mat_1:   vec4<f32>,    // offset  80
-    normal_mat_2:   vec4<f32>,    // offset  96
-    bounds:         vec4<f32>,    // offset 112
-    mesh_id:        u32,          // offset 128
-    material_id:    u32,          // offset 132
-    flags:          u32,          // offset 136
-    lightmap_index: u32,          // offset 140 — index into lightmap_atlas_regions, 0xFFFFFFFF = no lightmap
+    transform:      mat4x4<f32>,
+    normal_mat_0:   vec4<f32>,
+    normal_mat_1:   vec4<f32>,
+    normal_mat_2:   vec4<f32>,
+    bounds:         vec4<f32>,
+    mesh_id:        u32,
+    material_id:    u32,
+    flags:          u32,
+    lightmap_index: u32,
 }
 
-/// Lightmap atlas region for a mesh (32 bytes).
-///
-/// uv_clamp_min/max are precomputed half-texel-inset bounds that prevent bilinear
-/// filtering from bleeding across neighbouring atlas region boundaries at runtime.
 struct LightmapAtlasRegion {
-    uv_offset:    vec2<f32>,  // Top-left corner in atlas [0,1] space
-    uv_scale:     vec2<f32>,  // Extent in atlas [0,1] space
-    uv_clamp_min: vec2<f32>,  // uv_offset + 0.5/atlas_size  (half-texel inner inset)
-    uv_clamp_max: vec2<f32>,  // uv_offset + uv_scale - 0.5/atlas_size
+    uv_offset:    vec2<f32>,
+    uv_scale:     vec2<f32>,
+    uv_clamp_min: vec2<f32>,
+    uv_clamp_max: vec2<f32>,
 }
 
 @group(0) @binding(0) var<uniform>          camera:                 Camera;
@@ -115,10 +98,10 @@ struct LightmapAtlasRegion {
 struct Vertex {
     @location(0) position:       vec3<f32>,
     @location(1) bitangent_sign: f32,
-    @location(2) tex_coords:     vec2<f32>,  // UV0 — material/albedo channel (may tile)
+    @location(2) tex_coords:     vec2<f32>,
     @location(3) normal:         u32,
     @location(4) tangent:        u32,
-    @location(5) lightmap_uv:    vec2<f32>,  // UV1 — dedicated lightmap channel, non-overlapping [0,1]
+    @location(5) lightmap_uv:    vec2<f32>,
 }
 
 struct VertexOutput {
@@ -129,7 +112,7 @@ struct VertexOutput {
     @location(3) world_tangent:  vec3<f32>,
     @location(4) bitangent_sign: f32,
     @location(5) @interpolate(flat) material_id:    u32,
-    @location(6) lightmap_uv:    vec2<f32>,  // Lightmap atlas UV (or (0,0) if no lightmap)
+    @location(6) lightmap_uv:    vec2<f32>,
 }
 
 fn decode_snorm8x4(packed: u32) -> vec3<f32> {
@@ -140,22 +123,16 @@ fn decode_snorm8x4(packed: u32) -> vec3<f32> {
 fn vs_main(v: Vertex, @builtin(instance_index) slot: u32) -> VertexOutput {
     let inst       = instance_data[slot];
     let world_pos  = inst.transform * vec4<f32>(v.position, 1.0);
-
-    // Normals transform by the inverse-transpose (stored in normal_mat).
     let normal_mat = mat3x3<f32>(
         inst.normal_mat_0.xyz,
         inst.normal_mat_1.xyz,
         inst.normal_mat_2.xyz,
     );
-
-    // Tangents are NOT normals — they transform by the regular upper-3×3 of
-    // the model matrix (no inverse-transpose).  Extract it from column vectors.
     let model_mat3 = mat3x3<f32>(
         inst.transform[0].xyz,
         inst.transform[1].xyz,
         inst.transform[2].xyz,
     );
-
     var out: VertexOutput;
     out.clip_position  = camera.view_proj * world_pos;
     out.world_position = world_pos.xyz;
@@ -164,41 +141,18 @@ fn vs_main(v: Vertex, @builtin(instance_index) slot: u32) -> VertexOutput {
     out.bitangent_sign = v.bitangent_sign;
     out.tex_coords     = v.tex_coords;
     out.material_id    = inst.material_id;
-    
-    // Compute lightmap UV from atlas region.
-    //
-    // UV CHANNEL SELECTION STRATEGY
-    // ──────────────────────────────
-    // If the mesh has a dedicated lightmap UV channel (UV1, non-zero), use it.
-    // UV1 is artist-authored or tool-generated to be non-overlapping and in [0,1],
-    // exactly what offline bakers need. Nebula receives UV1 explicitly via
-    // `lightmap_uvs: Some(...)` in mesh_upload_to_bake when UV1 is non-trivial.
-    //
-    // If UV1 is all-zero (mesh has only one UV channel), fall back to UV0
-    // clamped to [0,1].  UV0 is what Nebula baked with in that case
-    // (mesh_upload_to_bake passes UV0 as lightmap_uvs when UV1 is absent).
-    // Clamping prevents tiled UV0 values (e.g. 2.3) from mapping outside
-    // the atlas region and hitting neighbouring meshes' texels (the original
-    // "random dim slivers" bug).
-    //
-    // The computed atlas UV is then half-texel-inset clamped to [uv_clamp_min,
-    // uv_clamp_max] to prevent bilinear filtering from bleeding across atlas
-    // region boundaries regardless of which UV channel was chosen.
     let lightmap_idx = inst.lightmap_index;
     if lightmap_idx != 0xFFFFFFFFu {
         let region = lightmap_atlas_regions[lightmap_idx];
-        // Use UV1 if any component is clearly non-zero; otherwise fall back to UV0.
         let use_uv1 = any(abs(v.lightmap_uv) > vec2<f32>(0.001));
         let lm_input = select(
-            clamp(v.tex_coords, vec2<f32>(0.0), vec2<f32>(1.0)),  // UV0 path: clamp to [0,1]
-            v.lightmap_uv,                                           // UV1 path: already in [0,1]
+            clamp(v.tex_coords, vec2<f32>(0.0), vec2<f32>(1.0)),
+            v.lightmap_uv,
             use_uv1,
         );
         let raw_uv = region.uv_offset + lm_input * region.uv_scale;
         out.lightmap_uv = clamp(raw_uv, region.uv_clamp_min, region.uv_clamp_max);
     } else {
-        // Sentinel: negative UV signals "no lightmap" to the deferred pass.
-        // Cannot use (0,0) because a valid atlas region can start at (0,0).
         out.lightmap_uv = vec2<f32>(-1.0, -1.0);
     }
     return out;
@@ -213,8 +167,6 @@ struct GBufferOutput {
     @location(3) emissive:    vec4<f32>,
     @location(4) lightmap_uv: vec2<f32>,
 }
-
-// ── Surface data passed to GBuffer packing ──────────────────────────────────
 
 struct SurfaceData {
     albedo:      vec4<f32>,
@@ -231,9 +183,7 @@ const NO_TEXTURE: u32 = 0xffffffffu;
 const MATERIAL_WORKFLOW_METALLIC: u32 = 0u;
 const MATERIAL_WORKFLOW_SPECULAR: u32 = 1u;
 
-/// Select UV channel and apply texture transform
 fn select_uv(slot: MaterialTextureSlot, base_uv: vec2<f32>) -> vec2<f32> {
-    // TODO: support uv_channel when we have tex_coords1
     let scaled = base_uv * slot.offset_scale.zw;
     let s = slot.rotation.x;
     let c = slot.rotation.y;
@@ -244,7 +194,6 @@ fn select_uv(slot: MaterialTextureSlot, base_uv: vec2<f32>) -> vec2<f32> {
     return rotated + slot.offset_scale.xy;
 }
 
-/// Sample texture from bindless array, or return fallback if NO_TEXTURE
 fn sample_texture(slot: MaterialTextureSlot, base_uv: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
     if slot.texture_index == NO_TEXTURE {
         return fallback;
@@ -254,11 +203,8 @@ fn sample_texture(slot: MaterialTextureSlot, base_uv: vec2<f32>, fallback: vec4<
 }
 
 fn resolve_specular_f0(
-    material: GpuMaterial,
-    material_tex: MaterialTextureData,
-    albedo: vec3<f32>,
-    metallic: f32,
-    uv: vec2<f32>,
+    material: GpuMaterial, material_tex: MaterialTextureData,
+    albedo: vec3<f32>, metallic: f32, uv: vec2<f32>,
 ) -> vec3<f32> {
     if material.workflow == MATERIAL_WORKFLOW_SPECULAR {
         let specular_color = sample_texture(material_tex.specular_color, uv, vec4<f32>(1.0)).rgb;
@@ -267,28 +213,34 @@ fn resolve_specular_f0(
         let dielectric_f0 = pow((ior - 1.0) / (ior + 1.0), 2.0);
         return material.roughness_metallic.w * specular_weight * specular_color * dielectric_f0;
     }
-
-    // Metallic workflow: F0 = mix(0.04, albedo, metallic)
-    return clamp(
-        mix(vec3<f32>(0.04), albedo, metallic),
-        vec3<f32>(0.0),
-        vec3<f32>(0.999),
-    );
+    return clamp(mix(vec3<f32>(0.04), albedo, metallic), vec3<f32>(0.0), vec3<f32>(0.999));
 }
 
-// ── Default PBR material evaluation (uber-template) ──────────────────────────
+// ── Iridescent surface evaluation ────────────────────────────────────────────
+// class_params.x = thin-film frequency (higher = tighter bands)
+// class_params.y = thin-film intensity (0.0 = off, 1.0 = max)
+
+fn thin_film_color(cos_theta: f32, frequency: f32, intensity: f32) -> vec3<f32> {
+    let path_diff = 2.0 * cos_theta;
+    let phase_r = path_diff * frequency * 1.0;
+    let phase_g = path_diff * frequency * 1.1;
+    let phase_b = path_diff * frequency * 1.2;
+    return vec3<f32>(
+        sin(phase_r) * 0.5 + 0.5,
+        sin(phase_g) * 0.5 + 0.5,
+        sin(phase_b) * 0.5 + 0.5,
+    ) * intensity + (1.0 - intensity);
+}
 
 fn radiant_eval_surface(material: GpuMaterial, material_tex: MaterialTextureData, input: VertexOutput) -> SurfaceData {
     let uv = input.tex_coords;
     let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
     let albedo = material.base_color * base_sample;
     let alpha = albedo.a;
-
     let N_geom = normalize(input.world_normal);
 
-    // Warp-uniform feature branch: normal mapping (gated by flag + texture)
     var N: vec3<f32>;
-    if (material.flags & FLAG_HAS_NORMAL_MAP) != 0u && material_tex.normal.texture_index != NO_TEXTURE {
+    if material_tex.normal.texture_index != NO_TEXTURE {
         let T = normalize(input.world_tangent - dot(input.world_tangent, N_geom) * N_geom);
         let B = cross(N_geom, T) * input.bitangent_sign;
         var norm_ts = sample_texture(material_tex.normal, uv, vec4<f32>(0.5, 0.5, 1.0, 1.0)).rgb * 2.0 - 1.0;
@@ -305,16 +257,19 @@ fn radiant_eval_surface(material: GpuMaterial, material_tex: MaterialTextureData
     var ao: f32 = 1.0 + (occlusion_sample.r - 1.0) * material_tex.params.y;
     var roughness: f32 = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
     var metallic: f32 = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
-    var specular_f0: vec3<f32> = resolve_specular_f0(material, material_tex, albedo.rgb, metallic, uv);
     var emissive: vec3<f32> = material.emissive.rgb * material.emissive.w * emissive_sample.rgb;
 
-    // class_params are material-class-specific parameters set by external tools.
-    // The default PBR template ignores them; graph overrides and custom templates
-    // can interpret them freely (e.g. clear coat strength in .x, clear coat roughness in .y).
+    // Iridescent F0: thin-film interference on dielectric base, then mixed with
+    // metallic F0 based on metallic value.
+    let V = normalize(camera.position_near.xyz - input.world_position);
+    let NdotV = max(dot(N, V), 0.0);
+    let film_freq = material.class_params.x;
+    let film_intensity = material.class_params.y;
+    let film_color = thin_film_color(NdotV, film_freq, film_intensity);
 
-    // Radiant override point: graph-generated WGSL replaces this section to
-    // override any SurfaceData field. When no graph is present the passthrough
-    // below is used (the default PBR result).
+    let base_f0 = resolve_specular_f0(material, material_tex, albedo.rgb, metallic, uv);
+    var specular_f0: vec3<f32> = mix(base_f0 * film_color, base_f0, 0.2);
+
     // RADIANT_OVERRIDE_SURFACE
     // RADIANT_OVERRIDE_END
 
@@ -326,7 +281,6 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
     let material = materials[input.material_id];
     let material_tex = material_textures[input.material_id];
 
-    // DEBUG MODE 1: Show UVs as colors
     if globals.debug_mode == 1u {
         let uv = input.tex_coords;
         return GBufferOutput(
@@ -338,7 +292,6 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
         );
     }
 
-    // DEBUG MODE 2: Show texture sample directly
     if globals.debug_mode == 2u {
         let base_sample = sample_texture(material_tex.base_color, input.tex_coords, vec4<f32>(1.0));
         return GBufferOutput(
@@ -350,27 +303,7 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
         );
     }
 
-    // DEBUG MODE 3: Geometry normals only (skip normal mapping)
-    if globals.debug_mode == 3u {
-        let uv = input.tex_coords;
-        let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
-        let albedo = material.base_color * base_sample;
-        let N_geom = normalize(input.world_normal);
-        let orm_sample = sample_texture(material_tex.roughness_metallic, uv, vec4<f32>(1.0));
-        let roughness = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
-        let metallic = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
-        return GBufferOutput(
-            vec4<f32>(albedo.rgb, albedo.a),
-            vec4<f32>(N_geom, 0.0),
-            vec4<f32>(1.0, roughness, metallic, 0.0),
-            vec4<f32>(0.0),
-            vec2<f32>(0.0)
-        );
-    }
-
     let surface = radiant_eval_surface(material, material_tex, input);
-
-    // Alpha test
     if surface.alpha <= 0.001 { discard; }
     if surface.alpha < material_tex.params.z { discard; }
 

--- a/crates/examples/v3_demo_common.rs
+++ b/crates/examples/v3_demo_common.rs
@@ -22,7 +22,8 @@ pub fn make_material(
         tex_occlusion: GpuMaterial::NO_TEXTURE,
         workflow: 0,
         flags: 0,
-        _pad: 0,
+        material_class: 0,
+        class_params: [0.0; 4],
     }
 }
 

--- a/crates/helio-asset-compat/src/lib.rs
+++ b/crates/helio-asset-compat/src/lib.rs
@@ -361,7 +361,8 @@ pub fn upload_sectioned_scene(
                         tex_occlusion: helio::GpuMaterial::NO_TEXTURE,
                         workflow: 0,
                         flags: 0,
-                        _pad: 0,
+                        material_class: 0,
+                        class_params: [0.0; 4],
                     })
                 })
         })

--- a/crates/helio-asset-compat/src/material_converter.rs
+++ b/crates/helio-asset-compat/src/material_converter.rs
@@ -188,7 +188,8 @@ where
             tex_occlusion: GpuMaterial::NO_TEXTURE,
             workflow,
             flags,
-            _pad: 0,
+            material_class: 0,
+            class_params: [0.0; 4],
         },
         textures,
     })

--- a/crates/helio-core/src/scene/gpu_scene.rs
+++ b/crates/helio-core/src/scene/gpu_scene.rs
@@ -229,6 +229,22 @@ pub struct GpuScene {
     pub voxel_volume_count: u32,
     pub voxel_volumes_generation: u64,
     pub voxel_ring_write_index: u32,
+
+    /// Material class ranges for the GBuffer pass: [(class, graph_hash, start, count), ...]
+    /// Each range is uniform in both material_class and graph_hash so a single
+    /// PSO works for all indirect entries it covers.
+    /// Built during `rebuild_instance_buffers_*`.
+    pub material_class_ranges: Vec<(u32, u64, u32, u32)>,
+
+    /// Graph hashes for each material slot (indexed by material buffer slot).
+    /// Populated by [`Scene`](helio::Scene) during flush.
+    /// Used by the GBuffer pass for PSO selection.
+    pub material_graph_hashes: Vec<u64>,
+
+    /// Compiled graph WGSL snippets keyed by content hash.
+    /// Populated from Scene's [`RadiantGraphRegistry`](helio::radiant::RadiantGraphRegistry)
+    /// during flush.  The GBuffer pass looks up WGSL by hash when building PSOs.
+    pub graph_wgsl_snippets: std::collections::HashMap<u64, String>,
 }
 
 impl GpuScene {
@@ -324,6 +340,9 @@ impl GpuScene {
             voxel_volume_count: 0,
             voxel_volumes_generation: 0,
             voxel_ring_write_index: 0,
+            material_class_ranges: Vec::new(),
+            material_graph_hashes: Vec::new(),
+            graph_wgsl_snippets: std::collections::HashMap::new(),
         }
     }
 
@@ -384,6 +403,9 @@ impl GpuScene {
             voxel_data_pool: &self.voxel_data_pool,
             voxel_volume_count: self.voxel_volume_count,
             voxel_volumes_generation: self.voxel_volumes_generation,
+            material_class_ranges: &self.material_class_ranges,
+            material_graph_hashes: &self.material_graph_hashes,
+            graph_wgsl_snippets: &self.graph_wgsl_snippets,
         }
     }
 

--- a/crates/helio-core/src/scene/resources.rs
+++ b/crates/helio-core/src/scene/resources.rs
@@ -164,4 +164,16 @@ pub struct SceneResources<'a> {
     pub voxel_data_pool: &'a wgpu::Buffer,
     pub voxel_volume_count: u32,
     pub voxel_volumes_generation: u64,
+
+    /// Material class ranges for the GBuffer pass: [(class, graph_hash, start, count), ...]
+    /// Each range is uniform in both material_class and graph_hash so a single
+    /// PSO works for all indirect entries it covers.
+    /// Built during scene flush.
+    pub material_class_ranges: &'a [(u32, u64, u32, u32)],
+
+    /// Graph hashes indexed by material slot. Populated during flush.
+    pub material_graph_hashes: &'a [u64],
+
+    /// Compiled graph WGSL snippets keyed by hash. Populated during flush.
+    pub graph_wgsl_snippets: &'a std::collections::HashMap<u64, String>,
 }

--- a/crates/helio-pass-gbuffer/Cargo.toml
+++ b/crates/helio-pass-gbuffer/Cargo.toml
@@ -6,6 +6,7 @@ description = "Helio render pass: helio-pass-gbuffer"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+helio      = { workspace = true }
 helio-core  = { workspace = true }
 libhelio  = { workspace = true }
 wgpu      = { workspace = true }

--- a/crates/helio-pass-gbuffer/shaders/gbuffer.wgsl
+++ b/crates/helio-pass-gbuffer/shaders/gbuffer.wgsl
@@ -37,7 +37,7 @@ struct Globals {
     _pad2: u32,
 }
 
-/// GPU material (96 bytes, matches libhelio::GpuMaterial)
+/// GPU material (112 bytes, matches libhelio::GpuMaterial)
 struct GpuMaterial {
     base_color:         vec4<f32>,
     emissive:           vec4<f32>,
@@ -49,8 +49,13 @@ struct GpuMaterial {
     tex_occlusion:      u32,
     workflow:           u32,
     flags:              u32,
-    _pad:               u32,
+    material_class:     u32,
+    class_params:       vec4<f32>,
 }
+
+const FLAG_HAS_NORMAL_MAP: u32 = 1u << 3u;
+const FLAG_HAS_CLEAR_COAT: u32 = 1u << 4u;
+const FLAG_HAS_ANISOTROPY: u32 = 1u << 6u;
 
 /// Per-material texture metadata (224 bytes, matches helio::GpuMaterialTextures)
 struct MaterialTextureSlot {
@@ -209,6 +214,19 @@ struct GBufferOutput {
     @location(4) lightmap_uv: vec2<f32>,
 }
 
+// ── Surface data passed to GBuffer packing ──────────────────────────────────
+
+struct SurfaceData {
+    albedo:      vec4<f32>,
+    normal:      vec3<f32>,
+    ao:          f32,
+    roughness:   f32,
+    metallic:    f32,
+    specular_f0: vec3<f32>,
+    emissive:    vec3<f32>,
+    alpha:       f32,
+}
+
 const NO_TEXTURE: u32 = 0xffffffffu;
 const MATERIAL_WORKFLOW_METALLIC: u32 = 0u;
 const MATERIAL_WORKFLOW_SPECULAR: u32 = 1u;
@@ -258,14 +276,59 @@ fn resolve_specular_f0(
     );
 }
 
+// ── Default PBR material evaluation (uber-template) ──────────────────────────
+
+fn radiant_eval_surface(material: GpuMaterial, material_tex: MaterialTextureData, input: VertexOutput) -> SurfaceData {
+    let uv = input.tex_coords;
+    let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
+    let albedo = material.base_color * base_sample;
+    let alpha = albedo.a;
+
+    let N_geom = normalize(input.world_normal);
+
+    // Warp-uniform feature branch: normal mapping (gated by flag + texture)
+    var N: vec3<f32>;
+    if (material.flags & FLAG_HAS_NORMAL_MAP) != 0u && material_tex.normal.texture_index != NO_TEXTURE {
+        let T = normalize(input.world_tangent - dot(input.world_tangent, N_geom) * N_geom);
+        let B = cross(N_geom, T) * input.bitangent_sign;
+        var norm_ts = sample_texture(material_tex.normal, uv, vec4<f32>(0.5, 0.5, 1.0, 1.0)).rgb * 2.0 - 1.0;
+        norm_ts = vec3<f32>(norm_ts.x * material_tex.params.x, norm_ts.y * material_tex.params.x, norm_ts.z);
+        N = normalize(T * norm_ts.x + B * norm_ts.y + N_geom * norm_ts.z);
+    } else {
+        N = N_geom;
+    }
+
+    let orm_sample = sample_texture(material_tex.roughness_metallic, uv, vec4<f32>(1.0));
+    let occlusion_sample = sample_texture(material_tex.occlusion, uv, vec4<f32>(1.0));
+    let emissive_sample = sample_texture(material_tex.emissive, uv, vec4<f32>(1.0));
+
+    let ao = 1.0 + (occlusion_sample.r - 1.0) * material_tex.params.y;
+    let roughness = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
+    let metallic = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
+    let specular_f0 = resolve_specular_f0(material, material_tex, albedo.rgb, metallic, uv);
+    let emissive = material.emissive.rgb * material.emissive.w * emissive_sample.rgb;
+
+    // class_params are material-class-specific parameters set by external tools.
+    // The default PBR template ignores them; graph overrides and custom templates
+    // can interpret them freely (e.g. clear coat strength in .x, clear coat roughness in .y).
+
+    // Radiant override point: graph-generated WGSL replaces this section to
+    // override any SurfaceData field. When no graph is present the passthrough
+    // below is used (the default PBR result).
+    // RADIANT_OVERRIDE_SURFACE
+    // RADIANT_OVERRIDE_END
+
+    return SurfaceData(albedo, N, ao, roughness, metallic, specular_f0, emissive, alpha);
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> GBufferOutput {
     let material = materials[input.material_id];
     let material_tex = material_textures[input.material_id];
-    let uv = input.tex_coords;
 
-    // DEBUG MODE 1: Show UVs as colors (R=U, G=V, helps verify UV layout)
+    // DEBUG MODE 1: Show UVs as colors
     if globals.debug_mode == 1u {
+        let uv = input.tex_coords;
         return GBufferOutput(
             vec4<f32>(uv.x, uv.y, 0.0, 1.0),
             vec4<f32>(0.0, 0.0, 1.0, 0.0),
@@ -275,13 +338,9 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
         );
     }
 
-    // Sampled once and reused below — this used to be sampled a second time via
-    // an identical call further down, so every non-debug pixel paid for the
-    // same texture fetch twice for zero extra benefit.
-    let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
-
-    // DEBUG MODE 2: Show texture sample directly (bypass material multiply AND lighting)
+    // DEBUG MODE 2: Show texture sample directly
     if globals.debug_mode == 2u {
+        let base_sample = sample_texture(material_tex.base_color, input.tex_coords, vec4<f32>(1.0));
         return GBufferOutput(
             vec4<f32>(base_sample.rgb, 1.0),
             vec4<f32>(0.0, 0.0, 1.0, 0.0),
@@ -291,57 +350,35 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
         );
     }
 
-    // Common for modes 0 and 3
-    let albedo = material.base_color * base_sample;
-    let alpha = albedo.a;
-
-    if alpha <= 0.001 { discard; }
-    if alpha < material_tex.params.z { discard; }  // alpha_cutoff in params.z
-
-    let N_geom = normalize(input.world_normal);
-
-    // DEBUG MODE 3: Use geometry normal only (skip normal mapping)
-    var N: vec3<f32>;
+    // DEBUG MODE 3: Geometry normals only (skip normal mapping)
     if globals.debug_mode == 3u {
-        N = N_geom;
-    } else {
-        // NORMAL RENDERING (mode 0): vertex TBN normal mapping (MikkTSpace-compatible).
-        //
-        // Use the per-vertex tangent and bitangent sign that were computed by the
-        // DCC tool (Maya / Blender / etc.) and stored in the FBX/glTF file.
-        // Gram-Schmidt re-orthogonalization keeps T strictly perpendicular to N
-        // after interpolation across the triangle, then B = cross(N, T) * sign.
-        //
-        // This replaces the previous screen-space derivative approach which
-        // produced checkerboard artifacts at every UV island boundary because
-        // dpdx/dpdy are undefined at triangle edges and discontinuous across seams.
-        if material_tex.normal.texture_index != NO_TEXTURE {
-            let T = normalize(input.world_tangent - dot(input.world_tangent, N_geom) * N_geom);
-            let B = cross(N_geom, T) * input.bitangent_sign;
-            var norm_ts = sample_texture(material_tex.normal, uv, vec4<f32>(0.5, 0.5, 1.0, 1.0)).rgb * 2.0 - 1.0;
-            norm_ts = vec3<f32>(norm_ts.x * material_tex.params.x, norm_ts.y * material_tex.params.x, norm_ts.z);  // normal_scale in params.x
-            N = normalize(T * norm_ts.x + B * norm_ts.y + N_geom * norm_ts.z);
-        } else {
-            N = N_geom;
-        }
+        let uv = input.tex_coords;
+        let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
+        let albedo = material.base_color * base_sample;
+        let N_geom = normalize(input.world_normal);
+        let orm_sample = sample_texture(material_tex.roughness_metallic, uv, vec4<f32>(1.0));
+        let roughness = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
+        let metallic = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
+        return GBufferOutput(
+            vec4<f32>(albedo.rgb, albedo.a),
+            vec4<f32>(N_geom, 0.0),
+            vec4<f32>(1.0, roughness, metallic, 0.0),
+            vec4<f32>(0.0),
+            vec2<f32>(0.0)
+        );
     }
 
-    let orm_sample = sample_texture(material_tex.roughness_metallic, uv, vec4<f32>(1.0));
-    let occlusion_sample = sample_texture(material_tex.occlusion, uv, vec4<f32>(1.0));
-    let emissive_sample = sample_texture(material_tex.emissive, uv, vec4<f32>(1.0));
+    let surface = radiant_eval_surface(material, material_tex, input);
 
-    let ao = 1.0 + (occlusion_sample.r - 1.0) * material_tex.params.y;  // occlusion_strength in params.y
-    let roughness = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
-    let metallic = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
-    let specular_f0 = resolve_specular_f0(material, material_tex, albedo.rgb, metallic, uv);
-
-    let emissive = material.emissive.rgb * material.emissive.w * emissive_sample.rgb;
+    // Alpha test
+    if surface.alpha <= 0.001 { discard; }
+    if surface.alpha < material_tex.params.z { discard; }
 
     var out: GBufferOutput;
-    out.albedo = vec4<f32>(albedo.rgb, alpha);
-    out.normal = vec4<f32>(N, specular_f0.r);
-    out.orm = vec4<f32>(ao, roughness, metallic, specular_f0.g);
-    out.emissive = vec4<f32>(emissive, specular_f0.b);
+    out.albedo = vec4<f32>(surface.albedo.rgb, surface.alpha);
+    out.normal = vec4<f32>(surface.normal, surface.specular_f0.r);
+    out.orm = vec4<f32>(surface.ao, surface.roughness, surface.metallic, surface.specular_f0.g);
+    out.emissive = vec4<f32>(surface.emissive, surface.specular_f0.b);
     out.lightmap_uv = input.lightmap_uv;
     return out;
 }

--- a/crates/helio-pass-gbuffer/src/lib.rs
+++ b/crates/helio-pass-gbuffer/src/lib.rs
@@ -548,6 +548,11 @@ impl GBufferPass {
         );
     }
 
+    /// Access the template registry for loading new surface archetypes at runtime.
+    pub fn template_registry_mut(&mut self) -> &mut RadiantTemplateRegistry {
+        &mut self.template_registry
+    }
+
     /// Get or create a render pipeline for the given key.
     /// Compiles the shader lazily on first access, injecting `graph_wgsl` when
     /// `graph_hash != 0`.
@@ -558,8 +563,16 @@ impl GBufferPass {
         graph_wgsl: &str,
     ) -> &wgpu::RenderPipeline {
         if !self.pipelines.contains_key(&key) {
-            let template = self.template_registry.get(key.template_id)
-                .expect("Unknown material template class");
+            let template = match self.template_registry.get(key.template_id) {
+                Some(t) => t,
+                None => {
+                    log::warn!(
+                        "Radiant: template class {} not found, falling back to class 0",
+                        key.template_id,
+                    );
+                    self.template_registry.get(0).expect("Default PBR template (class 0) missing")
+                }
+            };
             let module = self.shader_cache.get_or_compile(
                 device, key, template, graph_wgsl, MAX_TEXTURES, "GBuffer Shader",
             );

--- a/crates/helio-pass-gbuffer/src/lib.rs
+++ b/crates/helio-pass-gbuffer/src/lib.rs
@@ -26,8 +26,10 @@
 //! buffer (slot 0) and index buffer before this pass executes.
 
 use bytemuck::{Pod, Zeroable};
+use helio::radiant::{RadiantShaderCache, RadiantShaderKey, RadiantTemplateRegistry};
 use helio_core::graph::{ResourceBuilder, ResourceSize};
 use helio_core::{DebugViewDescriptor, PassContext, PrepareContext, RenderPass, Result as HelioResult};
+use std::collections::HashMap;
 use std::num::NonZeroU32;
 
 /// Bindless texture array size per shader stage.
@@ -60,7 +62,10 @@ pub struct GBufferGlobals {
 // ── Pass struct ───────────────────────────────────────────────────────────────
 
 pub struct GBufferPass {
-    pipeline: wgpu::RenderPipeline,
+    pipelines: HashMap<RadiantShaderKey, wgpu::RenderPipeline>,
+    shader_cache: RadiantShaderCache,
+    template_registry: RadiantTemplateRegistry,
+    pipeline_layout: wgpu::PipelineLayout,
     bind_group_layout_0: wgpu::BindGroupLayout,
     bind_group_layout_1: wgpu::BindGroupLayout,
     /// Group 0: camera + globals + instance_data. Rebuilt when buffer pointers change.
@@ -84,39 +89,6 @@ pub struct GBufferPass {
 impl GBufferPass {
     /// Create the GBuffer pass.
     pub fn new(device: &wgpu::Device) -> Self {
-        // ── Shader ────────────────────────────────────────────────────────────
-        let shader_src = include_str!("../shaders/gbuffer.wgsl")
-            .replace(
-                "binding_array<texture_2d<f32>, 256>",
-                &format!("binding_array<texture_2d<f32>, {MAX_TEXTURES}>"),
-            )
-            .replace(
-                "binding_array<sampler, 256>",
-                &format!("binding_array<sampler, {MAX_TEXTURES}>"),
-            );
-        // WebGPU does not support binding arrays; collapse to single texture/sampler.
-        #[cfg(target_arch = "wasm32")]
-        let shader_src = shader_src
-            .replace(
-                &format!("binding_array<sampler, {MAX_TEXTURES}>"),
-                "sampler",
-            )
-            .replace("scene_samplers[slot.texture_index]", "scene_samplers")
-            .replace(
-                &format!("binding_array<texture_2d<f32>, {MAX_TEXTURES}>"),
-                "texture_2d<f32>",
-            )
-            .replace("scene_textures[slot.texture_index]", "scene_textures")
-            // textureSample requires uniform control flow on WebGPU; use textureSampleLevel (LOD 0) instead.
-            .replace(
-                "return textureSample(scene_textures, scene_samplers, uv);",
-                "return textureSampleLevel(scene_textures, scene_samplers, uv, 0.0);",
-            );
-        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-            label: Some("GBuffer Shader"),
-            source: wgpu::ShaderSource::Wgsl(shader_src.into()),
-        });
-
         // ── Globals buffer ────────────────────────────────────────────────────
         let globals_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("GBufferGlobals"),
@@ -180,118 +152,11 @@ impl GBufferPass {
         // ── Bind Group Layout 1: material + textures ──────────────────────────
         let bind_group_layout_1 = create_gbuffer_material_bgl(device);
 
-        // ── Pipeline ──────────────────────────────────────────────────────────
+        // ── Pipeline layout (shared by all pipeline variants) ─────────────────
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("GBuffer PL"),
             bind_group_layouts: &[Some(&bind_group_layout_0), Some(&bind_group_layout_1)],
             immediate_size: 0,
-        });
-
-        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
-            label: Some("GBuffer Pipeline"),
-            layout: Some(&pipeline_layout),
-            vertex: wgpu::VertexState {
-                module: &shader,
-                entry_point: Some("vs_main"),
-                compilation_options: Default::default(),
-                // Full vertex layout (stride = 40 bytes, matching shared mesh buffer).
-                //   offset  0 — position       Float32x3  location 0
-                //   offset 12 — bitangent_sign Float32    location 1
-                //   offset 16 — tex_coords0   Float32x2  location 2  (UV0: material/albedo)
-                //   offset 24 — tex_coords1   Float32x2  location 5  (UV1: lightmap)
-                //   offset 32 — normal        Uint32     location 3
-                //   offset 36 — tangent       Uint32     location 4
-                buffers: &[wgpu::VertexBufferLayout {
-                    array_stride: 40,
-                    step_mode: wgpu::VertexStepMode::Vertex,
-                    attributes: &[
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x3,
-                            offset: 0,
-                            shader_location: 0,
-                        },
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32,
-                            offset: 12,
-                            shader_location: 1,
-                        },
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x2,
-                            offset: 16,
-                            shader_location: 2,
-                        },
-                        // UV1 — dedicated lightmap UV channel (non-overlapping, [0,1] per mesh).
-                        // Previously marked "unused, skipped"; now wired to shader location 5.
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Float32x2,
-                            offset: 24,
-                            shader_location: 5,
-                        },
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Uint32,
-                            offset: 32,
-                            shader_location: 3,
-                        },
-                        wgpu::VertexAttribute {
-                            format: wgpu::VertexFormat::Uint32,
-                            offset: 36,
-                            shader_location: 4,
-                        },
-                    ],
-                }],
-            },
-            fragment: Some(wgpu::FragmentState {
-                module: &shader,
-                entry_point: Some("fs_main"),
-                compilation_options: Default::default(),
-                targets: &[
-                    Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba8Unorm,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::ALL,
-                    }),
-                    Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba16Float,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::ALL,
-                    }),
-                    Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba8Unorm,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::ALL,
-                    }),
-                    Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rgba16Float,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::ALL,
-                    }),
-                    Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rg16Float,
-                        blend: None,
-                        write_mask: wgpu::ColorWrites::ALL,
-                    }),
-                ],
-            }),
-            primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                cull_mode: Some(wgpu::Face::Back),
-                ..Default::default()
-            },
-            depth_stencil: Some(wgpu::DepthStencilState {
-                format: wgpu::TextureFormat::Depth32Float,
-                // Depth prepass already wrote the closest depth with `Less`.
-                // Use `LessEqual` for early-Z culling while being robust to precision issues.
-                // This maintains early-Z benefits (GPU can discard fragments before shading)
-                // while avoiding re-shading due to minor floating-point differences.
-                // GBuffer owns the depth write (DepthPrepass no longer runs).
-                depth_write_enabled: Some(true),
-                depth_compare: Some(wgpu::CompareFunction::LessEqual),
-                stencil: wgpu::StencilState::default(),
-                bias: wgpu::DepthBiasState::default(),
-            }),
-            multisample: wgpu::MultisampleState::default(),
-            multiview_mask: None,
-            cache: None,
         });
 
         // Create empty lightmap atlas regions buffer (populated when bake data is loaded).
@@ -304,7 +169,10 @@ impl GBufferPass {
         });
 
         Self {
-            pipeline,
+            pipelines: HashMap::new(),
+            shader_cache: RadiantShaderCache::new(),
+            template_registry: RadiantTemplateRegistry::new(),
+            pipeline_layout,
             bind_group_layout_0,
             bind_group_layout_1,
             bind_group_0: None,
@@ -544,7 +412,6 @@ impl RenderPass for GBufferPass {
         let indirect = ctx.scene.indirect;
 
         let pass = unsafe { &mut *ctx.active_render_pass_ptr().unwrap() };
-        pass.set_pipeline(&self.pipeline);
         pass.set_bind_group(0, self.bind_group_0.as_ref().unwrap(), &[]);
         pass.set_bind_group(1, self.bind_group_1.as_ref().unwrap(), &[]);
         pass.set_vertex_buffer(0, main_scene.mesh_buffers.vertices.slice(..));
@@ -552,11 +419,50 @@ impl RenderPass for GBufferPass {
             main_scene.mesh_buffers.indices.slice(..),
             wgpu::IndexFormat::Uint32,
         );
-        #[cfg(not(target_arch = "wasm32"))]
-        pass.multi_draw_indexed_indirect(indirect, 0, draw_count);
-        #[cfg(target_arch = "wasm32")]
-        for i in 0..draw_count {
-            pass.draw_indexed_indirect(indirect, i as u64 * 20);
+
+        let ranges = ctx.scene.material_class_ranges;
+        if ranges.is_empty() {
+            // Fallback: no ranges (e.g. legacy mode without material_class data).
+            // Use the default PBR pipeline and draw everything in one batch.
+            let key = RadiantShaderKey {
+                template_id: 0,
+                graph_hash: 0,
+                feature_flags: 0,
+            };
+            let pipeline = self.get_or_create_pipeline(&ctx.device, key, "");
+            pass.set_pipeline(pipeline);
+            #[cfg(not(target_arch = "wasm32"))]
+            pass.multi_draw_indexed_indirect(indirect, 0, draw_count);
+            #[cfg(target_arch = "wasm32")]
+            for i in 0..draw_count {
+                pass.draw_indexed_indirect(indirect, i as u64 * 20);
+            }
+        } else {
+            for &(class, graph_hash, start, count) in ranges {
+                if count == 0 {
+                    continue;
+                }
+                let key = RadiantShaderKey {
+                    template_id: class,
+                    graph_hash,
+                    feature_flags: 0,
+                };
+                let graph_wgsl = ctx
+                    .scene
+                    .graph_wgsl_snippets
+                    .get(&graph_hash)
+                    .map(|s| s.as_str())
+                    .unwrap_or("");
+                let pipeline = self.get_or_create_pipeline(&ctx.device, key, graph_wgsl);
+                pass.set_pipeline(pipeline);
+                // DrawIndexedIndirectArgs = 5 × u32 = 20 bytes per entry
+                #[cfg(not(target_arch = "wasm32"))]
+                pass.multi_draw_indexed_indirect(indirect, start as u64 * 20, count);
+                #[cfg(target_arch = "wasm32")]
+                for i in start..start + count {
+                    pass.draw_indexed_indirect(indirect, i as u64 * 20);
+                }
+            }
         }
         Ok(())
     }
@@ -640,6 +546,125 @@ impl GBufferPass {
             regions.len(),
             buf_size
         );
+    }
+
+    /// Get or create a render pipeline for the given key.
+    /// Compiles the shader lazily on first access, injecting `graph_wgsl` when
+    /// `graph_hash != 0`.
+    fn get_or_create_pipeline(
+        &mut self,
+        device: &wgpu::Device,
+        key: RadiantShaderKey,
+        graph_wgsl: &str,
+    ) -> &wgpu::RenderPipeline {
+        if !self.pipelines.contains_key(&key) {
+            let template = self.template_registry.get(key.template_id)
+                .expect("Unknown material template class");
+            let module = self.shader_cache.get_or_compile(
+                device, key, template, graph_wgsl, MAX_TEXTURES, "GBuffer Shader",
+            );
+            let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+                label: Some("GBuffer Pipeline"),
+                layout: Some(&self.pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    // Full vertex layout (stride = 40 bytes, matching shared mesh buffer).
+                    //   offset  0 — position       Float32x3  location 0
+                    //   offset 12 — bitangent_sign Float32    location 1
+                    //   offset 16 — tex_coords0   Float32x2  location 2  (UV0: material/albedo)
+                    //   offset 24 — tex_coords1   Float32x2  location 5  (UV1: lightmap)
+                    //   offset 32 — normal        Uint32     location 3
+                    //   offset 36 — tangent       Uint32     location 4
+                    buffers: &[wgpu::VertexBufferLayout {
+                        array_stride: 40,
+                        step_mode: wgpu::VertexStepMode::Vertex,
+                        attributes: &[
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32x3,
+                                offset: 0,
+                                shader_location: 0,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32,
+                                offset: 12,
+                                shader_location: 1,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32x2,
+                                offset: 16,
+                                shader_location: 2,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Float32x2,
+                                offset: 24,
+                                shader_location: 5,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Uint32,
+                                offset: 32,
+                                shader_location: 3,
+                            },
+                            wgpu::VertexAttribute {
+                                format: wgpu::VertexFormat::Uint32,
+                                offset: 36,
+                                shader_location: 4,
+                            },
+                        ],
+                    }],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module,
+                    entry_point: Some("fs_main"),
+                    compilation_options: Default::default(),
+                    targets: &[
+                        Some(wgpu::ColorTargetState {
+                            format: wgpu::TextureFormat::Rgba8Unorm,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        }),
+                        Some(wgpu::ColorTargetState {
+                            format: wgpu::TextureFormat::Rgba16Float,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        }),
+                        Some(wgpu::ColorTargetState {
+                            format: wgpu::TextureFormat::Rgba8Unorm,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        }),
+                        Some(wgpu::ColorTargetState {
+                            format: wgpu::TextureFormat::Rgba16Float,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        }),
+                        Some(wgpu::ColorTargetState {
+                            format: wgpu::TextureFormat::Rg16Float,
+                            blend: None,
+                            write_mask: wgpu::ColorWrites::ALL,
+                        }),
+                    ],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    cull_mode: Some(wgpu::Face::Back),
+                    ..Default::default()
+                },
+                depth_stencil: Some(wgpu::DepthStencilState {
+                    format: wgpu::TextureFormat::Depth32Float,
+                    depth_write_enabled: Some(true),
+                    depth_compare: Some(wgpu::CompareFunction::LessEqual),
+                    stencil: wgpu::StencilState::default(),
+                    bias: wgpu::DepthBiasState::default(),
+                }),
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            });
+            self.pipelines.insert(key, pipeline);
+        }
+        self.pipelines.get(&key).unwrap()
     }
 }
 

--- a/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
@@ -44,7 +44,8 @@ struct GpuMaterial {
     tex_occlusion:      u32,
     workflow:           u32,
     flags:              u32,
-    _pad:               u32,
+    material_class:     u32,
+    class_params:       vec4<f32>,
 }
 
 struct MaterialTextureSlot {

--- a/crates/helio-web-demos/src/common.rs
+++ b/crates/helio-web-demos/src/common.rs
@@ -26,7 +26,8 @@ pub fn make_material(
         tex_occlusion: GpuMaterial::NO_TEXTURE,
         workflow: 0,
         flags: 0,
-        _pad: 0,
+        material_class: 0,
+        class_params: [0.0; 4],
     }
 }
 

--- a/crates/helio/src/lib.rs
+++ b/crates/helio/src/lib.rs
@@ -17,6 +17,7 @@ mod material;
 mod mesh;
 mod picking;
 mod quark_commands;
+pub mod radiant;
 mod renderer;
 mod scene;
 mod terrain;

--- a/crates/helio/src/radiant/graph_registry.rs
+++ b/crates/helio/src/radiant/graph_registry.rs
@@ -1,0 +1,38 @@
+use std::collections::HashMap;
+
+/// Registry of graph-generated WGSL snippets, keyed by hash.
+///
+/// External tools (graph compilers, editors) call `register()` to make a
+/// compiled material graph available to the engine. The GBuffer pass looks
+/// up the snippet by hash when it encounters a material with `graph_hash != 0`.
+pub struct RadiantGraphRegistry {
+    /// graph_hash → WGSL source snippet injected at RADIANT_OVERRIDE_SURFACE
+    snippets: HashMap<u64, String>,
+}
+
+impl RadiantGraphRegistry {
+    pub fn new() -> Self {
+        Self { snippets: HashMap::new() }
+    }
+
+    /// Register a compiled graph snippet. `graph_hash` should be a content-hash
+    /// of the graph's serialized form (provided by the external compiler).
+    pub fn register(&mut self, graph_hash: u64, wgsl_snippet: String) {
+        self.snippets.insert(graph_hash, wgsl_snippet);
+    }
+
+    /// Look up a graph snippet by hash. Returns None if not found.
+    pub fn get(&self, graph_hash: u64) -> Option<&str> {
+        self.snippets.get(&graph_hash).map(|s| s.as_str())
+    }
+
+    /// Remove a graph snippet (e.g. when a material is deleted).
+    pub fn unregister(&mut self, graph_hash: u64) {
+        self.snippets.remove(&graph_hash);
+    }
+
+    /// Number of registered graph snippets.
+    pub fn len(&self) -> usize {
+        self.snippets.len()
+    }
+}

--- a/crates/helio/src/radiant/material_flags.rs
+++ b/crates/helio/src/radiant/material_flags.rs
@@ -1,0 +1,48 @@
+//! Feature-flag helper functions for material flags.
+//!
+//! These are thin wrappers over the bit-flag constants defined in `libhelio`.
+
+use libhelio::{
+    FLAG_ALPHA_BLEND, FLAG_ALPHA_TEST, FLAG_DOUBLE_SIDED, FLAG_HAS_ANISOTROPY,
+    FLAG_HAS_CLEAR_COAT, FLAG_HAS_CUSTOM_SHADER, FLAG_HAS_NORMAL_MAP, FLAG_HAS_SUBSURFACE,
+};
+
+/// Check if a material has double-sided rendering enabled.
+pub fn is_double_sided(flags: u32) -> bool {
+    flags & FLAG_DOUBLE_SIDED != 0
+}
+
+/// Check if a material has alpha blending enabled.
+pub fn has_alpha_blend(flags: u32) -> bool {
+    flags & FLAG_ALPHA_BLEND != 0
+}
+
+/// Check if a material has alpha testing enabled.
+pub fn has_alpha_test(flags: u32) -> bool {
+    flags & FLAG_ALPHA_TEST != 0
+}
+
+/// Check if a material has a normal map bound.
+pub fn has_normal_map(flags: u32) -> bool {
+    flags & FLAG_HAS_NORMAL_MAP != 0
+}
+
+/// Check if a material has clear-coat rendering enabled.
+pub fn has_clear_coat(flags: u32) -> bool {
+    flags & FLAG_HAS_CLEAR_COAT != 0
+}
+
+/// Check if a material has subsurface scattering enabled.
+pub fn has_subsurface(flags: u32) -> bool {
+    flags & FLAG_HAS_SUBSURFACE != 0
+}
+
+/// Check if a material has anisotropy enabled.
+pub fn has_anisotropy(flags: u32) -> bool {
+    flags & FLAG_HAS_ANISOTROPY != 0
+}
+
+/// Check if a material uses a custom shader.
+pub fn has_custom_shader(flags: u32) -> bool {
+    flags & FLAG_HAS_CUSTOM_SHADER != 0
+}

--- a/crates/helio/src/radiant/mod.rs
+++ b/crates/helio/src/radiant/mod.rs
@@ -1,0 +1,15 @@
+//! Radiant — Helio's hybrid material template system.
+//!
+//! Radiant combines hand-authored template shaders with graph-generated WGSL
+//! snippets to give artists flexibility without forcing PSO permutations for
+//! every material.
+
+mod graph_registry;
+mod material_flags;
+mod shader_cache;
+pub mod template;
+
+pub use graph_registry::RadiantGraphRegistry;
+pub use material_flags::*;
+pub use shader_cache::*;
+pub use template::*;

--- a/crates/helio/src/radiant/shader_cache.rs
+++ b/crates/helio/src/radiant/shader_cache.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+
+/// Key for cached shader modules: (template_id, graph_hash, feature_flag_mask)
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
+pub struct RadiantShaderKey {
+    pub template_id: u32,
+    pub graph_hash: u64,
+    pub feature_flags: u32,
+}
+
+/// Cache of compiled shader modules keyed by template variant.
+///
+/// The same (template, graph, flags) tuple always produces identical WGSL, so
+/// we keep the `wgpu::ShaderModule` around to avoid recompilation.
+pub struct RadiantShaderCache {
+    modules: HashMap<RadiantShaderKey, wgpu::ShaderModule>,
+}
+
+impl RadiantShaderCache {
+    pub fn new() -> Self {
+        Self {
+            modules: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &RadiantShaderKey) -> Option<&wgpu::ShaderModule> {
+        self.modules.get(key)
+    }
+
+    pub fn insert(&mut self, key: RadiantShaderKey, module: wgpu::ShaderModule) {
+        self.modules.insert(key, module);
+    }
+
+    /// Get or compile a shader module for the given key.
+    /// If `graph_wgsl` is empty, the default template is used as-is.
+    pub fn get_or_compile(
+        &mut self,
+        device: &wgpu::Device,
+        key: RadiantShaderKey,
+        template: &super::template::RadiantTemplate,
+        graph_wgsl: &str,
+        max_textures: usize,
+        label: &str,
+    ) -> &wgpu::ShaderModule {
+        if !self.modules.contains_key(&key) {
+            let source = template.build_shader_source(graph_wgsl, max_textures);
+            let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+                label: Some(label),
+                source: wgpu::ShaderSource::Wgsl(source.into()),
+            });
+            self.modules.insert(key, module);
+        }
+        self.modules.get(&key).unwrap()
+    }
+
+    pub fn len(&self) -> usize {
+        self.modules.len()
+    }
+}

--- a/crates/helio/src/radiant/template.rs
+++ b/crates/helio/src/radiant/template.rs
@@ -1,0 +1,104 @@
+use std::collections::HashMap;
+
+pub struct RadiantTemplate {
+    pub name: &'static str,
+    /// Base WGSL source with `// RADIANT_OVERRIDE_SURFACE` markers
+    pub wgsl_source: &'static str,
+}
+
+impl RadiantTemplate {
+    /// Build the final WGSL source by optionally injecting a graph snippet.
+    /// If `graph_wgsl` is empty, the OVERRIDE markers are replaced with a no-op
+    /// passthrough to keep the default PBR evaluation.
+    pub fn build_shader_source(&self, graph_wgsl: &str, max_textures: usize) -> String {
+        let max_tex_str = max_textures.to_string();
+        let src = self.wgsl_source
+            .replace("binding_array<texture_2d<f32>, 256>", &format!("binding_array<texture_2d<f32>, {max_tex_str}>"))
+            .replace("binding_array<sampler, 256>", &format!("binding_array<sampler, {max_tex_str}>"));
+
+        if graph_wgsl.is_empty() {
+            // No graph: remove the override markers, leaving the default code
+            src.replace("// RADIANT_OVERRIDE_SURFACE\n", "")
+               .replace("// RADIANT_OVERRIDE_END\n", "")
+        } else {
+            // Graph present: replace everything from OVERRIDE_SURFACE to OVERRIDE_END
+            // with the graph's override code
+            let override_start = "// RADIANT_OVERRIDE_SURFACE";
+            let override_end = "// RADIANT_OVERRIDE_END";
+            if let Some(start) = src.find(override_start) {
+                if let Some(end) = src.find(override_end) {
+                    let before = &src[..start];
+                    let after = &src[end + override_end.len()..];
+                    format!("{}{}\n{}", before, graph_wgsl, after)
+                } else {
+                    src
+                }
+            } else {
+                src
+            }
+        }
+    }
+
+    /// Apply WebGPU-specific fixups (binding arrays, textureSampleLevel)
+    pub fn apply_webgpu_fixups(src: &str) -> String {
+        // This will be called by the GBuffer pass for wasm32 builds
+        src.to_string()
+    }
+}
+
+/// Built-in templates shipped with the engine.
+pub struct RadiantTemplateRegistry {
+    templates: HashMap<u32, RadiantTemplate>,
+    next_id: u32,
+}
+
+impl RadiantTemplateRegistry {
+    pub fn new() -> Self {
+        let mut reg = Self {
+            templates: HashMap::new(),
+            next_id: 1,
+        };
+        reg.templates.insert(0, RadiantTemplate {
+            name: "default_pbr",
+            wgsl_source: include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../helio-pass-gbuffer/shaders/gbuffer.wgsl"
+            )),
+        });
+        reg
+    }
+
+    pub fn get(&self, class: u32) -> Option<&RadiantTemplate> {
+        self.templates.get(&class)
+    }
+
+    pub fn register(&mut self, class: u32, template: RadiantTemplate) {
+        self.templates.insert(class, template);
+    }
+
+    /// Load a template from a WGSL file on disk. The template should contain
+    /// `// RADIANT_OVERRIDE_SURFACE` and `// RADIANT_OVERRIDE_END` markers.
+    /// Returns the assigned template_id.
+    pub fn load_from_file(&mut self, path: &std::path::Path) -> std::io::Result<u32> {
+        let source = std::fs::read_to_string(path)?;
+        Ok(self.register_str(
+            path.file_stem().and_then(|s| s.to_str()).unwrap_or("unknown"),
+            source,
+        ))
+    }
+
+    /// Register a template from a string (useful for embedded or generated templates).
+    pub fn register_str(&mut self, name: &str, wgsl_source: String) -> u32 {
+        let id = self.next_id;
+        self.next_id += 1;
+        self.templates.insert(id, RadiantTemplate {
+            name: Box::leak(format!("Radiant:{}", name).into_boxed_str()),
+            wgsl_source: Box::leak(wgsl_source.into_boxed_str()),
+        });
+        id
+    }
+
+    pub fn len(&self) -> usize {
+        self.templates.len()
+    }
+}

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -129,7 +129,7 @@ pub struct Scene {
 
     // ── Radiant material graph system ──────────────────────────────────────────
     /// Registry of compiled graph WGSL snippets, keyed by content hash.
-    pub(in crate::scene) radiant_graphs: RadiantGraphRegistry,
+    pub radiant_graphs: RadiantGraphRegistry,
 
     /// Transform-only changes accumulated until the next scene flush (end exclusive).
     pub(in crate::scene) vg_instance_dirty_range: Option<(usize, usize)>,
@@ -366,6 +366,16 @@ impl Scene {
         }
         let updated = self.gpu_scene.materials.update(slot, record.gpu);
         debug_assert!(updated);
+        Ok(())
+    }
+
+    /// Update only the class_params of a material (no texture revalidation).
+    pub fn update_material_class_params(&mut self, material_id: MaterialId, params: [f32; 4]) -> Result<()> {
+        let Some((slot, record)) = self.materials.get_mut_with_slot(material_id) else {
+            return Err(invalid("material"));
+        };
+        record.gpu.class_params = params;
+        self.gpu_scene.materials.update(slot, record.gpu);
         Ok(())
     }
 

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -18,6 +18,7 @@ use crate::handles::{
     LightId, MaterialId, MultiMeshId, ObjectId, PostProcessVolumeId, SectionedInstanceId,
     TextureId, VirtualObjectId, WaterHitboxId, WaterVolumeId, VoxelVolumeId,
 };
+use crate::radiant::RadiantGraphRegistry;
 use super::voxel::VoxelVolumeRecord;
 use super::types::VoxelVolumeDescriptor;
 use crate::mesh::{MeshPool, MultiMeshRecord};
@@ -125,6 +126,10 @@ pub struct Scene {
     /// Monotonically increasing counter forwarded to `VgFrameData::buffer_version`.
     /// The VG pass re-uploads GPU buffers only when this advances.
     pub(in crate::scene) vg_buffer_version: u64,
+
+    // ── Radiant material graph system ──────────────────────────────────────────
+    /// Registry of compiled graph WGSL snippets, keyed by content hash.
+    pub(in crate::scene) radiant_graphs: RadiantGraphRegistry,
 
     /// Transform-only changes accumulated until the next scene flush (end exclusive).
     pub(in crate::scene) vg_instance_dirty_range: Option<(usize, usize)>,
@@ -302,6 +307,7 @@ impl Scene {
             vg_cpu_instances: Vec::new(),
             vg_cpu_work_items: Vec::new(),
             vg_max_draw_count: 0,
+            radiant_graphs: RadiantGraphRegistry::new(),
             water_volumes: DenseArena::new(),
             water_volumes_dirty: false,
             water_volumes_dirty_range: None,
@@ -335,6 +341,31 @@ impl Scene {
     pub fn remove_voxel_volume(&mut self, id: VoxelVolumeId) -> Result<()> {
         self.voxel_volumes.remove(id);
         self.gpu_scene.voxel_volume_count = self.voxel_volumes.len() as u32;
+        Ok(())
+    }
+
+    /// Set the material class and graph hash for an existing material.
+    ///
+    /// `material_class` selects the surface archetype template (0 = default PBR).
+    /// `graph_hash` selects a WGSL snippet from the graph registry (0 = none).
+    /// `feature_flags` overrides the material's feature flags (pass `None` to keep existing).
+    pub fn set_material_class(
+        &mut self,
+        material_id: MaterialId,
+        material_class: u32,
+        graph_hash: u64,
+        feature_flags: Option<u32>,
+    ) -> Result<()> {
+        let Some((slot, record)) = self.materials.get_mut_with_slot(material_id) else {
+            return Err(invalid("material"));
+        };
+        record.gpu.material_class = material_class;
+        record.graph_hash = graph_hash;
+        if let Some(flags) = feature_flags {
+            record.gpu.flags = flags;
+        }
+        let updated = self.gpu_scene.materials.update(slot, record.gpu);
+        debug_assert!(updated);
         Ok(())
     }
 

--- a/crates/helio/src/scene/flush.rs
+++ b/crates/helio/src/scene/flush.rs
@@ -279,6 +279,42 @@ impl Scene {
             }
         }
 
+        // ── Material graph hashes ─────────────────────────────────────────────
+        // Build a slot-indexed Vec from the SparsePool so the GBuffer pass can
+        // look up graph_hash by material_id (slot index) for PSO selection.
+        {
+            let slot_count = self.materials.slot_len();
+            let mut hashes = vec![0u64; slot_count];
+            for slot in 0..slot_count {
+                if let Some(record) = self.materials.get_by_slot(slot) {
+                    hashes[slot] = record.graph_hash;
+                }
+            }
+            self.gpu_scene.material_graph_hashes = hashes;
+        }
+
+        // ── Graph WGSL snippets ────────────────────────────────────────────────
+        // Sync the global snippet registry into GpuScene so passes (GBuffer) can
+        // look up WGSL source by hash when building PSOs.
+        {
+            let registry = &self.radiant_graphs;
+            // Collect all unique hashes referenced by any material.
+            // This is a fast-path: copy the whole registry rather than
+            // diffing, because the registry is small (typically << 100 entries).
+            let mut snippets = std::collections::HashMap::new();
+            for slot in 0..self.materials.slot_len() {
+                if let Some(record) = self.materials.get_by_slot(slot) {
+                    let hash = record.graph_hash;
+                    if hash != 0 && !snippets.contains_key(&hash) {
+                        if let Some(wgsl) = registry.get(hash) {
+                            snippets.insert(hash, wgsl.to_owned());
+                        }
+                    }
+                }
+            }
+            self.gpu_scene.graph_wgsl_snippets = snippets;
+        }
+
         self.gpu_scene.flush();
     }
 }

--- a/crates/helio/src/scene/objects/rebuild.rs
+++ b/crates/helio/src/scene/objects/rebuild.rs
@@ -96,8 +96,26 @@ impl super::super::Scene {
             self.gpu_scene.draw_calls.set_data(Vec::new());
             self.gpu_scene.indirect.set_data(Vec::new());
             self.gpu_scene.visibility.set_data(Vec::new());
+            self.gpu_scene.material_class_ranges.clear();
             return;
         }
+
+        let group_hidden = self.group_hidden;
+
+        // Build sort order by (material_class, graph_hash) so contiguous
+        // ranges are uniform in both fields, letting each range share a single PSO.
+        let mut indexed: Vec<(u32, u64, usize)> = (0..n)
+            .map(|i| {
+                let r = self.objects.get_dense(i).unwrap();
+                let (class, graph_hash) = self
+                    .materials
+                    .get(r.material)
+                    .map(|m| (m.gpu.material_class, m.graph_hash))
+                    .unwrap_or((0, 0));
+                (class, graph_hash, i)
+            })
+            .collect();
+        indexed.sort_by_key(|&(class, gh, _)| (class, gh));
 
         let mut instances = Vec::with_capacity(n);
         let mut aabbs = Vec::with_capacity(n);
@@ -105,20 +123,17 @@ impl super::super::Scene {
         let mut indirect = Vec::with_capacity(n);
         let mut visibility = Vec::with_capacity(n);
 
-        let group_hidden = self.group_hidden;
-
-        // Linear iteration: each object gets slot = dense_index
-        for i in 0..n {
-            let r = self.objects.get_dense(i).unwrap();
+        for &(_, _, dense_idx) in &indexed {
+            let r = self.objects.get_dense(dense_idx).unwrap();
+            let slot = instances.len() as u32;
             instances.push(r.instance);
             aabbs.push(r.aabb);
 
-            // One draw call per object
             draw_calls.push(GpuDrawCall {
                 index_count: r.draw.index_count,
                 first_index: r.draw.first_index,
                 vertex_offset: r.draw.vertex_offset,
-                first_instance: i as u32,
+                first_instance: slot,
                 instance_count: 1,
             });
 
@@ -127,7 +142,7 @@ impl super::super::Scene {
                 instance_count: 1,
                 first_index: r.draw.first_index,
                 base_vertex: r.draw.vertex_offset,
-                first_instance: i as u32,
+                first_instance: slot,
             });
 
             visibility.push(if object_is_visible(r.groups, group_hidden) {
@@ -137,11 +152,27 @@ impl super::super::Scene {
             });
         }
 
-        // Update ObjectRecords with GPU slots
-        for i in 0..n {
-            if let Some(r) = self.objects.get_dense_mut(i) {
-                r.gpu_slot = i as u32;
-                r.draw.first_instance = i as u32;
+        // Build material class ranges (contiguous runs of the same class + graph_hash)
+        let mut ranges: Vec<(u32, u64, u32, u32)> = Vec::new();
+        let mut ri = 0;
+        while ri < indexed.len() {
+            let class = indexed[ri].0;
+            let graph_hash = indexed[ri].1;
+            let start = ri as u32;
+            let mut count = 0u32;
+            while ri < indexed.len() && indexed[ri].0 == class && indexed[ri].1 == graph_hash {
+                count += 1;
+                ri += 1;
+            }
+            ranges.push((class, graph_hash, start, count));
+        }
+        self.gpu_scene.material_class_ranges = ranges;
+
+        // Update ObjectRecords with their new sorted GPU slots
+        for (sorted_idx, &(_, _, dense_idx)) in indexed.iter().enumerate() {
+            if let Some(r) = self.objects.get_dense_mut(dense_idx) {
+                r.gpu_slot = sorted_idx as u32;
+                r.draw.first_instance = sorted_idx as u32;
             }
         }
 
@@ -208,14 +239,23 @@ impl super::super::Scene {
             self.gpu_scene.draw_calls.set_data(Vec::new());
             self.gpu_scene.indirect.set_data(Vec::new());
             self.gpu_scene.visibility.set_data(Vec::new());
+            self.gpu_scene.material_class_ranges.clear();
             return;
         }
 
-        // Build a sort order over the dense array indices, grouped by (mesh_id, material_id).
+        // Build a sort order over the dense array indices, grouped by
+        // (material_class, graph_hash, mesh_id, material_id) so that contiguous
+        // draw groups share both class and graph_hash, letting each range use a
+        // single PSO.
         let mut order: Vec<usize> = (0..n).collect();
         order.sort_by_key(|&i| {
             let r = self.objects.get_dense(i).unwrap();
-            (r.instance.mesh_id, r.instance.material_id)
+            let (class, graph_hash) = self
+                .materials
+                .get(r.material)
+                .map(|m| (m.gpu.material_class, m.graph_hash))
+                .unwrap_or((0, 0));
+            (class, graph_hash, r.instance.mesh_id, r.instance.material_id)
         });
 
         let mut instances: Vec<GpuInstanceData> = Vec::with_capacity(n);
@@ -225,12 +265,19 @@ impl super::super::Scene {
         let mut visibility: Vec<u32> = Vec::with_capacity(n);
         // Track the new GPU slot assigned to each dense-array entry.
         let mut gpu_slots: Vec<u32> = vec![0u32; n];
+        // Track the (material_class, graph_hash) of each draw group for range building.
+        let mut group_keys: Vec<(u32, u64)> = Vec::new();
 
         let group_hidden = self.group_hidden;
 
         let mut i = 0;
         while i < order.len() {
             let r0 = self.objects.get_dense(order[i]).unwrap();
+            let (class, graph_hash) = self
+                .materials
+                .get(r0.material)
+                .map(|m| (m.gpu.material_class, m.graph_hash))
+                .unwrap_or((0, 0));
             let key = (r0.instance.mesh_id, r0.instance.material_id);
             let group_start = instances.len() as u32;
             let (index_count, first_index, vertex_offset) = (
@@ -271,7 +318,24 @@ impl super::super::Scene {
                 base_vertex: vertex_offset,
                 first_instance: group_start,
             });
+            group_keys.push((class, graph_hash));
         }
+
+        // Build material class ranges from consecutive draw groups with the same
+        // (class, graph_hash) so each range can use a single PSO.
+        let mut ranges: Vec<(u32, u64, u32, u32)> = Vec::new();
+        let mut gi = 0;
+        while gi < group_keys.len() {
+            let (class, graph_hash) = group_keys[gi];
+            let start = gi as u32;
+            let mut count = 0u32;
+            while gi < group_keys.len() && group_keys[gi] == (class, graph_hash) {
+                count += 1;
+                gi += 1;
+            }
+            ranges.push((class, graph_hash, start, count));
+        }
+        self.gpu_scene.material_class_ranges = ranges;
 
         // Patch each ObjectRecord with its new GPU slot so that in-frame
         // `update_object_transform` / `update_object_bounds` can update in-place.

--- a/crates/helio/src/scene/resources/materials.rs
+++ b/crates/helio/src/scene/resources/materials.rs
@@ -113,6 +113,7 @@ impl super::super::Scene {
             gpu: material.gpu,
             textures: material.textures,
             ref_count: 0,
+            graph_hash: 0,
         });
         // Use the GrowableBuffer length as the source of truth for push-vs-update.
         // After a pool reset the GPU buffer is empty (len=0) even though the SparsePool

--- a/crates/helio/src/scene/types.rs
+++ b/crates/helio/src/scene/types.rs
@@ -129,6 +129,11 @@ pub(crate) struct MaterialRecord {
 
     /// Number of objects currently using this material.
     pub ref_count: u32,
+
+    /// Graph-compiled WGSL hash (0 = no override). Copied to
+    /// [`GpuScene::material_graph_hashes`](helio_core::GpuScene::material_graph_hashes)
+    /// during flush for PSO selection in the GBuffer pass.
+    pub graph_hash: u64,
 }
 
 /// Internal record for a light.

--- a/crates/libhelio/src/material.rs
+++ b/crates/libhelio/src/material.rs
@@ -10,7 +10,27 @@ pub enum MaterialWorkflow {
     Specular = 1,
 }
 
-/// GPU material data. 96 bytes (matches helio-render-v2).
+/// Feature flags for [`GpuMaterial::flags`].
+///
+/// Each flag toggles a warp-uniform branch in the generated WGSL; disabled
+/// features cost zero instructions via constant-condition elimination.
+pub const FLAG_DOUBLE_SIDED: u32 = 1 << 0;
+pub const FLAG_ALPHA_BLEND: u32 = 1 << 1;
+pub const FLAG_ALPHA_TEST: u32 = 1 << 2;
+pub const FLAG_HAS_NORMAL_MAP: u32 = 1 << 3;
+pub const FLAG_HAS_CLEAR_COAT: u32 = 1 << 4;
+pub const FLAG_HAS_SUBSURFACE: u32 = 1 << 5;
+pub const FLAG_HAS_ANISOTROPY: u32 = 1 << 6;
+pub const FLAG_HAS_CUSTOM_SHADER: u32 = 1 << 7;
+
+/// Material class shader archetypes.
+pub const MATERIAL_CLASS_DEFAULT: u32 = 0;
+pub const MATERIAL_CLASS_CLEAR_COAT: u32 = 1;
+pub const MATERIAL_CLASS_SUBSURFACE: u32 = 2;
+pub const MATERIAL_CLASS_ANISOTROPIC: u32 = 3;
+pub const MATERIAL_CLASS_CUSTOM: u32 = 0xFFFF;
+
+/// GPU material data. 112 bytes.
 ///
 /// All texture indices reference the global bindless texture array.
 /// If a texture is not present, the index is u32::MAX.
@@ -28,7 +48,8 @@ pub enum MaterialWorkflow {
 ///     tex_occlusion:        u32,
 ///     workflow:             u32,
 ///     flags:                u32,
-///     _pad:                 u32,
+///     material_class:       u32,
+///     class_params:         vec4<f32>,
 /// }
 /// ```
 #[repr(C)]
@@ -48,9 +69,14 @@ pub struct GpuMaterial {
     pub tex_occlusion: u32,
     /// MaterialWorkflow discriminant
     pub workflow: u32,
-    /// Flags (bit 0 = double-sided, bit 1 = alpha-blend, bit 2 = alpha-test)
+    /// Feature flags (see `FLAG_*` constants)
     pub flags: u32,
-    pub _pad: u32,
+    /// Material class selector (see `MATERIAL_CLASS_*` constants)
+    pub material_class: u32,
+    /// Class-specific parameters interpreted by the active Radiant template.
+    /// The default PBR template ignores these; custom templates can use them
+    /// for any purpose (e.g. clear-coat strength, subsurface colour, anisotropy direction).
+    pub class_params: [f32; 4],
 }
 
 impl GpuMaterial {

--- a/crates_other/helio-snapshot/src/renderer.rs
+++ b/crates_other/helio-snapshot/src/renderer.rs
@@ -199,7 +199,8 @@ async fn render_snapshot_async<P: AsRef<Path>>(
         tex_occlusion: GpuMaterial::NO_TEXTURE,
         workflow: 0,
         flags: 0,
-        _pad: 0,
+        material_class: 0,
+        class_params: [0.0; 4],
     });
 
     // ── 8. Place a renderable object for each uploaded mesh ───────────────────
@@ -536,7 +537,7 @@ impl SnapshotBatch {
             tex_roughness:  GpuMaterial::NO_TEXTURE,
             tex_emissive:   GpuMaterial::NO_TEXTURE,
             tex_occlusion:  GpuMaterial::NO_TEXTURE,
-            workflow: 0, flags: 0, _pad: 0,
+            workflow: 0, flags: 0, material_class: 0, class_params: [0.0; 4],
         });
 
         for (i, mesh) in scene.meshes.iter().enumerate() {


### PR DESCRIPTION
# Radiant Material System + Rendering Pipeline Improvements

## Summary

This PR introduces the Radiant hybrid material system, swaps the default/FXAA anti-aliasing pipelines, fixes voxel terrain integration, and adds a full Radiant material demo.

---

## 1. Radiant — Hybrid Material Templates

A new material system that combines hand-authored surface templates with graph-generated WGSL snippets, delivering custom surface shaders without forcing per-permutation PSO cost.

**Three-tier cost model:**

| Tier | Mechanism | PSOs | Use case |
|------|-----------|------|----------|
| Tier 1 | Feature flags on the built-in uber-shader | 1 | ~95% of materials |
| Tier 2 | Hand-authored `.wgsl` template + optional graph snippet | Per template | Surface archetypes (clear coat, skin, fabric) |
| Tier 3 | Full custom WGSL via graph compiler | Per snippet | Unique surfaces |

**New modules:**
- `crates/helio/src/radiant/` — `template.rs` (template concatenation at `RADIANT_OVERRIDE_SURFACE` markers), `shader_cache.rs` (lazy shader compilation keyed by template_id × graph_hash × flags), `graph_registry.rs` (hash → WGSL snippet storage for external compilers), `material_flags.rs`
- `crates/helio-pass-gbuffer/` — PSO table (`HashMap<RadiantShaderKey, wgpu::RenderPipeline>`), lazy compilation, draw-call grouping by `(material_class, graph_hash)` ranges

**API surface for external toolchains:**
- `scene.radiant_graphs.register(hash, wgsl)` — register compiled graph snippets
- `scene.set_material_class(id, class, hash, flags)` — assign template/graph/flags
- `scene.update_material_class_params(id, [f32; 4])` — animate class params per frame
- `pass.template_registry_mut().load_from_file(path)` / `.register_str(name, wgsl)` — register new templates

**Data structure changes:**
- `GpuMaterial`: `_pad` → `material_class: u32`; added `class_params: [f32; 4]` (96 → 112 bytes)
- Feature flags extended: `FLAG_HAS_NORMAL_MAP`, `FLAG_HAS_CLEAR_COAT`, `FLAG_HAS_SUBSURFACE`, `FLAG_HAS_ANISOTROPY`, `FLAG_HAS_CUSTOM`
- Material class constants: `MATERIAL_CLASS_DEFAULT`, `CLEAR_COAT`, `SUBSURFACE`, `ANISOTROPIC`, `CUSTOM`
- Instance rebuild sorts by `(material_class, graph_hash)` and builds contiguous ranges for PSO selection

**GBuffer shader refactored:**
- Material evaluation extracted into `radiant_eval_surface()` returning `SurfaceData`
- Warp-uniform branches gated by `material.flags` (zero cost when untaken)
- `// RADIANT_OVERRIDE_SURFACE` markers for graph snippet injection
- Surface data variables changed from `let` to `var` so graph snippets can reassign them

---

## 2. Anti-Aliasing Pipeline Swap

Swapped AA methods between the default and FXAA graph builders:

- **`build_default_graph*`** now uses **FXAA** at internal resolution (no temporal jitter, no Halton jitter requirement). PostProcessPass handles the final blit/upscale.
- **`build_fxaa_graph*`** now uses **TAA** with temporal accumulation and upscaling.

---

## 3. Voxel Rendering Fixes

**Sky removed from voxel passes** — `VoxelRayMarchPass` no longer writes a hardcoded sky gradient on miss. Miss pixels write transparent black `(0,0,0,0)`; the shade shader discards alpha=0 fragments, letting the `SkyPass` output show through.

**VoxelMeshPass integrated** — replaced `VoxelRayMarchPass` in the default graph with `VoxelMeshPass` (real triangles via marching cubes). Voxel mesh pass now uses `LoadOp::Load` for both color and depth attachments, compositing over deferred lighting with proper depth testing. Backface normal direction fixed with `@builtin(front_facing)` to eliminate patchy lighting artifacts.

---

## 4. Terrain Component Fixes

**Generation parameters wired through** — `VoxelGrid::generate_heightmap` now accepts `seed`, `base_height`, `amplitude`, `frequency`, `octaves`, `lacunarity`, and `persistence`. `TerrainEntry::sync_procedural` forwards all params. The `ProceduralTerrainComponent` runtime now passes all editor-configured values through to the generator instead of ignoring everything except seed.

**VoxelTerrainCache fixed** — flush now writes to `VoxelMeshPass` buffers via `upload_mesh()` + `mark_dirty()` instead of `upload_raymarch()`, matching the new graph topology.

---

## 5. Example: `radiant_demo`

Interactive demo (WASD fly, mouse look) showing all three Radiant tiers:
- **Tier 1:** Gold metallic, red plastic, blue clear-coat spheres via uber-shader flags
- **Tier 2:** Animated emissive pulse via graph snippet injected at `RADIANT_OVERRIDE_SURFACE`
- **Tier 3:** Iridescent thin-film spheres via custom `radiant_iridescent.wgsl` template with per-frame animated `class_params`

---

## 6. Blog Post

`Helio Radiant: Zero-Cost Custom Materials Through Template Fusion` — covers the problem, three-tier design, GpuMaterial evolution, shader template mechanism, PSO table, draw-call grouping, warp-uniform guarantee, edge cases, cost comparison with Unreal's permutation model, template authoring contract, and future work.
