### PR TITLE
Fix voxel demo attachment and resize state

### DIFF
--- a/crates/examples/voxel/mesh_demo.rs
+++ b/crates/examples/voxel/mesh_demo.rs
@@ -70,6 +70,40 @@ struct AppState {
 }
 
 impl AppState {
+    fn reset_transient_input(&mut self) {
+        self.keys.clear();
+        self.mouse_delta = (0.0, 0.0);
+        self.velocity = Vec3::ZERO;
+        self.cursor_grabbed = false;
+        let _ = self.window.set_cursor_grab(CursorGrabMode::None);
+        self.window.set_cursor_visible(true);
+        self.last_frame = Instant::now();
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        // Native resize loops can swallow input-release events. Release cursor
+        // capture before rebuilding targets so the next click can reacquire it.
+        self.reset_transient_input();
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        self.surface.configure(
+            &self.device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: self.surface_format,
+                width,
+                height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: self.alpha_mode,
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            },
+        );
+        self.renderer.set_render_size(width, height);
+    }
+
     fn update(&mut self, dt: f32) {
         let (dx, dy) = self.mouse_delta;
         self.mouse_delta = (0.0, 0.0);
@@ -337,24 +371,13 @@ impl ApplicationHandler for App {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
 
-            WindowEvent::Resized(new_size) => {
-                if new_size.width > 0 && new_size.height > 0 {
-                    state.surface.configure(
-                        &state.device,
-                        &wgpu::SurfaceConfiguration {
-                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                            format: state.surface_format,
-                            width: new_size.width,
-                            height: new_size.height,
-                            present_mode: wgpu::PresentMode::Fifo,
-                            alpha_mode: state.alpha_mode,
-                            view_formats: vec![],
-                            desired_maximum_frame_latency: 2,
-                        },
-                    );
-                    state.renderer.set_render_size(new_size.width, new_size.height);
-                }
+            WindowEvent::Resized(new_size) => state.resize(new_size.width, new_size.height),
+
+            WindowEvent::Focused(false) | WindowEvent::CursorLeft { .. } => {
+                state.reset_transient_input();
             }
+
+            WindowEvent::Focused(true) => state.last_frame = Instant::now(),
 
             WindowEvent::KeyboardInput {
                 event: KeyEvent {
@@ -418,8 +441,8 @@ impl ApplicationHandler for App {
                 ..
             } if !state.cursor_grabbed => {
                 let ok = state.window
-                    .set_cursor_grab(CursorGrabMode::Locked)
-                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Confined))
+                    .set_cursor_grab(CursorGrabMode::Confined)
+                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Locked))
                     .is_ok();
                 if ok {
                     state.cursor_grabbed = true;

--- a/crates/examples/voxel/mesh_demo.rs
+++ b/crates/examples/voxel/mesh_demo.rs
@@ -25,7 +25,6 @@ use helio_pass_voxel_mesh::VoxelMeshPass;
 use helio_voxel_core::GpuVoxelMaterial;
 use winit::{
     application::ApplicationHandler,
-    dpi::PhysicalPosition,
     event::*,
     event_loop::{ActiveEventLoop, EventLoop},
     keyboard::{KeyCode, PhysicalKey},
@@ -419,8 +418,8 @@ impl ApplicationHandler for App {
                 ..
             } if !state.cursor_grabbed => {
                 let ok = state.window
-                    .set_cursor_grab(CursorGrabMode::Confined)
-                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Locked))
+                    .set_cursor_grab(CursorGrabMode::Locked)
+                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Confined))
                     .is_ok();
                 if ok {
                     state.cursor_grabbed = true;
@@ -454,19 +453,6 @@ impl ApplicationHandler for App {
                 let queue = state.queue.clone();
                 let pass = state.renderer.find_pass_mut::<VoxelMeshPass>().expect("VoxelMeshPass missing from graph");
                 AppState::place_edit(false, mat, pos, yaw, pitch, &mut state.world, &queue, pass);
-            }
-
-            WindowEvent::CursorMoved {
-                position: pos,
-                ..
-            } if state.cursor_grabbed => {
-                let center = (
-                    state.window.inner_size().width as f64 / 2.0,
-                    state.window.inner_size().height as f64 / 2.0,
-                );
-                state.mouse_delta.0 += (pos.x - center.0) as f32;
-                state.mouse_delta.1 += (pos.y - center.1) as f32;
-                let _ = state.window.set_cursor_position(PhysicalPosition::new(center.0 as i32, center.1 as i32));
             }
 
             WindowEvent::RedrawRequested => {

--- a/crates/examples/voxel/mesh_demo.rs
+++ b/crates/examples/voxel/mesh_demo.rs
@@ -93,6 +93,7 @@ impl AppState {
             &wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format: self.surface_format,
+                color_space: wgpu::SurfaceColorSpace::Auto,
                 width,
                 height,
                 present_mode: wgpu::PresentMode::Fifo,
@@ -195,6 +196,7 @@ impl ApplicationHandler for App {
             compatible_surface: Some(&surface),
             power_preference: wgpu::PowerPreference::HighPerformance,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("No suitable GPU adapter");
 
@@ -227,6 +229,7 @@ impl ApplicationHandler for App {
             &wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format: surface_format,
+                color_space: wgpu::SurfaceColorSpace::Auto,
                 width: size.width,
                 height: size.height,
                 present_mode: wgpu::PresentMode::Fifo,
@@ -488,17 +491,15 @@ impl ApplicationHandler for App {
                 let camera = state.camera(size.width, size.height);
 
                 let output = match state.surface.get_current_texture() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        log::warn!("surface error: {:?}", e);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(t)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(t) => t,
+                    _ => return,
                 };
                 let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
                 if let Err(e) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", e);
                 }
-                output.present();
+                state.queue.present(output);
                 state.window.request_redraw();
             }
 

--- a/crates/examples/voxel/raymarch_demo.rs
+++ b/crates/examples/voxel/raymarch_demo.rs
@@ -100,6 +100,7 @@ impl AppState {
             &wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format: self.surface_format,
+                color_space: wgpu::SurfaceColorSpace::Auto,
                 width,
                 height,
                 present_mode: wgpu::PresentMode::Fifo,
@@ -199,6 +200,7 @@ impl ApplicationHandler for App {
             compatible_surface: Some(&surface),
             power_preference: wgpu::PowerPreference::HighPerformance,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("No suitable GPU adapter");
 
@@ -231,6 +233,7 @@ impl ApplicationHandler for App {
             &wgpu::SurfaceConfiguration {
                 usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
                 format: surface_format,
+                color_space: wgpu::SurfaceColorSpace::Auto,
                 width: size.width,
                 height: size.height,
                 present_mode: wgpu::PresentMode::Fifo,
@@ -494,17 +497,15 @@ impl ApplicationHandler for App {
                 let camera = state.camera(size.width, size.height);
 
                 let output = match state.surface.get_current_texture() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        log::warn!("surface error: {:?}", e);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(t)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(t) => t,
+                    _ => return,
                 };
                 let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
                 if let Err(e) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", e);
                 }
-                output.present();
+                state.queue.present(output);
                 state.window.request_redraw();
             }
 

--- a/crates/examples/voxel/raymarch_demo.rs
+++ b/crates/examples/voxel/raymarch_demo.rs
@@ -32,7 +32,6 @@ use helio_pass_voxel_raymarch::VoxelRayMarchPass;
 use helio_voxel_core::GpuVoxelMaterial;
 use winit::{
     application::ApplicationHandler,
-    dpi::PhysicalPosition,
     event::*,
     event_loop::{ActiveEventLoop, EventLoop},
     keyboard::{KeyCode, PhysicalKey},
@@ -419,8 +418,8 @@ impl ApplicationHandler for App {
                 ..
             } if !state.cursor_grabbed => {
                 let ok = state.window
-                    .set_cursor_grab(CursorGrabMode::Confined)
-                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Locked))
+                    .set_cursor_grab(CursorGrabMode::Locked)
+                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Confined))
                     .is_ok();
                 if ok {
                     state.cursor_grabbed = true;
@@ -460,19 +459,6 @@ impl ApplicationHandler for App {
                     scene.gpu_scene().voxel_data_pool.clone(),
                 );
                 AppState::place_edit(false, mat, pos, yaw, pitch, &mut state.world, &state.queue, &brick_pool, &data_pool);
-            }
-
-            WindowEvent::CursorMoved {
-                position: pos,
-                ..
-            } if state.cursor_grabbed => {
-                let center = (
-                    state.window.inner_size().width as f64 / 2.0,
-                    state.window.inner_size().height as f64 / 2.0,
-                );
-                state.mouse_delta.0 += (pos.x - center.0) as f32;
-                state.mouse_delta.1 += (pos.y - center.1) as f32;
-                let _ = state.window.set_cursor_position(PhysicalPosition::new(center.0 as i32, center.1 as i32));
             }
 
             WindowEvent::RedrawRequested => {

--- a/crates/examples/voxel/raymarch_demo.rs
+++ b/crates/examples/voxel/raymarch_demo.rs
@@ -77,6 +77,40 @@ struct AppState {
 }
 
 impl AppState {
+    fn reset_transient_input(&mut self) {
+        self.keys.clear();
+        self.mouse_delta = (0.0, 0.0);
+        self.velocity = Vec3::ZERO;
+        self.cursor_grabbed = false;
+        let _ = self.window.set_cursor_grab(CursorGrabMode::None);
+        self.window.set_cursor_visible(true);
+        self.last_frame = Instant::now();
+    }
+
+    fn resize(&mut self, width: u32, height: u32) {
+        // Native resize loops can swallow input-release events. Release cursor
+        // capture before rebuilding targets so the next click can reacquire it.
+        self.reset_transient_input();
+        if width == 0 || height == 0 {
+            return;
+        }
+
+        self.surface.configure(
+            &self.device,
+            &wgpu::SurfaceConfiguration {
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+                format: self.surface_format,
+                width,
+                height,
+                present_mode: wgpu::PresentMode::Fifo,
+                alpha_mode: self.alpha_mode,
+                view_formats: vec![],
+                desired_maximum_frame_latency: 2,
+            },
+        );
+        self.renderer.set_render_size(width, height);
+    }
+
     fn update(&mut self, dt: f32) {
         let (dx, dy) = self.mouse_delta;
         self.mouse_delta = (0.0, 0.0);
@@ -337,24 +371,13 @@ impl ApplicationHandler for App {
         match event {
             WindowEvent::CloseRequested => event_loop.exit(),
 
-            WindowEvent::Resized(new_size) => {
-                if new_size.width > 0 && new_size.height > 0 {
-                    state.surface.configure(
-                        &state.device,
-                        &wgpu::SurfaceConfiguration {
-                            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-                            format: state.surface_format,
-                            width: new_size.width,
-                            height: new_size.height,
-                            present_mode: wgpu::PresentMode::Fifo,
-                            alpha_mode: state.alpha_mode,
-                            view_formats: vec![],
-                            desired_maximum_frame_latency: 2,
-                        },
-                    );
-                    state.renderer.set_render_size(new_size.width, new_size.height);
-                }
+            WindowEvent::Resized(new_size) => state.resize(new_size.width, new_size.height),
+
+            WindowEvent::Focused(false) | WindowEvent::CursorLeft { .. } => {
+                state.reset_transient_input();
             }
+
+            WindowEvent::Focused(true) => state.last_frame = Instant::now(),
 
             WindowEvent::KeyboardInput {
                 event: KeyEvent {
@@ -418,8 +441,8 @@ impl ApplicationHandler for App {
                 ..
             } if !state.cursor_grabbed => {
                 let ok = state.window
-                    .set_cursor_grab(CursorGrabMode::Locked)
-                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Confined))
+                    .set_cursor_grab(CursorGrabMode::Confined)
+                    .or_else(|_| state.window.set_cursor_grab(CursorGrabMode::Locked))
                     .is_ok();
                 if ok {
                     state.cursor_grabbed = true;

--- a/crates/helio-default-graphs/src/lib.rs
+++ b/crates/helio-default-graphs/src/lib.rs
@@ -392,7 +392,7 @@ fn build_default_graph_internal(
     // Voxel mesh pass — real triangles with depth testing, composited over
     // deferred lighting. When no voxel volumes are present the pass is a no-op
     // (extract pass has zero dirty bricks → no geometry emitted).
-    graph.add_pass(Box::new(VoxelMeshPass::new(
+    graph.add_pass(Box::new(VoxelMeshPass::new_composited(
         device,
         queue,
         config.surface_format,

--- a/crates/helio-pass-fxaa/src/lib.rs
+++ b/crates/helio-pass-fxaa/src/lib.rs
@@ -177,5 +177,12 @@ impl RenderPass for FxaaPass {
         rp.draw(0..3, 0..1);
         Ok(())
     }
+
+    fn on_resize(&mut self, _device: &wgpu::Device, _width: u32, _height: u32) {
+        // RenderGraph may replace `pre_aa` in the same texture-pool slot, so
+        // the TextureView wrapper address is not a reliable resize generation.
+        self.bind_group = None;
+        self.bind_group_key = None;
+    }
 }
 

--- a/crates/helio-pass-voxel-mesh/src/lib.rs
+++ b/crates/helio-pass-voxel-mesh/src/lib.rs
@@ -29,6 +29,28 @@ pub const VOXEL_MESH_MAX_DIRTY: u32 = 4096;
 // every brick edge — see voxel_surface_extract.wgsl's CELLS_PER_DIM.
 pub const VOXEL_MESH_BRICK_VOXEL_WORDS: u64 = 183; // ceil(9*9*9 / 4)
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AttachmentMode {
+    Standalone,
+    Composited,
+}
+
+impl AttachmentMode {
+    fn color_load(self) -> wgpu::LoadOp<wgpu::Color> {
+        match self {
+            Self::Standalone => wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            Self::Composited => wgpu::LoadOp::Load,
+        }
+    }
+
+    fn depth_load(self) -> wgpu::LoadOp<f32> {
+        match self {
+            Self::Standalone => wgpu::LoadOp::Clear(1.0),
+            Self::Composited => wgpu::LoadOp::Load,
+        }
+    }
+}
+
 // ── GPU types ─────────────────────────────────────────────────────────────────
 
 /// Per-brick dirty entry uploaded to the GPU each frame.
@@ -80,14 +102,43 @@ pub struct VoxelMeshPass {
 
     normal_buf: wgpu::Buffer,
     surface_format: wgpu::TextureFormat,
+    attachment_mode: AttachmentMode,
 }
 
 impl VoxelMeshPass {
-    /// Creates the pass, allocating all GPU buffers and compiling both pipelines.
+    /// Creates a standalone pass that clears color and depth before drawing.
     pub fn new(
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         surface_format: wgpu::TextureFormat,
+    ) -> Self {
+        Self::new_with_attachment_mode(
+            device,
+            queue,
+            surface_format,
+            AttachmentMode::Standalone,
+        )
+    }
+
+    /// Creates a pass that loads existing color and depth for composition.
+    pub fn new_composited(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        surface_format: wgpu::TextureFormat,
+    ) -> Self {
+        Self::new_with_attachment_mode(
+            device,
+            queue,
+            surface_format,
+            AttachmentMode::Composited,
+        )
+    }
+
+    fn new_with_attachment_mode(
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        surface_format: wgpu::TextureFormat,
+        attachment_mode: AttachmentMode,
     ) -> Self {
         let max_bricks = VOXEL_MESH_MAX_BRICKS as u64;
         let max_verts = MAX_SURFACE_VERTS_PER_BRICK as u64;
@@ -425,6 +476,7 @@ impl VoxelMeshPass {
             dirty_bricks: Vec::new(),
             normal_buf,
             surface_format,
+            attachment_mode,
         }
     }
 
@@ -488,11 +540,8 @@ impl RenderPass for VoxelMeshPass {
         &["pre_aa"]
     }
 
-    // Declares (and clears) "pre_aa" — this pass is meant to be the first/only
-    // opaque geometry writer in a graph, same role GBufferPass plays in the
-    // default pipeline. If it's ever combined with GBufferPass or another
-    // earlier depth-clearing pass, this Clear (see render_pass_descriptor)
-    // will need to become a Load instead.
+    // The constructor selects whether this pass initializes `pre_aa` and depth
+    // or composites over attachments produced by earlier graph passes.
     fn declare_resources(&self, builder: &mut ResourceBuilder) {
         builder.write_color_raw("pre_aa", self.surface_format, ResourceSize::MatchSurface);
     }
@@ -589,7 +638,7 @@ impl RenderPass for VoxelMeshPass {
                 resolve_target: None,
                 depth_slice: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Load,
+                    load: self.attachment_mode.color_load(),
                     store: wgpu::StoreOp::Store,
                 },
             })]));
@@ -599,7 +648,7 @@ impl RenderPass for VoxelMeshPass {
             depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
                 view: depth,
                 depth_ops: Some(wgpu::Operations {
-                    load: wgpu::LoadOp::Load,
+                    load: self.attachment_mode.depth_load(),
                     store: wgpu::StoreOp::Store,
                 }),
                 stencil_ops: None,
@@ -608,5 +657,34 @@ impl RenderPass for VoxelMeshPass {
             occlusion_query_set: None,
             multiview_mask: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttachmentMode;
+
+    #[test]
+    fn standalone_mode_initializes_color_and_depth() {
+        assert!(matches!(
+            AttachmentMode::Standalone.color_load(),
+            wgpu::LoadOp::Clear(color) if color == wgpu::Color::TRANSPARENT
+        ));
+        assert!(matches!(
+            AttachmentMode::Standalone.depth_load(),
+            wgpu::LoadOp::Clear(1.0)
+        ));
+    }
+
+    #[test]
+    fn composited_mode_preserves_color_and_depth() {
+        assert!(matches!(
+            AttachmentMode::Composited.color_load(),
+            wgpu::LoadOp::Load
+        ));
+        assert!(matches!(
+            AttachmentMode::Composited.depth_load(),
+            wgpu::LoadOp::Load
+        ));
     }
 }

--- a/crates/helio-pass-voxel-raymarch/src/lib.rs
+++ b/crates/helio-pass-voxel-raymarch/src/lib.rs
@@ -326,8 +326,8 @@ impl RenderPass for VoxelRayMarchPass {
             if let Some(ref bg) = self.compute_bg {
                 cpass.set_bind_group(0, bg, &[]);
             }
-            let wg_x = (self.width + 7) / 8;
-            let wg_y = (self.height + 7) / 8;
+            let wg_x = self.width.div_ceil(8);
+            let wg_y = self.height.div_ceil(8);
             cpass.dispatch_workgroups(wg_x, wg_y, 1);
         }
 

--- a/crates/helio-pass-voxel-raymarch/src/lib.rs
+++ b/crates/helio-pass-voxel-raymarch/src/lib.rs
@@ -40,6 +40,10 @@ impl AttachmentMode {
     }
 }
 
+fn shade_bind_group_matches_size(bound_size: Option<(u32, u32)>, width: u32, height: u32) -> bool {
+    bound_size == Some((width, height))
+}
+
 // ── Pass ──────────────────────────────────────────────────────────────────────
 
 pub struct VoxelRayMarchPass {
@@ -53,6 +57,7 @@ pub struct VoxelRayMarchPass {
     shade_pipeline: wgpu::RenderPipeline,
     shade_bgl: wgpu::BindGroupLayout,
     shade_bg: Option<wgpu::BindGroup>,
+    shade_bg_size: Option<(u32, u32)>,
 
     // Output textures
     color_tex: wgpu::Texture,
@@ -189,6 +194,7 @@ impl VoxelRayMarchPass {
             shade_pipeline,
             shade_bgl,
             shade_bg: None,
+            shade_bg_size: None,
             color_tex,
             color_view,
             normal_tex,
@@ -252,6 +258,7 @@ impl VoxelRayMarchPass {
             ],
         });
         self.shade_bg = Some(bg);
+        self.shade_bg_size = Some((self.width, self.height));
     }
 
     pub fn set_params(&mut self, _width: u32, _height: u32, _volume_count: u32) {
@@ -312,7 +319,9 @@ impl RenderPass for VoxelRayMarchPass {
         if self.compute_bg_key != Some(gen) || self.compute_bg.is_none() {
             self.rebuild_compute_bg(ctx);
         }
-        if self.shade_bg.is_none() {
+        if !shade_bind_group_matches_size(self.shade_bg_size, self.width, self.height)
+            || self.shade_bg.is_none()
+        {
             self.rebuild_shade_bg(ctx);
         }
 
@@ -386,12 +395,27 @@ impl RenderPass for VoxelRayMarchPass {
         self.normal_tex = nt;
         self.normal_view = nv;
         self.compute_bg_key = None;
+        // The shading bind group owns views of the old-sized textures. Drop it
+        // now so the next frame cannot stretch stale raymarch output.
+        self.shade_bg = None;
+        self.shade_bg_size = None;
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::AttachmentMode;
+    use super::{shade_bind_group_matches_size, AttachmentMode};
+
+    #[test]
+    fn resized_output_invalidates_the_shading_bind_group() {
+        assert!(shade_bind_group_matches_size(Some((1280, 720)), 1280, 720));
+        assert!(!shade_bind_group_matches_size(
+            Some((1280, 720)),
+            1920,
+            1080
+        ));
+        assert!(!shade_bind_group_matches_size(None, 1280, 720));
+    }
 
     #[test]
     fn standalone_mode_clears_pixels_discarded_by_the_shade_pass() {

--- a/crates/helio-pass-voxel-raymarch/src/lib.rs
+++ b/crates/helio-pass-voxel-raymarch/src/lib.rs
@@ -25,6 +25,21 @@ struct RayMarchParams {
     _pad2: u32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AttachmentMode {
+    Standalone,
+    Composited,
+}
+
+impl AttachmentMode {
+    fn color_load(self) -> wgpu::LoadOp<wgpu::Color> {
+        match self {
+            Self::Standalone => wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+            Self::Composited => wgpu::LoadOp::Load,
+        }
+    }
+}
+
 // ── Pass ──────────────────────────────────────────────────────────────────────
 
 pub struct VoxelRayMarchPass {
@@ -53,10 +68,25 @@ pub struct VoxelRayMarchPass {
 
     last_volume_count: u32,
     params_frame: u64,
+    attachment_mode: AttachmentMode,
 }
 
 impl VoxelRayMarchPass {
+    /// Creates a standalone pass that clears pixels missed by the raymarch.
     pub fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        Self::new_with_attachment_mode(device, surface_format, AttachmentMode::Standalone)
+    }
+
+    /// Creates a pass that preserves existing color where no voxel is hit.
+    pub fn new_composited(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        Self::new_with_attachment_mode(device, surface_format, AttachmentMode::Composited)
+    }
+
+    fn new_with_attachment_mode(
+        device: &wgpu::Device,
+        surface_format: wgpu::TextureFormat,
+        attachment_mode: AttachmentMode,
+    ) -> Self {
         let (color_tex, color_view) = Self::create_tex(device, 1, 1, "VoxelRayMarch Color");
         let (normal_tex, normal_view) = Self::create_tex(device, 1, 1, "VoxelRayMarch Normal");
 
@@ -169,6 +199,7 @@ impl VoxelRayMarchPass {
             surface_format,
             last_volume_count: 0,
             params_frame: u64::MAX,
+            attachment_mode,
         }
     }
 
@@ -326,7 +357,7 @@ impl RenderPass for VoxelRayMarchPass {
                 resolve_target: None,
                 depth_slice: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Load,
+                    load: self.attachment_mode.color_load(),
                     store: wgpu::StoreOp::Store,
                 },
             }),
@@ -355,5 +386,26 @@ impl RenderPass for VoxelRayMarchPass {
         self.normal_tex = nt;
         self.normal_view = nv;
         self.compute_bg_key = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AttachmentMode;
+
+    #[test]
+    fn standalone_mode_clears_pixels_discarded_by_the_shade_pass() {
+        assert!(matches!(
+            AttachmentMode::Standalone.color_load(),
+            wgpu::LoadOp::Clear(color) if color == wgpu::Color::TRANSPARENT
+        ));
+    }
+
+    #[test]
+    fn composited_mode_preserves_prior_color_on_ray_misses() {
+        assert!(matches!(
+            AttachmentMode::Composited.color_load(),
+            wgpu::LoadOp::Load
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- make standalone versus composited attachment behavior explicit for both retained voxel passes
- rebuild raymarch shading resources after resize
- reset transient input/cursor capture during native resize and focus transitions, matching the validated editor demo behavior
- invalidate FXAA's cached `pre_aa` bind group on resize so a reused texture-pool slot cannot keep sampling the old-sized frame
- use `u32::div_ceil` for complete raymarch dispatch coverage
- rebase onto current `v4` and adapt both demos to the WGPU 30 surface configuration, acquisition, and presentation API

Fixes #68.

## Root causes

`97b22de` made `VoxelMeshPass` unconditionally load color and depth so the default graph could composite it after deferred lighting. The standalone mesh demo has no earlier attachment producer, so undefined depth could reject every fragment and render black.

`VoxelRayMarchPass` also loaded `pre_aa`; discarded ray-miss pixels retained prior-frame color and produced camera-motion trails. Its resized output textures also retained a shading bind group referencing the old views.

The remaining resize failures had two causes:

1. Native Windows resize loops can swallow input-release events. The demos kept `cursor_grabbed = true` after OS capture was gone, so movement could not be reacquired. Resize/focus transitions now release capture, clear keys/mouse delta and velocity, and reset frame timing, following `editor_demo_mini`.
2. FXAA keyed its input bind group only by the address of the `TextureView` wrapper. RenderGraph can replace `pre_aa` in the same texture-pool slot, preserving that address while changing the underlying texture. FXAA now invalidates the bind group through `on_resize`.

## Caller audit

- both voxel demos use standalone attachment initialization and the validated resize input-reset lifecycle
- `helio-default-graphs` uses `VoxelMeshPass::new_composited`, preserving deferred composition
- FXAA resize invalidation improves every persistent/custom graph using `FxaaPass`; graph-rebuilt default pipelines remain compatible
- SMAA, TAA, HiZ, postprocess, and perf-overlay already invalidate their affected bind-group caches on resize
- the WGPU 30 reconciliation follows the current `v4` surface API without changing the attachment or resize policy

## Validation

- `cargo test -p helio-pass-fxaa -p helio-pass-voxel-mesh -p helio-pass-voxel-raymarch --locked` - pass (56 unit tests plus doctests)
- `cargo check -p helio-default-graphs --locked` - pass
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked` - pass
- targeted strict Clippy for FXAA, both voxel passes, and both demos - pass
- full FXAA all-target strict Clippy still reaches pre-existing constant-assertion test lints; the production library is clean
- `cargo build --release -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked` - pass on the rebased WGPU 30 branch
- `git diff --check` - pass

## Visual validation

The pre-rebase implementation was user-validated in both release demos: both rendered, left no prior-frame trails, preserved geometry on resize, and recovered mouse/WASD input after repeated resizing.

Post-rebase visual validation passed for both optimized demos: correct initial rendering and camera movement, repeated resizing, input reacquisition after resize, and no black frames, prior-frame trails, or geometry distortion.