### PR TITLE
Centralize complete WebGPU material binding rewrite

### DIFF
--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -92,11 +92,7 @@ impl VirtualGeometryPass {
                         &format!("binding_array<sampler, {MAX_TEXTURES}>"),
                     );
                 #[cfg(target_arch = "wasm32")]
-                let s = {
-                    let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
-                    s.replace("enable wgpu_binding_array;\n", "")
-                     .replace("enable wgpu_binding_array;\r\n", "")
-                };
+                let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
                 s.into()
             }),
         });

--- a/crates/libhelio/src/shader.rs
+++ b/crates/libhelio/src/shader.rs
@@ -2,7 +2,8 @@
 ///
 /// Browser WebGPU does not expose wgpu's `binding_array` WGSL extension. The
 /// fixed bindings and switch preserve every material texture slot without
-/// requiring a native-only feature.
+/// requiring a native-only feature. The native-only extension directive is
+/// removed together with the binding-array declarations.
 pub fn apply_webgpu_material_bindings(src: &str, max_textures: usize) -> String {
     let mut declarations = String::new();
     for index in 0..max_textures {
@@ -20,7 +21,9 @@ pub fn apply_webgpu_material_bindings(src: &str, max_textures: usize) -> String 
 
     let mut source = String::with_capacity(src.len() + declarations.len());
     for line in src.lines() {
-        if line.contains("scene_textures:") && line.contains("binding_array<texture_2d") {
+        if line.trim() == "enable wgpu_binding_array;" {
+            // The rewritten shader no longer uses this native-only extension.
+        } else if line.contains("scene_textures:") && line.contains("binding_array<texture_2d") {
             source.push_str(&declarations);
         } else if line.contains("scene_samplers:") && line.contains("binding_array<sampler") {
             // Both binding tables were emitted in place of scene_textures.
@@ -51,6 +54,7 @@ mod tests {
     #[test]
     fn expands_material_binding_arrays() {
         let source = r#"
+enable wgpu_binding_array;
 @group(1) @binding(2) var scene_textures: binding_array<texture_2d<f32>, 2>;
 @group(1) @binding(3) var scene_samplers: binding_array<sampler, 2>;
 fn sample_texture(slot: MaterialTextureSlot, uv: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {


### PR DESCRIPTION
## Summary

Fixes #92.

Make the shared WebGPU material-binding rewrite remove the native-only `enable wgpu_binding_array;` directive itself. The virtual-geometry pass now relies on that shared policy instead of carrying a caller-specific string replacement.

## Scope

- centralizes the complete native-to-WebGPU shader rewrite in `libhelio`
- extends the shared rewrite regression test to cover the directive
- removes duplicate policy from the virtual-geometry caller

## Validation

- `cargo test -p libhelio --locked`: 4 passed, 0 failed; doctests pass
- `cargo test -p helio-pass-virtual-geometry --test cull_tests --locked`: 24 passed, 0 failed
- `cargo clippy -p libhelio -p helio-pass-virtual-geometry --lib --tests --no-deps --locked`: pass (existing warnings remain)
- combined current-`v4` `cargo build --workspace --all-targets --locked`: pass
- combined current-`v4` `cargo test --workspace --lib --bins --tests --locked`: pass
- `git diff --check`: pass

This is a shared engine shader-policy change and is ready for maintainer review and merge.