### PR TITLE
Add bounded GPU Transvoxel classification

### DIFF
--- a/crates/helio-pass-planetary-voxel/src/lib.rs
+++ b/crates/helio-pass-planetary-voxel/src/lib.rs
@@ -11,6 +11,7 @@ mod fixture;
 mod gpu;
 mod table;
 mod transvoxel;
+mod transvoxel_gpu;
 
 pub use config::*;
 pub use extraction::*;
@@ -18,6 +19,8 @@ pub use fixture::*;
 pub use gpu::*;
 pub use table::*;
 pub use transvoxel::*;
+pub use transvoxel_gpu::*;
 
 pub const EXTRACTION_LAYOUT_WGSL: &str = include_str!("extraction_layout.wgsl");
 pub const RESIDENCY_WGSL: &str = include_str!("residency.wgsl");
+pub const TRANSVOXEL_CLASSIFY_WGSL: &str = include_str!("transvoxel_classify.wgsl");

--- a/crates/helio-pass-planetary-voxel/src/transvoxel.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel.rs
@@ -4,7 +4,7 @@
 //! Keeping a small CPU decoder lets tests exhaustively check every table case,
 //! winding flag, edge endpoint, and triangle index before shader integration.
 
-mod generated {
+pub(crate) mod generated {
     include!("transvoxel_tables.rs");
 }
 

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_classify.wgsl
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_classify.wgsl
@@ -1,0 +1,116 @@
+const PAGE_EDGE: u32 = 32u;
+const SAMPLE_EDGE: u32 = 34u;
+const PAGE_CELL_COUNT: u32 = 32768u;
+
+struct GpuTransvoxelDispatch {
+    dirty_microbricks_low: u32,
+    dirty_microbricks_high: u32,
+    generation_low: u32,
+    generation_high: u32,
+    cell_count: u32,
+    _pad0: u32,
+    _pad1: u32,
+    _pad2: u32,
+};
+
+struct GpuTransvoxelCell {
+    packed_case_class_counts: u32,
+    generation_low: u32,
+    generation_high: u32,
+    _pad: u32,
+};
+
+struct GpuTransvoxelClassifyCounters {
+    visited_cells: atomic<u32>,
+    active_cells: atomic<u32>,
+    vertices: atomic<u32>,
+    triangles: atomic<u32>,
+};
+
+@group(0) @binding(0)
+var<uniform> dispatch: GpuTransvoxelDispatch;
+@group(0) @binding(1)
+var<storage, read> samples: array<u32>;
+@group(0) @binding(2)
+var<storage, read> regular_cell_class: array<u32>;
+@group(0) @binding(3)
+var<storage, read> regular_geometry_counts: array<u32>;
+@group(0) @binding(4)
+var<storage, read_write> cells: array<GpuTransvoxelCell>;
+@group(0) @binding(5)
+var<storage, read_write> counters: GpuTransvoxelClassifyCounters;
+
+const REGULAR_CORNERS: array<vec3<u32>, 8> = array<vec3<u32>, 8>(
+    vec3<u32>(0u, 0u, 0u),
+    vec3<u32>(1u, 0u, 0u),
+    vec3<u32>(0u, 1u, 0u),
+    vec3<u32>(1u, 1u, 0u),
+    vec3<u32>(0u, 0u, 1u),
+    vec3<u32>(1u, 0u, 1u),
+    vec3<u32>(0u, 1u, 1u),
+    vec3<u32>(1u, 1u, 1u),
+);
+
+fn sample_index(position: vec3<u32>) -> u32 {
+    return position.x + position.y * SAMPLE_EDGE + position.z * SAMPLE_EDGE * SAMPLE_EDGE;
+}
+
+fn is_solid(word: u32) -> bool {
+    let density_bits = word & 0xffffu;
+    let sign_extension = select(0u, 0xffff0000u, (density_bits & 0x8000u) != 0u);
+    return bitcast<i32>(density_bits | sign_extension) <= 0;
+}
+
+fn is_dirty_microbrick(index: u32) -> bool {
+    if index < 32u {
+        return (dispatch.dirty_microbricks_low & (1u << index)) != 0u;
+    }
+    return (dispatch.dirty_microbricks_high & (1u << (index - 32u))) != 0u;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn classify_regular_cells(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let linear = global_id.x;
+    if linear >= dispatch.cell_count || linear >= PAGE_CELL_COUNT {
+        return;
+    }
+
+    let x = linear % PAGE_EDGE;
+    let y = (linear / PAGE_EDGE) % PAGE_EDGE;
+    let z = linear / (PAGE_EDGE * PAGE_EDGE);
+    let microbrick = x / 8u + (y / 8u) * 4u + (z / 8u) * 16u;
+    if !is_dirty_microbrick(microbrick) {
+        return;
+    }
+    atomicAdd(&counters.visited_cells, 1u);
+
+    let sample_origin = vec3<u32>(x + 1u, y + 1u, z + 1u);
+    var case_index = 0u;
+    for (var corner = 0u; corner < 8u; corner += 1u) {
+        let word = samples[sample_index(sample_origin + REGULAR_CORNERS[corner])];
+        if is_solid(word) {
+            case_index |= 1u << corner;
+        }
+    }
+
+    let class_index = regular_cell_class[case_index];
+    let geometry_counts = regular_geometry_counts[class_index];
+    let vertex_count = geometry_counts >> 4u;
+    let triangle_count = geometry_counts & 0x0fu;
+    let packed_case_class_counts = case_index
+        | (class_index << 8u)
+        | (vertex_count << 16u)
+        | (triangle_count << 24u)
+        | 0x80000000u;
+    cells[linear] = GpuTransvoxelCell(
+        packed_case_class_counts,
+        dispatch.generation_low,
+        dispatch.generation_high,
+        0u,
+    );
+    if vertex_count != 0u {
+        atomicAdd(&counters.active_cells, 1u);
+        atomicAdd(&counters.vertices, vertex_count);
+        atomicAdd(&counters.triangles, triangle_count);
+    }
+}

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_gpu.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_gpu.rs
@@ -1,0 +1,436 @@
+use crate::{
+    transvoxel::generated, EXTRACTION_SAMPLE_COUNT, REGULAR_CASE_COUNT, TRANSVOXEL_CLASSIFY_WGSL,
+};
+use bytemuck::{Pod, Zeroable};
+use helio_planet_voxel_core::{CellWord, PAGE_CELL_COUNT};
+use wgpu::util::DeviceExt;
+
+pub const TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE: u32 = 64;
+pub const TRANSVOXEL_CLASSIFY_WORKGROUPS: u32 =
+    (PAGE_CELL_COUNT as u32).div_ceil(TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE);
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelDispatch {
+    pub dirty_microbricks_low: u32,
+    pub dirty_microbricks_high: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub cell_count: u32,
+    pub _pad0: u32,
+    pub _pad1: u32,
+    pub _pad2: u32,
+}
+
+impl GpuTransvoxelDispatch {
+    pub const fn new(generation: u64, dirty_microbricks: u64) -> Self {
+        Self {
+            dirty_microbricks_low: dirty_microbricks as u32,
+            dirty_microbricks_high: (dirty_microbricks >> 32) as u32,
+            generation_low: generation as u32,
+            generation_high: (generation >> 32) as u32,
+            cell_count: PAGE_CELL_COUNT as u32,
+            _pad0: 0,
+            _pad1: 0,
+            _pad2: 0,
+        }
+    }
+
+    pub const fn dirty_microbricks(self) -> u64 {
+        self.dirty_microbricks_low as u64 | ((self.dirty_microbricks_high as u64) << 32)
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelCell {
+    pub packed_case_class_counts: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub _pad: u32,
+}
+
+impl GpuTransvoxelCell {
+    const VALID_BIT: u32 = 1 << 31;
+
+    pub const fn new(
+        case_index: u8,
+        class_index: u8,
+        vertex_count: u8,
+        triangle_count: u8,
+        generation: u64,
+    ) -> Self {
+        assert!(triangle_count <= 0x0f);
+        Self {
+            packed_case_class_counts: case_index as u32
+                | ((class_index as u32) << 8)
+                | ((vertex_count as u32) << 16)
+                | ((triangle_count as u32) << 24)
+                | Self::VALID_BIT,
+            generation_low: generation as u32,
+            generation_high: (generation >> 32) as u32,
+            _pad: 0,
+        }
+    }
+
+    pub const fn case_index(self) -> u8 {
+        self.packed_case_class_counts as u8
+    }
+
+    pub const fn class_index(self) -> u8 {
+        (self.packed_case_class_counts >> 8) as u8
+    }
+
+    pub const fn vertex_count(self) -> u8 {
+        (self.packed_case_class_counts >> 16) as u8
+    }
+
+    pub const fn triangle_count(self) -> u8 {
+        ((self.packed_case_class_counts >> 24) & 0x0f) as u8
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+
+    pub const fn is_valid_for(self, generation: u64) -> bool {
+        self.packed_case_class_counts & Self::VALID_BIT != 0 && self.generation() == generation
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelClassifyCounters {
+    pub visited_cells: u32,
+    pub active_cells: u32,
+    pub vertices: u32,
+    pub triangles: u32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransvoxelClassifierResourceStats {
+    pub buffers: u32,
+    pub allocated_bytes: u64,
+}
+
+/// A bounded regular-cell Transvoxel classification stage. It owns no
+/// size-dependent resources and writes one fixed record per page cell. The
+/// output stays on the GPU for the later prefix-sum and emission stages;
+/// readback is used only by validation and benchmark tooling.
+pub struct TransvoxelGpuClassifier {
+    pipeline: wgpu::ComputePipeline,
+    bind_group: wgpu::BindGroup,
+    dispatch_buffer: wgpu::Buffer,
+    sample_buffer: wgpu::Buffer,
+    output_buffer: wgpu::Buffer,
+    counters_buffer: wgpu::Buffer,
+    resource_stats: TransvoxelClassifierResourceStats,
+}
+
+impl TransvoxelGpuClassifier {
+    pub fn new(device: &wgpu::Device) -> Result<Self, TransvoxelGpuError> {
+        validate_device_limits(&device.limits())?;
+
+        let regular_cell_class = generated::REGULAR_CELL_CLASS.map(u32::from);
+        let regular_geometry_counts = generated::REGULAR_CELL_GEOMETRY_COUNTS.map(u32::from);
+        let dispatch_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Planetary Transvoxel Dispatch"),
+            contents: bytemuck::bytes_of(&GpuTransvoxelDispatch::default()),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        });
+        let sample_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Halo Samples"),
+            size: sample_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let class_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Planetary Transvoxel Regular Classes"),
+            contents: bytemuck::cast_slice(&regular_cell_class),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let geometry_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Planetary Transvoxel Regular Geometry Counts"),
+            contents: bytemuck::cast_slice(&regular_geometry_counts),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Classified Cells"),
+            size: output_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let counters_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Classify Counters"),
+            size: counters_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Planetary Transvoxel Classify Shader"),
+            source: wgpu::ShaderSource::Wgsl(TRANSVOXEL_CLASSIFY_WGSL.into()),
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("Planetary Transvoxel Classify Pipeline"),
+            layout: None,
+            module: &shader,
+            entry_point: Some("classify_regular_cells"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+        let layout = pipeline.get_bind_group_layout(0);
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Classify Bind Group"),
+            layout: &layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: dispatch_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: sample_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: class_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: geometry_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: output_buffer.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 5,
+                    resource: counters_buffer.as_entire_binding(),
+                },
+            ],
+        });
+        let resource_stats = TransvoxelClassifierResourceStats {
+            buffers: 6,
+            allocated_bytes: dispatch_buffer_bytes()
+                + sample_buffer_bytes()
+                + class_buffer_bytes()
+                + geometry_buffer_bytes()
+                + output_buffer_bytes()
+                + counters_buffer_bytes(),
+        };
+        Ok(Self {
+            pipeline,
+            bind_group,
+            dispatch_buffer,
+            sample_buffer,
+            output_buffer,
+            counters_buffer,
+            resource_stats,
+        })
+    }
+
+    pub fn dispatch(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        samples: &[CellWord],
+        generation: u64,
+        dirty_microbricks: u64,
+    ) -> Result<wgpu::SubmissionIndex, TransvoxelGpuError> {
+        if samples.len() != EXTRACTION_SAMPLE_COUNT {
+            return Err(TransvoxelGpuError::SampleCount {
+                actual: samples.len(),
+                expected: EXTRACTION_SAMPLE_COUNT,
+            });
+        }
+        queue.write_buffer(&self.sample_buffer, 0, bytemuck::cast_slice(samples));
+        queue.write_buffer(
+            &self.dispatch_buffer,
+            0,
+            bytemuck::bytes_of(&GpuTransvoxelDispatch::new(generation, dirty_microbricks)),
+        );
+
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Planetary Transvoxel Classify Encoder"),
+        });
+        encoder.clear_buffer(&self.counters_buffer, 0, None);
+        {
+            let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("Planetary Transvoxel Classify Dispatch"),
+                timestamp_writes: None,
+            });
+            pass.set_pipeline(&self.pipeline);
+            pass.set_bind_group(0, &self.bind_group, &[]);
+            pass.dispatch_workgroups(TRANSVOXEL_CLASSIFY_WORKGROUPS, 1, 1);
+        }
+        Ok(queue.submit([encoder.finish()]))
+    }
+
+    pub fn output_buffer(&self) -> &wgpu::Buffer {
+        &self.output_buffer
+    }
+
+    pub fn counters_buffer(&self) -> &wgpu::Buffer {
+        &self.counters_buffer
+    }
+
+    pub const fn resource_stats(&self) -> TransvoxelClassifierResourceStats {
+        self.resource_stats
+    }
+
+    /// Classification owns no surface-size-dependent resources.
+    pub fn resize(&mut self, _width: u32, _height: u32) {}
+}
+
+fn validate_device_limits(limits: &wgpu::Limits) -> Result<(), TransvoxelGpuError> {
+    if limits.max_storage_buffers_per_shader_stage < 5 {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "storage buffers per shader stage",
+            required: 5,
+            available: u64::from(limits.max_storage_buffers_per_shader_stage),
+        });
+    }
+    if limits.max_uniform_buffers_per_shader_stage < 1 {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "uniform buffers per shader stage",
+            required: 1,
+            available: u64::from(limits.max_uniform_buffers_per_shader_stage),
+        });
+    }
+    if limits.max_compute_invocations_per_workgroup < TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE
+        || limits.max_compute_workgroup_size_x < TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE
+    {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "compute workgroup width",
+            required: u64::from(TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE),
+            available: u64::from(
+                limits
+                    .max_compute_invocations_per_workgroup
+                    .min(limits.max_compute_workgroup_size_x),
+            ),
+        });
+    }
+    if limits.max_compute_workgroups_per_dimension < TRANSVOXEL_CLASSIFY_WORKGROUPS {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "compute workgroups per dimension",
+            required: u64::from(TRANSVOXEL_CLASSIFY_WORKGROUPS),
+            available: u64::from(limits.max_compute_workgroups_per_dimension),
+        });
+    }
+    for (name, bytes) in [
+        ("halo samples", sample_buffer_bytes()),
+        ("regular classes", class_buffer_bytes()),
+        ("regular geometry counts", geometry_buffer_bytes()),
+        ("classified cells", output_buffer_bytes()),
+        ("classify counters", counters_buffer_bytes()),
+    ] {
+        let available = limits
+            .max_buffer_size
+            .min(limits.max_storage_buffer_binding_size);
+        if bytes > available {
+            return Err(TransvoxelGpuError::DeviceLimit {
+                name,
+                required: bytes,
+                available,
+            });
+        }
+    }
+    if dispatch_buffer_bytes() > limits.max_uniform_buffer_binding_size {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "dispatch uniform",
+            required: dispatch_buffer_bytes(),
+            available: limits.max_uniform_buffer_binding_size,
+        });
+    }
+    Ok(())
+}
+
+const fn dispatch_buffer_bytes() -> u64 {
+    core::mem::size_of::<GpuTransvoxelDispatch>() as u64
+}
+
+const fn sample_buffer_bytes() -> u64 {
+    (EXTRACTION_SAMPLE_COUNT * core::mem::size_of::<CellWord>()) as u64
+}
+
+const fn class_buffer_bytes() -> u64 {
+    (REGULAR_CASE_COUNT * core::mem::size_of::<u32>()) as u64
+}
+
+const fn geometry_buffer_bytes() -> u64 {
+    (generated::REGULAR_CELL_GEOMETRY_COUNTS.len() * core::mem::size_of::<u32>()) as u64
+}
+
+const fn output_buffer_bytes() -> u64 {
+    (PAGE_CELL_COUNT * core::mem::size_of::<GpuTransvoxelCell>()) as u64
+}
+
+const fn counters_buffer_bytes() -> u64 {
+    core::mem::size_of::<GpuTransvoxelClassifyCounters>() as u64
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum TransvoxelGpuError {
+    #[error("Transvoxel classification received {actual} samples; expected {expected}")]
+    SampleCount { actual: usize, expected: usize },
+    #[error(
+        "Transvoxel classification requires {required} {name}, but the device exposes {available}"
+    )]
+    DeviceLimit {
+        name: &'static str,
+        required: u64,
+        available: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allocation_is_fixed_and_exact() {
+        assert_eq!(dispatch_buffer_bytes(), 32);
+        assert_eq!(sample_buffer_bytes(), 157_216);
+        assert_eq!(class_buffer_bytes(), 1_024);
+        assert_eq!(geometry_buffer_bytes(), 64);
+        assert_eq!(output_buffer_bytes(), 524_288);
+        assert_eq!(counters_buffer_bytes(), 16);
+        assert_eq!(TRANSVOXEL_CLASSIFY_WORKGROUPS, 512);
+    }
+
+    #[test]
+    fn insufficient_device_limits_fail_before_allocation() {
+        let limits = wgpu::Limits {
+            max_storage_buffers_per_shader_stage: 4,
+            ..wgpu::Limits::default()
+        };
+        assert!(matches!(
+            validate_device_limits(&limits),
+            Err(TransvoxelGpuError::DeviceLimit {
+                name: "storage buffers per shader stage",
+                required: 5,
+                available: 4,
+            })
+        ));
+    }
+
+    #[test]
+    fn packed_cell_preserves_full_generation_and_counts() {
+        let cell = GpuTransvoxelCell::new(0xfe, 55, 12, 12, u64::MAX - 7);
+        assert_eq!(cell.case_index(), 0xfe);
+        assert_eq!(cell.class_index(), 55);
+        assert_eq!(cell.vertex_count(), 12);
+        assert_eq!(cell.triangle_count(), 12);
+        assert_eq!(cell.generation(), u64::MAX - 7);
+        assert!(cell.is_valid_for(u64::MAX - 7));
+        assert!(!cell.is_valid_for(u64::MAX - 8));
+        assert!(!GpuTransvoxelCell::default().is_valid_for(0));
+    }
+}

--- a/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel.rs
@@ -1,0 +1,243 @@
+use bytemuck::Pod;
+use helio_pass_planetary_voxel::{
+    regular_case_from_fixture, ExtractionFixture, ExtractionFixtureKind, GpuTransvoxelCell,
+    GpuTransvoxelClassifyCounters, TransvoxelGpuClassifier, TransvoxelGpuError,
+};
+use helio_planet_voxel_core::{PageKey, PAGE_CELL_COUNT, PAGE_EDGE};
+use std::sync::mpsc;
+
+#[test]
+fn headless_transvoxel_classification_matches_every_fixture_cell() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = request_test_adapter(&instance).await;
+        let Some(adapter) = adapter else {
+            eprintln!(
+                "GPU_VALIDATION_SKIPPED_NO_ADAPTER: no primary or fallback adapter available"
+            );
+            return;
+        };
+        let adapter_info = adapter.get_info();
+        eprintln!(
+            "GPU_VALIDATION_ADAPTER: name={:?} backend={:?} device_type={:?}",
+            adapter_info.name, adapter_info.backend, adapter_info.device_type
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planetary Transvoxel Validation Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a validation device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("planetary Transvoxel GPU validation error: {error:?}");
+        }));
+
+        let mut classifier = TransvoxelGpuClassifier::new(&device).unwrap();
+        assert_eq!(classifier.resource_stats().buffers, 6);
+        assert_eq!(classifier.resource_stats().allocated_bytes, 682_640);
+        let resources = classifier.resource_stats();
+        classifier.resize(3840, 2160);
+        assert_eq!(classifier.resource_stats(), resources);
+
+        for (fixture_index, kind) in ExtractionFixtureKind::ALL.into_iter().enumerate() {
+            let generation = 10 + fixture_index as u64;
+            let fixture = fixture(kind);
+            let expected = expected_classification(&fixture, generation, u64::MAX);
+            classifier
+                .dispatch(&device, &queue, fixture.samples(), generation, u64::MAX)
+                .unwrap();
+            let actual_cells: Vec<GpuTransvoxelCell> = read_buffer(
+                &device,
+                &queue,
+                classifier.output_buffer(),
+                PAGE_CELL_COUNT as u64 * size_of::<GpuTransvoxelCell>() as u64,
+            );
+            let actual_counters: Vec<GpuTransvoxelClassifyCounters> = read_buffer(
+                &device,
+                &queue,
+                classifier.counters_buffer(),
+                size_of::<GpuTransvoxelClassifyCounters>() as u64,
+            );
+            assert_eq!(actual_cells, expected.0, "{} cell parity", kind.name());
+            assert_eq!(
+                actual_counters,
+                vec![expected.1],
+                "{} counters",
+                kind.name()
+            );
+
+            classifier
+                .dispatch(&device, &queue, fixture.samples(), generation, u64::MAX)
+                .unwrap();
+            let repeated: Vec<GpuTransvoxelCell> = read_buffer(
+                &device,
+                &queue,
+                classifier.output_buffer(),
+                PAGE_CELL_COUNT as u64 * size_of::<GpuTransvoxelCell>() as u64,
+            );
+            assert_eq!(repeated, actual_cells, "{} deterministic", kind.name());
+        }
+
+        let fixture = fixture(ExtractionFixtureKind::Plane);
+        let generation = 100;
+        let dirty_microbricks = 1_u64 << 12;
+        let expected = expected_classification(&fixture, generation, dirty_microbricks);
+        classifier
+            .dispatch(
+                &device,
+                &queue,
+                fixture.samples(),
+                generation,
+                dirty_microbricks,
+            )
+            .unwrap();
+        let cells: Vec<GpuTransvoxelCell> = read_buffer(
+            &device,
+            &queue,
+            classifier.output_buffer(),
+            PAGE_CELL_COUNT as u64 * size_of::<GpuTransvoxelCell>() as u64,
+        );
+        let counters: Vec<GpuTransvoxelClassifyCounters> = read_buffer(
+            &device,
+            &queue,
+            classifier.counters_buffer(),
+            size_of::<GpuTransvoxelClassifyCounters>() as u64,
+        );
+        for (linear, (cell, expected_cell)) in cells.iter().zip(&expected.0).enumerate() {
+            let x = linear % PAGE_EDGE;
+            let y = (linear / PAGE_EDGE) % PAGE_EDGE;
+            let z = linear / (PAGE_EDGE * PAGE_EDGE);
+            let microbrick = x / 8 + (y / 8) * 4 + (z / 8) * 16;
+            if microbrick == 12 {
+                assert_eq!(cell, expected_cell, "dirty cell {linear}");
+                assert!(cell.is_valid_for(generation));
+            } else {
+                assert!(!cell.is_valid_for(generation), "stale cell {linear}");
+            }
+        }
+        assert_eq!(counters, vec![expected.1]);
+        assert_eq!(counters[0].visited_cells, 8 * 8 * 8);
+        assert!(counters[0].active_cells > 0);
+
+        assert!(matches!(
+            classifier.dispatch(
+                &device,
+                &queue,
+                &fixture.samples()[..fixture.samples().len() - 1],
+                generation,
+                u64::MAX,
+            ),
+            Err(TransvoxelGpuError::SampleCount { .. })
+        ));
+    });
+}
+
+fn fixture(kind: ExtractionFixtureKind) -> ExtractionFixture {
+    let page_xyz = match kind {
+        ExtractionFixtureKind::Plane
+        | ExtractionFixtureKind::ThinSlab
+        | ExtractionFixtureKind::MaterialSeam => [0, -1, 0],
+        ExtractionFixtureKind::Sphere
+        | ExtractionFixtureKind::Cave
+        | ExtractionFixtureKind::SharpCorner => [0, 0, 0],
+    };
+    ExtractionFixture::new(kind, PageKey::new(0, page_xyz)).unwrap()
+}
+
+fn expected_classification(
+    fixture: &ExtractionFixture,
+    generation: u64,
+    dirty_microbricks: u64,
+) -> (Vec<GpuTransvoxelCell>, GpuTransvoxelClassifyCounters) {
+    let mut cells = vec![GpuTransvoxelCell::default(); PAGE_CELL_COUNT];
+    let mut counters = GpuTransvoxelClassifyCounters::default();
+    for z in 0..PAGE_EDGE as u8 {
+        for y in 0..PAGE_EDGE as u8 {
+            for x in 0..PAGE_EDGE as u8 {
+                let linear = usize::from(x)
+                    + usize::from(y) * PAGE_EDGE
+                    + usize::from(z) * PAGE_EDGE * PAGE_EDGE;
+                let microbrick = u32::from(x / 8) + u32::from(y / 8) * 4 + u32::from(z / 8) * 16;
+                if dirty_microbricks & (1_u64 << microbrick) == 0 {
+                    continue;
+                }
+                counters.visited_cells += 1;
+                let fixture_case = fixture.cell_case([x, y, z]).unwrap();
+                let topology = regular_case_from_fixture(fixture_case);
+                cells[linear] = GpuTransvoxelCell::new(
+                    topology.case_index() as u8,
+                    topology.class_index(),
+                    topology.vertex_count() as u8,
+                    topology.triangle_count() as u8,
+                    generation,
+                );
+                if topology.vertex_count() != 0 {
+                    counters.active_cells += 1;
+                    counters.vertices += topology.vertex_count() as u32;
+                    counters.triangles += topology.triangle_count() as u32;
+                }
+            }
+        }
+    }
+    (cells, counters)
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}
+
+fn read_buffer<T: Pod + Copy>(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source: &wgpu::Buffer,
+    size: u64,
+) -> Vec<T> {
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planetary Transvoxel Validation Readback"),
+        size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planetary Transvoxel Validation Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(source, 0, &readback, 0, size);
+    queue.submit([encoder.finish()]);
+
+    let slice = readback.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv()
+        .expect("GPU readback callback must run")
+        .expect("GPU readback mapping must succeed");
+    let mapped = slice
+        .get_mapped_range()
+        .expect("GPU readback range must be available");
+    let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
+    drop(mapped);
+    readback.unmap();
+    values
+}
+
+const fn size_of<T>() -> usize {
+    core::mem::size_of::<T>()
+}

--- a/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
+++ b/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
@@ -1,7 +1,8 @@
 use helio_pass_planetary_voxel::{
     GpuExtractionCounters, GpuExtractionRange, GpuExtractionRequest, GpuLookupQuery,
     GpuLookupResult, GpuPageTableEntry, GpuResidencyCounters, GpuResidencyUniform,
-    GpuTerrainMeshlet, GpuTerrainVertex, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL,
+    GpuTerrainMeshlet, GpuTerrainVertex, GpuTransvoxelCell, GpuTransvoxelClassifyCounters,
+    GpuTransvoxelDispatch, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL, TRANSVOXEL_CLASSIFY_WGSL,
 };
 use std::mem::{align_of, offset_of, size_of};
 use wgpu::naga::{
@@ -295,6 +296,64 @@ fn counters_are_explicitly_padded_and_pod_sized() {
                 ("atlas_shards".into(), 80),
                 ("device_rebuilds".into(), 84),
                 ("_pad".into(), 88),
+            ],
+        )
+    );
+}
+
+#[test]
+fn transvoxel_classifier_layouts_match_wgsl_exactly() {
+    let module =
+        wgsl::parse_str(TRANSVOXEL_CLASSIFY_WGSL).expect("Transvoxel classify WGSL parses");
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .expect("Transvoxel classify WGSL validates");
+
+    assert_eq!(align_of::<GpuTransvoxelDispatch>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelDispatch>(), 32);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_CLASSIFY_WGSL, "GpuTransvoxelDispatch"),
+        (
+            32,
+            vec![
+                ("dirty_microbricks_low".into(), 0),
+                ("dirty_microbricks_high".into(), 4),
+                ("generation_low".into(), 8),
+                ("generation_high".into(), 12),
+                ("cell_count".into(), 16),
+                ("_pad0".into(), 20),
+                ("_pad1".into(), 24),
+                ("_pad2".into(), 28),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelCell>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelCell>(), 16);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_CLASSIFY_WGSL, "GpuTransvoxelCell"),
+        (
+            16,
+            vec![
+                ("packed_case_class_counts".into(), 0),
+                ("generation_low".into(), 4),
+                ("generation_high".into(), 8),
+                ("_pad".into(), 12),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelClassifyCounters>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelClassifyCounters>(), 16);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_CLASSIFY_WGSL, "GpuTransvoxelClassifyCounters"),
+        (
+            16,
+            vec![
+                ("visited_cells".into(), 0),
+                ("active_cells".into(), 4),
+                ("vertices".into(), 8),
+                ("triangles".into(), 12),
             ],
         )
     );


### PR DESCRIPTION
Part of #96.

Adds the first executable GPU Transvoxel stage: a bounded regular-cell classifier/count pass using the pinned official tables and the same canonical 34^3 halo fixtures as the CPU reference.

Correctness and cost properties:
- fixed 682,640-byte allocation; five storage bindings plus one uniform
- full 64-bit generation stamps on packed cell records
- dirty-microbrick dispatch writes only selected cells and does not clear the 512 KiB output buffer
- explicit adapter limit rejection before resource creation
- no surface-size resources and no render-graph registration
- all 196,608 cells across six fixture pages match CPU case/class/vertex/triangle results on an RTX 3060
- repeat dispatch determinism and stale-generation rejection validated

Validation:
- `cargo test -p helio-pass-planetary-voxel --locked`
- `cargo clippy -p helio-pass-planetary-voxel --all-targets --locked -- -D warnings`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked`

This does not claim extraction complete. Issue #96 remains open for prefix allocation, vertex/index emission, transition cells, topology checks, and measured comparison with manifold dual contouring.