### PR TITLE
Use supported native backends in Helio GPU tests

### DIFF
--- a/crates/helio/src/scene/lifecycle.rs
+++ b/crates/helio/src/scene/lifecycle.rs
@@ -295,7 +295,7 @@ mod tests {
 
     fn create_test_device() -> (std::sync::Arc<wgpu::Device>, std::sync::Arc<wgpu::Queue>) {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::BROWSER_WEBGPU,
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/crates/helio/src/scene/virtual_geometry/objects.rs
+++ b/crates/helio/src/scene/virtual_geometry/objects.rs
@@ -233,7 +233,7 @@ mod tests {
 
     fn create_test_scene() -> Scene {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
-            backends: wgpu::Backends::BROWSER_WEBGPU,
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
             ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {


### PR DESCRIPTION
## Summary

Fixes #91.

Helio's native GPU test helpers requested only `BROWSER_WEBGPU`, which has no supported adapter on native Windows. Use `WGPU_BACKEND` when explicitly configured, otherwise request WGPU's primary native backends.

## Scope

- updates both shared Helio GPU test device helpers
- preserves environment-driven backend selection
- changes test setup only; runtime renderer backend selection is untouched

## Validation

- `cargo test -p helio --lib --locked`: 19 passed, 0 failed
- `cargo clippy -p helio --lib --tests --no-deps --locked`: pass (existing warnings remain)
- combined current-`v4` `cargo build --workspace --all-targets --locked`: pass
- combined current-`v4` `cargo test --workspace --lib --bins --tests --locked`: pass
- `git diff --check`: pass

This is an engine test-infrastructure change and is ready for maintainer review and merge.