### PR TITLE
Complete WGPU 30 migration across native examples

### DIFF
--- a/crates/examples/churn_benchmark.rs
+++ b/crates/examples/churn_benchmark.rs
@@ -64,6 +64,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -111,9 +112,9 @@ impl ApplicationHandler for App {
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Churn Benchmark").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
 
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -122,7 +123,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -169,6 +170,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -248,6 +250,7 @@ impl ApplicationHandler for App {
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![],
                     desired_maximum_frame_latency: 1,
+                    color_space: wgpu::SurfaceColorSpace::Auto,
                 });
                 state.renderer.set_render_size(s.width, s.height);
             }
@@ -437,13 +440,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/corona_demo.rs
+++ b/crates/examples/corona_demo.rs
@@ -47,6 +47,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -187,7 +188,7 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance
             .create_surface(window.clone())
@@ -196,6 +197,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("no adapter");
         let (device, queue) =
@@ -227,6 +229,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -298,6 +301,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -348,6 +352,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(size.width, size.height);
@@ -432,11 +437,9 @@ impl ApplicationHandler for App {
 
                 // ── Render ────────────────────────────────────────────────────
                 let output = match state.surface.get_current_texture() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        log::warn!("surface error: {:?}", e);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(texture)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    _ => return,
                 };
                 let view = output
                     .texture
@@ -444,7 +447,7 @@ impl ApplicationHandler for App {
                 if let Err(e) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", e);
                 }
-                output.present();
+                state.queue.present(output);
             }
 
             _ => {}

--- a/crates/examples/debug_shapes.rs
+++ b/crates/examples/debug_shapes.rs
@@ -40,6 +40,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -71,13 +72,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -110,6 +112,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -142,6 +145,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -171,6 +175,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(sz.width, sz.height);
@@ -360,11 +365,9 @@ impl AppState {
         self.renderer.debug_line(world_cam_mark.to_array(), (world_cam_mark + glam::Vec3::new(0.,0.,cross)).to_array(), [1.0,0.5,0.0,1.0]);
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -385,7 +388,7 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/editor_demo.rs
+++ b/crates/examples/editor_demo.rs
@@ -69,6 +69,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     surface_alpha_mode: wgpu::CompositeAlphaMode,
     renderer: Renderer,
@@ -114,13 +115,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -158,6 +160,7 @@ impl ApplicationHandler for App {
                 alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -568,6 +571,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             surface_alpha_mode: alpha_mode,
             renderer,
@@ -842,6 +846,7 @@ impl AppState {
                 alpha_mode: self.surface_alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
         self.renderer.set_render_size(width, height);
@@ -953,13 +958,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("surface: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }

--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -70,6 +70,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     surface_alpha_mode: wgpu::CompositeAlphaMode,
     renderer: Renderer,
@@ -119,13 +120,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -161,6 +163,7 @@ impl ApplicationHandler for App {
                 alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -799,6 +802,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             surface_alpha_mode: alpha_mode,
             renderer,
@@ -1164,6 +1168,7 @@ impl AppState {
                 alpha_mode: self.surface_alpha_mode,
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
         self.renderer.set_render_size(width, height);
@@ -1298,11 +1303,9 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -1310,6 +1313,6 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }

--- a/crates/examples/indoor_cathedral.rs
+++ b/crates/examples/indoor_cathedral.rs
@@ -99,6 +99,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -173,13 +174,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -214,6 +216,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -559,6 +562,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -729,6 +733,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -845,18 +850,16 @@ impl AppState {
         // Scene state is persistent — no per-frame setup needed.
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_cathedral_fxaa.rs
+++ b/crates/examples/indoor_cathedral_fxaa.rs
@@ -97,6 +97,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -171,13 +172,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -212,6 +214,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -715,6 +718,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -879,6 +883,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -995,17 +1000,15 @@ impl AppState {
         // Scene state is persistent — no per-frame setup needed.
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }

--- a/crates/examples/indoor_cathedral_fxaa_hlfs.rs
+++ b/crates/examples/indoor_cathedral_fxaa_hlfs.rs
@@ -96,6 +96,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -170,13 +171,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -211,6 +213,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -571,6 +574,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -741,6 +745,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -857,18 +862,16 @@ impl AppState {
         // Scene state is persistent — no per-frame setup needed.
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_cathedral_hlfs.rs
+++ b/crates/examples/indoor_cathedral_hlfs.rs
@@ -95,6 +95,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -143,13 +144,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -184,6 +186,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -535,6 +538,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -687,6 +691,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -803,18 +808,16 @@ impl AppState {
         // Scene state is persistent — no per-frame setup needed.
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_cathedral_pp_volumes.rs
+++ b/crates/examples/indoor_cathedral_pp_volumes.rs
@@ -80,6 +80,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -146,13 +147,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) =
@@ -188,6 +190,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -745,6 +748,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -912,6 +916,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -1021,17 +1026,15 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }

--- a/crates/examples/indoor_cathedral_water.rs
+++ b/crates/examples/indoor_cathedral_water.rs
@@ -142,6 +142,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -223,13 +224,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -264,6 +266,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -713,6 +716,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -900,6 +904,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -1083,18 +1088,16 @@ impl AppState {
         // ---------------------------------------------------------------------
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_corridor.rs
+++ b/crates/examples/indoor_corridor.rs
@@ -44,6 +44,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -83,13 +84,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -126,6 +128,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -264,6 +267,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -343,6 +347,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -422,18 +427,16 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_room.rs
+++ b/crates/examples/indoor_room.rs
@@ -40,6 +40,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -80,13 +81,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -128,6 +130,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -236,6 +239,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -316,6 +320,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -403,18 +408,16 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/indoor_server_room.rs
+++ b/crates/examples/indoor_server_room.rs
@@ -70,6 +70,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -101,13 +102,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -140,6 +142,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -331,6 +334,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -419,6 +423,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -497,18 +502,16 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/light_benchmark.rs
+++ b/crates/examples/light_benchmark.rs
@@ -89,6 +89,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -132,13 +133,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -171,6 +173,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 1,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -282,6 +285,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -401,6 +405,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 1,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -418,6 +423,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 1,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -526,11 +532,9 @@ impl AppState {
 
         let get_texture_start = std::time::Instant::now();
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface error: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let get_texture_ms = get_texture_start.elapsed().as_secs_f32() * 1000.0;
         if get_texture_ms > 10.0 {
@@ -568,7 +572,7 @@ impl AppState {
         }
 
         let present_start = std::time::Instant::now();
-        output.present();
+        self.queue.present(output);
         let present_ms = present_start.elapsed().as_secs_f32() * 1000.0;
 
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/load_fbx.rs
+++ b/crates/examples/load_fbx.rs
@@ -29,6 +29,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     point_light_id: helio::LightId,
@@ -110,6 +111,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("no adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(
@@ -142,6 +144,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -253,6 +256,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             point_light_id,
@@ -302,6 +306,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(size.width, size.height);
@@ -383,11 +388,9 @@ impl ApplicationHandler for App {
                 );
 
                 let output = match state.surface.get_current_texture() {
-                    Ok(texture) => texture,
-                    Err(error) => {
-                        log::warn!("surface error: {:?}", error);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(texture)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    _ => return,
                 };
                 let view = output
                     .texture
@@ -395,7 +398,7 @@ impl ApplicationHandler for App {
                 if let Err(error) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", error);
                 }
-                output.present();
+                state.queue.present(output);
             }
             _ => {}
         }

--- a/crates/examples/load_fbx_embedded.rs
+++ b/crates/examples/load_fbx_embedded.rs
@@ -237,6 +237,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     movement_speed: f32,
@@ -313,6 +314,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("no adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(
@@ -344,6 +346,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
         let config = RendererConfig::new(size.width, size.height, surface_format);
@@ -403,6 +406,7 @@ impl ApplicationHandler for App {
                     window,
                     surface,
                     device,
+                    queue,
                     surface_format,
                     renderer,
                     movement_speed: fallback_bounds.movement_speed(),
@@ -453,6 +457,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             movement_speed: bounds.movement_speed(),
@@ -501,6 +506,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(size.width, size.height);
@@ -558,11 +564,9 @@ impl ApplicationHandler for App {
                     200.0,
                 );
                 let output = match state.surface.get_current_texture() {
-                    Ok(texture) => texture,
-                    Err(error) => {
-                        log::warn!("surface error: {:?}", error);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(texture)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    _ => return,
                 };
                 let view = output
                     .texture
@@ -570,7 +574,7 @@ impl ApplicationHandler for App {
                 if let Err(error) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", error);
                 }
-                output.present();
+                state.queue.present(output);
             }
             _ => {}
         }

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -93,13 +93,14 @@ async fn run() {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: benchmark_backends(),
         flags: wgpu::InstanceFlags::empty(),
-        ..Default::default()
+        ..wgpu::InstanceDescriptor::new_without_display_handle()
     });
     let adapter = instance
         .request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: None,
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         })
         .await
         .expect("no GPU adapter available");
@@ -798,7 +799,9 @@ fn read_mapped<T: Pod + Copy>(device: &wgpu::Device, buffer: &wgpu::Buffer, coun
     });
     let _ = device.poll(wgpu::PollType::wait_indefinitely());
     rx.recv().expect("map callback dropped").expect("readback mapping failed");
-    let data = slice.get_mapped_range();
+    let data = slice
+        .get_mapped_range()
+        .expect("readback range unavailable");
     let values = bytemuck::cast_slice::<u8, T>(&data)[..count].to_vec();
     drop(data);
     buffer.unmap();

--- a/crates/examples/oil_rig_night.rs
+++ b/crates/examples/oil_rig_night.rs
@@ -44,6 +44,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -83,13 +84,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -131,6 +133,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -322,6 +325,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -401,6 +405,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -480,17 +485,15 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }

--- a/crates/examples/outdoor_canyon.rs
+++ b/crates/examples/outdoor_canyon.rs
@@ -47,6 +47,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -91,13 +92,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -134,6 +136,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -278,6 +281,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -362,6 +366,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -476,18 +481,16 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/outdoor_city.rs
+++ b/crates/examples/outdoor_city.rs
@@ -105,6 +105,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -154,13 +155,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -195,6 +197,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -313,6 +316,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -400,6 +404,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -499,11 +504,9 @@ impl AppState {
         ];
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
@@ -541,7 +544,7 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/outdoor_night.rs
+++ b/crates/examples/outdoor_night.rs
@@ -40,6 +40,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -79,13 +80,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -127,6 +129,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -281,6 +284,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -360,6 +364,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -439,18 +444,16 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/outdoor_rocks.rs
+++ b/crates/examples/outdoor_rocks.rs
@@ -85,6 +85,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: Instant,
@@ -186,6 +187,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("no adapter");
 
@@ -217,6 +219,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -462,6 +465,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             last_frame: Instant::now(),
@@ -521,6 +525,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(size.width, size.height);
@@ -643,11 +648,9 @@ impl ApplicationHandler for App {
                 // ── Render ────────────────────────────────────────────────
                 let t_render_start = Instant::now();
                 let output = match state.surface.get_current_texture() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        log::warn!("surface error: {e:?}");
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(texture)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    _ => return,
                 };
                 let view = output
                     .texture
@@ -658,7 +661,7 @@ impl ApplicationHandler for App {
                 let t_render_ms = t_render_start.elapsed().as_secs_f64() * 1000.0;
 
                 let t_present_start = Instant::now();
-                output.present();
+                state.queue.present(output);
                 let t_present_ms = t_present_start.elapsed().as_secs_f64() * 1000.0;
 
                 // ── Profiling accumulate + print every 100 frames ─────────

--- a/crates/examples/outdoor_volcano.rs
+++ b/crates/examples/outdoor_volcano.rs
@@ -86,6 +86,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -142,13 +143,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -183,6 +185,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -389,6 +392,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -483,6 +487,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(s.width, s.height);
@@ -566,11 +571,9 @@ impl AppState {
         let f = |phase: f32, freq: f32, amp: f32| 1.0 + (time * freq + phase).sin() * amp;
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
@@ -585,7 +588,7 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/rapier_collision_groups.rs
+++ b/crates/examples/rapier_collision_groups.rs
@@ -27,6 +27,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -73,9 +74,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Collision Groups Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -84,7 +85,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -123,6 +124,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -194,7 +196,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -346,13 +348,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rapier_pendulum.rs
+++ b/crates/examples/rapier_pendulum.rs
@@ -27,6 +27,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -71,9 +72,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Pendulum Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -82,7 +83,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -120,6 +121,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -188,7 +190,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -346,13 +348,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rapier_pendulum_bigcloth.rs
+++ b/crates/examples/rapier_pendulum_bigcloth.rs
@@ -32,6 +32,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -76,9 +77,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Pendulum Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -87,7 +88,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -125,6 +126,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -193,7 +195,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -368,13 +370,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rapier_pendulum_cloth.rs
+++ b/crates/examples/rapier_pendulum_cloth.rs
@@ -31,6 +31,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -75,9 +76,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Pendulum Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -86,7 +87,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -124,6 +125,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -192,7 +194,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -405,13 +407,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rapier_pendulum_line.rs
+++ b/crates/examples/rapier_pendulum_line.rs
@@ -27,6 +27,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -71,9 +72,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Pendulum Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -82,7 +83,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -120,6 +121,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -188,7 +190,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -346,13 +348,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rapier_salva.rs
+++ b/crates/examples/rapier_salva.rs
@@ -106,6 +106,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -344,9 +345,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Faucet Fill Box (Salva3d)").with_inner_size(winit::dpi::LogicalSize::new(1600u32, 900u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -355,7 +356,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -442,6 +443,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -513,7 +515,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -744,15 +746,16 @@ impl AppState {
         let camera = Camera::perspective_look_at(self.cam_pos, self.cam_pos + forward, glam::Vec3::Y, std::f32::consts::FRAC_PI_3, aspect, 0.1, 300.0);
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render error: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
 

--- a/crates/examples/rapier_stack.rs
+++ b/crates/examples/rapier_stack.rs
@@ -27,6 +27,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -71,9 +72,9 @@ impl ApplicationHandler for App {
         if self.state.is_some() { return; }
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Rapier Stack Demo").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -82,7 +83,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -120,6 +121,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -188,7 +190,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1 });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -331,13 +333,14 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.frame_count += 1;
         self.time_render_end = Some(std::time::Instant::now());

--- a/crates/examples/rc_benchmark.rs
+++ b/crates/examples/rc_benchmark.rs
@@ -51,6 +51,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -83,13 +84,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
 
@@ -124,6 +126,7 @@ impl ApplicationHandler for App {
                 desired_maximum_frame_latency: 1,
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -215,6 +218,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -329,6 +333,7 @@ impl ApplicationHandler for App {
                         desired_maximum_frame_latency: 1,
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(sz.width, sz.height);
@@ -407,11 +412,9 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface error: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -427,7 +430,7 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("Render error: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/render_v2_basic.rs
+++ b/crates/examples/render_v2_basic.rs
@@ -43,6 +43,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -85,7 +86,7 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance
             .create_surface(window.clone())
@@ -95,6 +96,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("Failed to find adapter");
 
@@ -135,6 +137,7 @@ impl ApplicationHandler for App {
             alpha_mode: surface_caps.alpha_modes[0],
             view_formats: vec![],
             desired_maximum_frame_latency: 2,
+            color_space: wgpu::SurfaceColorSpace::Auto,
         };
         surface.configure(&device, &config);
 
@@ -192,6 +195,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -283,6 +287,7 @@ impl ApplicationHandler for App {
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![],
                     desired_maximum_frame_latency: 2,
+                    color_space: wgpu::SurfaceColorSpace::Auto,
                 };
                 state.surface.configure(&state.device, &config);
                 state.renderer.set_render_size(size.width, size.height);
@@ -374,11 +379,9 @@ impl AppState {
 
         // ── Acquire surface ────────────────────────────────────────────────────
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface error: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -395,7 +398,7 @@ impl AppState {
             log::error!("Render error: {:?}", e);
         }
 
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/render_v2_sky.rs
+++ b/crates/examples/render_v2_sky.rs
@@ -49,6 +49,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -93,7 +94,7 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance
             .create_surface(window.clone())
@@ -103,6 +104,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("Failed to find adapter");
 
@@ -143,6 +145,7 @@ impl ApplicationHandler for App {
             alpha_mode: surface_caps.alpha_modes[0],
             view_formats: vec![],
             desired_maximum_frame_latency: 2,
+            color_space: wgpu::SurfaceColorSpace::Auto,
         };
         surface.configure(&device, &config);
 
@@ -221,6 +224,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -307,6 +311,7 @@ impl ApplicationHandler for App {
                     alpha_mode: wgpu::CompositeAlphaMode::Auto,
                     view_formats: vec![],
                     desired_maximum_frame_latency: 2,
+                    color_space: wgpu::SurfaceColorSpace::Auto,
                 };
                 state.surface.configure(&state.device, &cfg);
                 state.renderer.set_render_size(size.width, size.height);
@@ -412,11 +417,9 @@ impl AppState {
         ];
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface error: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -431,7 +434,7 @@ impl AppState {
             log::error!("Render error: {:?}", e);
         }
 
-        output.present();
+        self.queue.present(output);
     }
 }
 

--- a/crates/examples/shape_battle_royale.rs
+++ b/crates/examples/shape_battle_royale.rs
@@ -49,6 +49,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: Instant,
@@ -98,9 +99,9 @@ impl ApplicationHandler for App {
 
         let window = Arc::new(event_loop.create_window(Window::default_attributes().with_title("Helio — Shape Battle Royale").with_inner_size(winit::dpi::LogicalSize::new(1280u32, 720u32))).expect("window"));
 
-        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..Default::default() });
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor { backends: wgpu::Backends::all(), flags: wgpu::InstanceFlags::empty(), ..wgpu::InstanceDescriptor::new_without_display_handle() });
         let surface = instance.create_surface(window.clone()).expect("surface");
-        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false })).expect("adapter");
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions { power_preference: wgpu::PowerPreference::HighPerformance, compatible_surface: Some(&surface), force_fallback_adapter: false, apply_limit_buckets: false })).expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor { required_features: required_wgpu_features(adapter.features()), required_limits: required_wgpu_limits(adapter.limits()), ..Default::default() })).expect("device");
         device.on_uncaptured_error(Arc::new(|e: wgpu::Error| { panic!("[GPU] {:?}", e) }));
         let device = Arc::new(device);
@@ -109,7 +110,7 @@ impl ApplicationHandler for App {
         let caps = surface.get_capabilities(&adapter);
         let fmt = caps.formats.iter().copied().find(|f| f.is_srgb()).unwrap_or(caps.formats[0]);
         let size = window.inner_size();
-        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1 });
+        surface.configure(&device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: fmt, width: size.width, height: size.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: caps.alpha_modes[0], view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
 
         let config = RendererConfig::new(size.width, size.height, fmt);
         let scene = Scene::new(device.clone(), queue.clone());
@@ -158,6 +159,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: Instant::now(),
@@ -239,7 +241,7 @@ impl ApplicationHandler for App {
                 }
             }
             WindowEvent::Resized(s) if s.width > 0 && s.height > 0 => {
-                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, });
+                state.surface.configure(&state.device, &wgpu::SurfaceConfiguration { usage: wgpu::TextureUsages::RENDER_ATTACHMENT, format: state.surface_format, width: s.width, height: s.height, present_mode: wgpu::PresentMode::Fifo, alpha_mode: wgpu::CompositeAlphaMode::Auto, view_formats: vec![], desired_maximum_frame_latency: 1, color_space: wgpu::SurfaceColorSpace::Auto });
                 state.renderer.set_render_size(s.width, s.height);
             }
             WindowEvent::RedrawRequested => {
@@ -546,13 +548,14 @@ impl AppState {
         self.update_battle_state();
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => { log::warn!("Surface error: {:?}", e); return; }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&wgpu::TextureViewDescriptor::default());
 
         if let Err(e) = self.renderer.render(&camera, &view) { log::error!("Render error: {:?}", e); }
-        output.present();
+        self.queue.present(output);
 
         self.time_render_end = Some(Instant::now());
         self.frame_count += 1;

--- a/crates/examples/simple_graph.rs
+++ b/crates/examples/simple_graph.rs
@@ -40,6 +40,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: Instant,
@@ -152,6 +153,7 @@ impl ApplicationHandler for App {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("no adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -182,6 +184,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -213,6 +216,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format,
             renderer,
             last_frame: Instant::now(),
@@ -261,6 +265,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Opaque,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(size.width, size.height);
@@ -311,11 +316,9 @@ impl ApplicationHandler for App {
                 let camera = state.camera(size.width, size.height);
 
                 let output = match state.surface.get_current_texture() {
-                    Ok(t) => t,
-                    Err(e) => {
-                        log::warn!("surface error: {:?}", e);
-                        return;
-                    }
+                    wgpu::CurrentSurfaceTexture::Success(texture)
+                    | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+                    _ => return,
                 };
                 let view = output
                     .texture
@@ -323,7 +326,7 @@ impl ApplicationHandler for App {
                 if let Err(e) = state.renderer.render(&camera, &view) {
                     log::error!("render error: {:?}", e);
                 }
-                output.present();
+                state.queue.present(output);
             }
 
             _ => {}

--- a/crates/examples/space_station.rs
+++ b/crates/examples/space_station.rs
@@ -46,6 +46,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Renderer,
     last_frame: std::time::Instant,
@@ -83,13 +84,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -122,6 +124,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -209,6 +212,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: fmt,
             renderer,
             last_frame: std::time::Instant::now(),
@@ -296,6 +300,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 state.renderer.set_render_size(sz.width, sz.height);
@@ -374,11 +379,9 @@ impl AppState {
         );
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output
             .texture
@@ -444,7 +447,7 @@ impl AppState {
         if let Err(e) = self.renderer.render(&camera, &view) {
             log::error!("render error: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
         self.frame_count += 1;
     }
 }

--- a/crates/examples/vhs_backrooms.rs
+++ b/crates/examples/vhs_backrooms.rs
@@ -678,6 +678,7 @@ struct AppState {
     window: Arc<Window>,
     surface: wgpu::Surface<'static>,
     device: Arc<wgpu::Device>,
+    queue: Arc<wgpu::Queue>,
     surface_format: wgpu::TextureFormat,
     renderer: Arc<Mutex<Renderer>>,
     action_rx: Receiver<HelioAction>,
@@ -1009,13 +1010,14 @@ impl ApplicationHandler for App {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
             backends: wgpu::Backends::all(),
             flags: wgpu::InstanceFlags::empty(),
-            ..Default::default()
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
         });
         let surface = instance.create_surface(window.clone()).expect("surface");
         let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
             power_preference: wgpu::PowerPreference::HighPerformance,
             compatible_surface: Some(&surface),
             force_fallback_adapter: false,
+            apply_limit_buckets: false,
         }))
         .expect("adapter");
         let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
@@ -1050,6 +1052,7 @@ impl ApplicationHandler for App {
                 alpha_mode: caps.alpha_modes[0],
                 view_formats: vec![],
                 desired_maximum_frame_latency: 2,
+                color_space: wgpu::SurfaceColorSpace::Auto,
             },
         );
 
@@ -1145,6 +1148,7 @@ impl ApplicationHandler for App {
             window,
             surface,
             device,
+            queue,
             surface_format: format,
             renderer,
             action_rx,
@@ -1238,6 +1242,7 @@ impl ApplicationHandler for App {
                         alpha_mode: wgpu::CompositeAlphaMode::Auto,
                         view_formats: vec![],
                         desired_maximum_frame_latency: 2,
+                        color_space: wgpu::SurfaceColorSpace::Auto,
                     },
                 );
                 if let Ok(mut renderer) = state.renderer.lock() {
@@ -1368,17 +1373,15 @@ impl AppState {
         }
 
         let output = match self.surface.get_current_texture() {
-            Ok(t) => t,
-            Err(e) => {
-                log::warn!("Surface: {:?}", e);
-                return;
-            }
+            wgpu::CurrentSurfaceTexture::Success(texture)
+            | wgpu::CurrentSurfaceTexture::Suboptimal(texture) => texture,
+            _ => return,
         };
         let view = output.texture.create_view(&Default::default());
 
         if let Err(e) = renderer.render(&camera, &view) {
             log::error!("Render: {:?}", e);
         }
-        output.present();
+        self.queue.present(output);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #90.

Complete the WGPU 30 migration across the remaining native examples so the full examples package builds again on current `v4`.

## Changes

- use display-handle-free instance descriptors for native setup
- provide the new device and surface configuration fields
- handle `CurrentSurfaceTexture::{Success, Suboptimal}` explicitly
- retain the queue in application state and present through `Queue::present`
- adapt the meshlet benchmark readback to the fallible mapped-range API

## Caller audit

All affected native example callers were migrated. A package-wide all-target check confirms no stale WGPU 30 call site remains in `crates/examples`.

## Validation

- `cargo check -p examples --all-targets --locked`: pass
- `cargo clippy -p examples --all-targets --no-deps --locked`: pass (existing warnings remain)
- combined current-`v4` `cargo build --workspace --all-targets --locked`: pass
- combined current-`v4` `cargo test --workspace --lib --bins --tests --locked`: pass
- `git diff --check`: pass

This is an engine/examples compatibility change and is ready for maintainer review and merge.