### PR TITLE
Add deterministic GPU Transvoxel emission

### DIFF
--- a/crates/helio-pass-planetary-voxel/src/lib.rs
+++ b/crates/helio-pass-planetary-voxel/src/lib.rs
@@ -11,6 +11,7 @@ mod fixture;
 mod gpu;
 mod table;
 mod transvoxel;
+mod transvoxel_emit;
 mod transvoxel_gpu;
 
 pub use config::*;
@@ -19,8 +20,10 @@ pub use fixture::*;
 pub use gpu::*;
 pub use table::*;
 pub use transvoxel::*;
+pub use transvoxel_emit::*;
 pub use transvoxel_gpu::*;
 
 pub const EXTRACTION_LAYOUT_WGSL: &str = include_str!("extraction_layout.wgsl");
 pub const RESIDENCY_WGSL: &str = include_str!("residency.wgsl");
 pub const TRANSVOXEL_CLASSIFY_WGSL: &str = include_str!("transvoxel_classify.wgsl");
+pub const TRANSVOXEL_EMIT_WGSL: &str = include_str!("transvoxel_emit.wgsl");

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_classify.wgsl
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_classify.wgsl
@@ -8,9 +8,9 @@ struct GpuTransvoxelDispatch {
     generation_low: u32,
     generation_high: u32,
     cell_count: u32,
-    _pad0: u32,
-    _pad1: u32,
-    _pad2: u32,
+    max_vertices: u32,
+    max_indices: u32,
+    scan_block_count: u32,
 };
 
 struct GpuTransvoxelCell {

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_emit.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_emit.rs
@@ -1,0 +1,454 @@
+use crate::{
+    transvoxel::generated, GpuTerrainVertex, GpuTransvoxelDispatch, TransvoxelGpuClassifier,
+    TransvoxelGpuError, TRANSVOXEL_CLASSIFY_WORKGROUPS, TRANSVOXEL_EMIT_WGSL,
+    TRANSVOXEL_SCAN_BLOCKS, TRANSVOXEL_SCAN_WORKGROUP_SIZE,
+};
+use bytemuck::{Pod, Zeroable};
+use helio_planet_voxel_core::{CellWord, PAGE_CELL_COUNT};
+use wgpu::util::DeviceExt;
+
+const REGULAR_VERTEX_TABLE_VALUES: usize = 256 * 12;
+const REGULAR_TOPOLOGY_TABLE_VALUES: usize = 16 * 15;
+const REGULAR_TABLE_VALUES: usize = REGULAR_VERTEX_TABLE_VALUES + REGULAR_TOPOLOGY_TABLE_VALUES;
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelCellOffset {
+    pub first_vertex: u32,
+    pub first_index: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+}
+
+impl GpuTransvoxelCellOffset {
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelScanBlock {
+    pub vertex_count: u32,
+    pub index_count: u32,
+    pub first_vertex: u32,
+    pub first_index: u32,
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelEmissionCounters {
+    pub required_vertices: u32,
+    pub required_indices: u32,
+    pub emitted_vertices: u32,
+    pub emitted_indices: u32,
+    pub vertex_overflow: u32,
+    pub index_overflow: u32,
+    pub completed: u32,
+    pub _pad: u32,
+}
+
+impl GpuTransvoxelEmissionCounters {
+    pub const fn overflowed(self) -> bool {
+        self.vertex_overflow != 0 || self.index_overflow != 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransvoxelGpuExtractorConfig {
+    pub max_vertices: u32,
+    pub max_indices: u32,
+}
+
+impl TransvoxelGpuExtractorConfig {
+    pub fn new(max_vertices: u32, max_indices: u32) -> Result<Self, TransvoxelGpuError> {
+        if max_vertices == 0 || max_indices == 0 {
+            return Err(TransvoxelGpuError::InvalidExtractionCapacity {
+                max_vertices,
+                max_indices,
+            });
+        }
+        Ok(Self {
+            max_vertices,
+            max_indices,
+        })
+    }
+}
+
+impl Default for TransvoxelGpuExtractorConfig {
+    fn default() -> Self {
+        Self {
+            max_vertices: 393_216,
+            max_indices: 491_520,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransvoxelExtractorResourceStats {
+    pub buffers: u32,
+    pub allocated_bytes: u64,
+}
+
+/// Deterministic regular-cell allocation and emission built on the classifier.
+/// Prefix sums give every cell a stable range; capacity overflow suppresses the
+/// entire emission rather than publishing a partial mesh.
+pub struct TransvoxelGpuExtractor {
+    classifier: TransvoxelGpuClassifier,
+    scan_cells_pipeline: wgpu::ComputePipeline,
+    scan_blocks_pipeline: wgpu::ComputePipeline,
+    emit_pipeline: wgpu::ComputePipeline,
+    scan_cells_bind_group: wgpu::BindGroup,
+    scan_blocks_bind_group: wgpu::BindGroup,
+    emit_bind_group: wgpu::BindGroup,
+    offsets_buffer: wgpu::Buffer,
+    blocks_buffer: wgpu::Buffer,
+    vertices_buffer: wgpu::Buffer,
+    indices_buffer: wgpu::Buffer,
+    counters_buffer: wgpu::Buffer,
+    config: TransvoxelGpuExtractorConfig,
+    resource_stats: TransvoxelExtractorResourceStats,
+}
+
+impl TransvoxelGpuExtractor {
+    pub fn new(
+        device: &wgpu::Device,
+        config: TransvoxelGpuExtractorConfig,
+    ) -> Result<Self, TransvoxelGpuError> {
+        validate_extractor_limits(&device.limits(), config)?;
+        let classifier = TransvoxelGpuClassifier::new(device)?;
+        let offsets_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Cell Offsets"),
+            size: offsets_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let blocks_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Scan Blocks"),
+            size: blocks_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let tables = packed_regular_tables();
+        let tables_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Planetary Transvoxel Emission Tables"),
+            contents: bytemuck::cast_slice(&tables),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let vertices_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Vertices"),
+            size: vertices_buffer_bytes(config),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let indices_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Indices"),
+            size: indices_buffer_bytes(config),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::INDEX
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let counters_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Emission Counters"),
+            size: counters_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Planetary Transvoxel Emission Shader"),
+            source: wgpu::ShaderSource::Wgsl(TRANSVOXEL_EMIT_WGSL.into()),
+        });
+        let scan_cells_pipeline = compute_pipeline(device, &shader, "scan_regular_cells");
+        let scan_blocks_pipeline = compute_pipeline(device, &shader, "scan_regular_blocks");
+        let emit_pipeline = compute_pipeline(device, &shader, "emit_regular_cells");
+        let scan_cells_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Cell Scan Bind Group"),
+            layout: &scan_cells_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, classifier.dispatch_buffer()),
+                entry(2, classifier.output_buffer()),
+                entry(3, &offsets_buffer),
+                entry(4, &blocks_buffer),
+            ],
+        });
+        let scan_blocks_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Block Scan Bind Group"),
+            layout: &scan_blocks_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, classifier.dispatch_buffer()),
+                entry(4, &blocks_buffer),
+                entry(8, &counters_buffer),
+            ],
+        });
+        let emit_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Emission Bind Group"),
+            layout: &emit_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, classifier.dispatch_buffer()),
+                entry(1, classifier.sample_buffer()),
+                entry(2, classifier.output_buffer()),
+                entry(3, &offsets_buffer),
+                entry(4, &blocks_buffer),
+                entry(5, &tables_buffer),
+                entry(6, &vertices_buffer),
+                entry(7, &indices_buffer),
+                entry(8, &counters_buffer),
+            ],
+        });
+        let classifier_stats = classifier.resource_stats();
+        let resource_stats = TransvoxelExtractorResourceStats {
+            buffers: classifier_stats.buffers + 6,
+            allocated_bytes: classifier_stats.allocated_bytes
+                + offsets_buffer_bytes()
+                + blocks_buffer_bytes()
+                + tables_buffer_bytes()
+                + vertices_buffer_bytes(config)
+                + indices_buffer_bytes(config)
+                + counters_buffer_bytes(),
+        };
+        Ok(Self {
+            classifier,
+            scan_cells_pipeline,
+            scan_blocks_pipeline,
+            emit_pipeline,
+            scan_cells_bind_group,
+            scan_blocks_bind_group,
+            emit_bind_group,
+            offsets_buffer,
+            blocks_buffer,
+            vertices_buffer,
+            indices_buffer,
+            counters_buffer,
+            config,
+            resource_stats,
+        })
+    }
+
+    pub fn dispatch(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        samples: &[CellWord],
+        generation: u64,
+        dirty_microbricks: u64,
+    ) -> Result<wgpu::SubmissionIndex, TransvoxelGpuError> {
+        self.classifier.prepare(
+            queue,
+            samples,
+            GpuTransvoxelDispatch::with_limits(
+                generation,
+                dirty_microbricks,
+                self.config.max_vertices,
+                self.config.max_indices,
+            ),
+        )?;
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Planetary Transvoxel Extraction Encoder"),
+        });
+        self.classifier.encode(&mut encoder);
+        encoder.clear_buffer(&self.counters_buffer, 0, None);
+        dispatch(
+            &mut encoder,
+            &self.scan_cells_pipeline,
+            &self.scan_cells_bind_group,
+            TRANSVOXEL_SCAN_BLOCKS,
+            "Planetary Transvoxel Cell Scan",
+        );
+        dispatch(
+            &mut encoder,
+            &self.scan_blocks_pipeline,
+            &self.scan_blocks_bind_group,
+            1,
+            "Planetary Transvoxel Block Scan",
+        );
+        dispatch(
+            &mut encoder,
+            &self.emit_pipeline,
+            &self.emit_bind_group,
+            TRANSVOXEL_CLASSIFY_WORKGROUPS,
+            "Planetary Transvoxel Emission",
+        );
+        Ok(queue.submit([encoder.finish()]))
+    }
+
+    pub fn vertices_buffer(&self) -> &wgpu::Buffer {
+        &self.vertices_buffer
+    }
+
+    pub fn indices_buffer(&self) -> &wgpu::Buffer {
+        &self.indices_buffer
+    }
+
+    pub fn counters_buffer(&self) -> &wgpu::Buffer {
+        &self.counters_buffer
+    }
+
+    pub fn offsets_buffer(&self) -> &wgpu::Buffer {
+        &self.offsets_buffer
+    }
+
+    pub fn blocks_buffer(&self) -> &wgpu::Buffer {
+        &self.blocks_buffer
+    }
+
+    pub const fn config(&self) -> TransvoxelGpuExtractorConfig {
+        self.config
+    }
+
+    pub const fn resource_stats(&self) -> TransvoxelExtractorResourceStats {
+        self.resource_stats
+    }
+
+    pub fn resize(&mut self, _width: u32, _height: u32) {}
+}
+
+fn compute_pipeline(
+    device: &wgpu::Device,
+    shader: &wgpu::ShaderModule,
+    entry_point: &str,
+) -> wgpu::ComputePipeline {
+    device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some(entry_point),
+        layout: None,
+        module: shader,
+        entry_point: Some(entry_point),
+        compilation_options: Default::default(),
+        cache: None,
+    })
+}
+
+fn entry(binding: u32, buffer: &wgpu::Buffer) -> wgpu::BindGroupEntry<'_> {
+    wgpu::BindGroupEntry {
+        binding,
+        resource: buffer.as_entire_binding(),
+    }
+}
+
+fn dispatch(
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::ComputePipeline,
+    bind_group: &wgpu::BindGroup,
+    workgroups: u32,
+    label: &'static str,
+) {
+    let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+        label: Some(label),
+        timestamp_writes: None,
+    });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, bind_group, &[]);
+    pass.dispatch_workgroups(workgroups, 1, 1);
+}
+
+fn packed_regular_tables() -> Vec<u32> {
+    let mut tables = Vec::with_capacity(REGULAR_TABLE_VALUES);
+    for row in generated::REGULAR_VERTEX_DATA {
+        tables.extend(row.map(u32::from));
+    }
+    for row in generated::REGULAR_CELL_VERTEX_INDEX {
+        tables.extend(row.map(u32::from));
+    }
+    tables
+}
+
+fn validate_extractor_limits(
+    limits: &wgpu::Limits,
+    config: TransvoxelGpuExtractorConfig,
+) -> Result<(), TransvoxelGpuError> {
+    TransvoxelGpuExtractorConfig::new(config.max_vertices, config.max_indices)?;
+    if limits.max_storage_buffers_per_shader_stage < 8 {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "storage buffers per shader stage",
+            required: 8,
+            available: u64::from(limits.max_storage_buffers_per_shader_stage),
+        });
+    }
+    let compute_width = limits
+        .max_compute_invocations_per_workgroup
+        .min(limits.max_compute_workgroup_size_x);
+    if compute_width < TRANSVOXEL_SCAN_WORKGROUP_SIZE {
+        return Err(TransvoxelGpuError::DeviceLimit {
+            name: "compute workgroup width",
+            required: u64::from(TRANSVOXEL_SCAN_WORKGROUP_SIZE),
+            available: u64::from(compute_width),
+        });
+    }
+    let available = limits
+        .max_buffer_size
+        .min(limits.max_storage_buffer_binding_size);
+    for (name, required) in [
+        ("cell offsets", offsets_buffer_bytes()),
+        ("scan blocks", blocks_buffer_bytes()),
+        ("emission tables", tables_buffer_bytes()),
+        ("terrain vertices", vertices_buffer_bytes(config)),
+        ("terrain indices", indices_buffer_bytes(config)),
+        ("emission counters", counters_buffer_bytes()),
+    ] {
+        if required > available {
+            return Err(TransvoxelGpuError::DeviceLimit {
+                name,
+                required,
+                available,
+            });
+        }
+    }
+    Ok(())
+}
+
+const fn offsets_buffer_bytes() -> u64 {
+    (PAGE_CELL_COUNT * core::mem::size_of::<GpuTransvoxelCellOffset>()) as u64
+}
+
+const fn blocks_buffer_bytes() -> u64 {
+    (TRANSVOXEL_SCAN_BLOCKS as usize * core::mem::size_of::<GpuTransvoxelScanBlock>()) as u64
+}
+
+const fn tables_buffer_bytes() -> u64 {
+    (REGULAR_TABLE_VALUES * core::mem::size_of::<u32>()) as u64
+}
+
+const fn vertices_buffer_bytes(config: TransvoxelGpuExtractorConfig) -> u64 {
+    config.max_vertices as u64 * core::mem::size_of::<GpuTerrainVertex>() as u64
+}
+
+const fn indices_buffer_bytes(config: TransvoxelGpuExtractorConfig) -> u64 {
+    config.max_indices as u64 * core::mem::size_of::<u32>() as u64
+}
+
+const fn counters_buffer_bytes() -> u64 {
+    core::mem::size_of::<GpuTransvoxelEmissionCounters>() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worst_case_regular_page_budget_is_exact() {
+        let config = TransvoxelGpuExtractorConfig::default();
+        assert_eq!(offsets_buffer_bytes(), 524_288);
+        assert_eq!(blocks_buffer_bytes(), 2_048);
+        assert_eq!(tables_buffer_bytes(), 13_248);
+        assert_eq!(vertices_buffer_bytes(config), 12_582_912);
+        assert_eq!(indices_buffer_bytes(config), 1_966_080);
+        assert_eq!(counters_buffer_bytes(), 32);
+    }
+
+    #[test]
+    fn zero_capacity_is_rejected() {
+        assert!(matches!(
+            TransvoxelGpuExtractorConfig::new(0, 1),
+            Err(TransvoxelGpuError::InvalidExtractionCapacity { .. })
+        ));
+        assert!(matches!(
+            TransvoxelGpuExtractorConfig::new(1, 0),
+            Err(TransvoxelGpuError::InvalidExtractionCapacity { .. })
+        ));
+    }
+}

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_emit.wgsl
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_emit.wgsl
@@ -1,0 +1,322 @@
+const PAGE_EDGE: u32 = 32u;
+const SAMPLE_EDGE: u32 = 34u;
+const PAGE_CELL_COUNT: u32 = 32768u;
+const SCAN_WORKGROUP_SIZE: u32 = 256u;
+const REGULAR_VERTEX_TABLE_STRIDE: u32 = 12u;
+const REGULAR_TOPOLOGY_TABLE_OFFSET: u32 = 3072u;
+const REGULAR_TOPOLOGY_TABLE_STRIDE: u32 = 15u;
+
+struct GpuTransvoxelDispatch {
+    dirty_microbricks_low: u32,
+    dirty_microbricks_high: u32,
+    generation_low: u32,
+    generation_high: u32,
+    cell_count: u32,
+    max_vertices: u32,
+    max_indices: u32,
+    scan_block_count: u32,
+};
+
+struct GpuTransvoxelCell {
+    packed_case_class_counts: u32,
+    generation_low: u32,
+    generation_high: u32,
+    _pad: u32,
+};
+
+struct GpuTransvoxelCellOffset {
+    first_vertex: u32,
+    first_index: u32,
+    generation_low: u32,
+    generation_high: u32,
+};
+
+struct GpuTransvoxelScanBlock {
+    vertex_count: u32,
+    index_count: u32,
+    first_vertex: u32,
+    first_index: u32,
+};
+
+struct GpuTerrainVertex {
+    position: vec3<f32>,
+    material: u32,
+    normal: vec3<f32>,
+    flags: u32,
+};
+
+struct GpuTransvoxelEmissionCounters {
+    required_vertices: atomic<u32>,
+    required_indices: atomic<u32>,
+    emitted_vertices: atomic<u32>,
+    emitted_indices: atomic<u32>,
+    vertex_overflow: atomic<u32>,
+    index_overflow: atomic<u32>,
+    completed: atomic<u32>,
+    _pad: u32,
+};
+
+@group(0) @binding(0)
+var<uniform> dispatch: GpuTransvoxelDispatch;
+@group(0) @binding(1)
+var<storage, read> samples: array<u32>;
+@group(0) @binding(2)
+var<storage, read> cells: array<GpuTransvoxelCell>;
+@group(0) @binding(3)
+var<storage, read_write> cell_offsets: array<GpuTransvoxelCellOffset>;
+@group(0) @binding(4)
+var<storage, read_write> scan_blocks: array<GpuTransvoxelScanBlock>;
+@group(0) @binding(5)
+var<storage, read> regular_tables: array<u32>;
+@group(0) @binding(6)
+var<storage, read_write> vertices: array<GpuTerrainVertex>;
+@group(0) @binding(7)
+var<storage, read_write> indices: array<u32>;
+@group(0) @binding(8)
+var<storage, read_write> emission: GpuTransvoxelEmissionCounters;
+
+const REGULAR_CORNERS: array<vec3<u32>, 8> = array<vec3<u32>, 8>(
+    vec3<u32>(0u, 0u, 0u),
+    vec3<u32>(1u, 0u, 0u),
+    vec3<u32>(0u, 1u, 0u),
+    vec3<u32>(1u, 1u, 0u),
+    vec3<u32>(0u, 0u, 1u),
+    vec3<u32>(1u, 0u, 1u),
+    vec3<u32>(0u, 1u, 1u),
+    vec3<u32>(1u, 1u, 1u),
+);
+
+var<workgroup> vertex_scan: array<u32, 256>;
+var<workgroup> index_scan: array<u32, 256>;
+
+fn cell_is_current(cell: GpuTransvoxelCell) -> bool {
+    return (cell.packed_case_class_counts & 0x80000000u) != 0u
+        && cell.generation_low == dispatch.generation_low
+        && cell.generation_high == dispatch.generation_high;
+}
+
+fn cell_vertex_count(cell: GpuTransvoxelCell) -> u32 {
+    return (cell.packed_case_class_counts >> 16u) & 0xffu;
+}
+
+fn cell_triangle_count(cell: GpuTransvoxelCell) -> u32 {
+    return (cell.packed_case_class_counts >> 24u) & 0x0fu;
+}
+
+fn inclusive_scan(local_index: u32) {
+    var step = 1u;
+    loop {
+        if step >= SCAN_WORKGROUP_SIZE {
+            break;
+        }
+        var add_vertices = 0u;
+        var add_indices = 0u;
+        if local_index >= step {
+            add_vertices = vertex_scan[local_index - step];
+            add_indices = index_scan[local_index - step];
+        }
+        workgroupBarrier();
+        vertex_scan[local_index] += add_vertices;
+        index_scan[local_index] += add_indices;
+        workgroupBarrier();
+        step <<= 1u;
+    }
+}
+
+@compute @workgroup_size(256, 1, 1)
+fn scan_regular_cells(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+) {
+    let linear = global_id.x;
+    let local_index = local_id.x;
+    var vertex_count = 0u;
+    var index_count = 0u;
+    var current = false;
+    if linear < dispatch.cell_count && linear < PAGE_CELL_COUNT {
+        let cell = cells[linear];
+        current = cell_is_current(cell);
+        if current {
+            vertex_count = cell_vertex_count(cell);
+            index_count = cell_triangle_count(cell) * 3u;
+        }
+    }
+
+    vertex_scan[local_index] = vertex_count;
+    index_scan[local_index] = index_count;
+    workgroupBarrier();
+    inclusive_scan(local_index);
+
+    if current {
+        cell_offsets[linear] = GpuTransvoxelCellOffset(
+            vertex_scan[local_index] - vertex_count,
+            index_scan[local_index] - index_count,
+            dispatch.generation_low,
+            dispatch.generation_high,
+        );
+    }
+    if local_index == SCAN_WORKGROUP_SIZE - 1u {
+        scan_blocks[workgroup_id.x] = GpuTransvoxelScanBlock(
+            vertex_scan[local_index],
+            index_scan[local_index],
+            0u,
+            0u,
+        );
+    }
+}
+
+@compute @workgroup_size(256, 1, 1)
+fn scan_regular_blocks(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    let local_index = local_id.x;
+    var vertex_count = 0u;
+    var index_count = 0u;
+    if local_index < dispatch.scan_block_count {
+        let block = scan_blocks[local_index];
+        vertex_count = block.vertex_count;
+        index_count = block.index_count;
+    }
+    vertex_scan[local_index] = vertex_count;
+    index_scan[local_index] = index_count;
+    workgroupBarrier();
+    inclusive_scan(local_index);
+
+    if local_index < dispatch.scan_block_count {
+        scan_blocks[local_index].first_vertex = vertex_scan[local_index] - vertex_count;
+        scan_blocks[local_index].first_index = index_scan[local_index] - index_count;
+    }
+    if local_index == SCAN_WORKGROUP_SIZE - 1u {
+        let required_vertices = vertex_scan[local_index];
+        let required_indices = index_scan[local_index];
+        atomicStore(&emission.required_vertices, required_vertices);
+        atomicStore(&emission.required_indices, required_indices);
+        atomicStore(&emission.vertex_overflow, select(0u, 1u, required_vertices > dispatch.max_vertices));
+        atomicStore(&emission.index_overflow, select(0u, 1u, required_indices > dispatch.max_indices));
+        atomicStore(&emission.completed, 1u);
+    }
+}
+
+fn sample_index(position: vec3<u32>) -> u32 {
+    return position.x + position.y * SAMPLE_EDGE + position.z * SAMPLE_EDGE * SAMPLE_EDGE;
+}
+
+fn density(word: u32) -> f32 {
+    let density_bits = word & 0xffffu;
+    let sign_extension = select(0u, 0xffff0000u, (density_bits & 0x8000u) != 0u);
+    return f32(bitcast<i32>(density_bits | sign_extension));
+}
+
+fn sample_density(position: vec3<u32>) -> f32 {
+    return density(samples[sample_index(position)]);
+}
+
+fn density_difference(position: vec3<u32>, axis: u32) -> f32 {
+    var lower = position;
+    var upper = position;
+    if position[axis] == 0u {
+        upper[axis] += 1u;
+        return sample_density(upper) - sample_density(position);
+    }
+    if position[axis] + 1u >= SAMPLE_EDGE {
+        lower[axis] -= 1u;
+        return sample_density(position) - sample_density(lower);
+    }
+    lower[axis] -= 1u;
+    upper[axis] += 1u;
+    return (sample_density(upper) - sample_density(lower)) * 0.5;
+}
+
+fn sample_gradient(position: vec3<u32>) -> vec3<f32> {
+    return vec3<f32>(
+        density_difference(position, 0u),
+        density_difference(position, 1u),
+        density_difference(position, 2u),
+    );
+}
+
+fn normalized_or_up(value: vec3<f32>) -> vec3<f32> {
+    let squared_length = dot(value, value);
+    if squared_length <= 1.0e-12 {
+        return vec3<f32>(0.0, 1.0, 0.0);
+    }
+    return value * inverseSqrt(squared_length);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn emit_regular_cells(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let linear = global_id.x;
+    if linear >= dispatch.cell_count || linear >= PAGE_CELL_COUNT {
+        return;
+    }
+    if atomicLoad(&emission.vertex_overflow) != 0u || atomicLoad(&emission.index_overflow) != 0u {
+        return;
+    }
+    let cell = cells[linear];
+    if !cell_is_current(cell) {
+        return;
+    }
+    let local_offset = cell_offsets[linear];
+    if local_offset.generation_low != dispatch.generation_low
+        || local_offset.generation_high != dispatch.generation_high {
+        return;
+    }
+    let block = scan_blocks[linear / SCAN_WORKGROUP_SIZE];
+    let first_vertex = block.first_vertex + local_offset.first_vertex;
+    let first_index = block.first_index + local_offset.first_index;
+    let case_index = cell.packed_case_class_counts & 0xffu;
+    let class_index = (cell.packed_case_class_counts >> 8u) & 0xffu;
+    let vertex_count = cell_vertex_count(cell);
+    let index_count = cell_triangle_count(cell) * 3u;
+
+    let x = linear % PAGE_EDGE;
+    let y = (linear / PAGE_EDGE) % PAGE_EDGE;
+    let z = linear / (PAGE_EDGE * PAGE_EDGE);
+    let cell_position = vec3<f32>(f32(x), f32(y), f32(z));
+    let sample_origin = vec3<u32>(x + 1u, y + 1u, z + 1u);
+    for (var vertex = 0u; vertex < vertex_count; vertex += 1u) {
+        let code = regular_tables[case_index * REGULAR_VERTEX_TABLE_STRIDE + vertex];
+        let first_corner = (code >> 4u) & 0x0fu;
+        let second_corner = code & 0x0fu;
+        let first_sample = sample_origin + REGULAR_CORNERS[first_corner];
+        let second_sample = sample_origin + REGULAR_CORNERS[second_corner];
+        let first_word = samples[sample_index(first_sample)];
+        let second_word = samples[sample_index(second_sample)];
+        let first_density = density(first_word);
+        let second_density = density(second_word);
+        let denominator = first_density - second_density;
+        var interpolation = 0.5;
+        if abs(denominator) > 1.0e-12 {
+            interpolation = clamp(first_density / denominator, 0.0, 1.0);
+        }
+        let first_position = vec3<f32>(REGULAR_CORNERS[first_corner]);
+        let second_position = vec3<f32>(REGULAR_CORNERS[second_corner]);
+        let position = cell_position + mix(first_position, second_position, interpolation);
+        let gradient = mix(
+            sample_gradient(first_sample),
+            sample_gradient(second_sample),
+            interpolation,
+        );
+        let material = select(
+            (second_word >> 16u) & 0xffu,
+            (first_word >> 16u) & 0xffu,
+            first_density <= 0.0,
+        );
+        vertices[first_vertex + vertex] = GpuTerrainVertex(
+            position,
+            material,
+            normalized_or_up(gradient),
+            0u,
+        );
+    }
+
+    for (var index = 0u; index < index_count; index += 1u) {
+        let local_vertex = regular_tables[
+            REGULAR_TOPOLOGY_TABLE_OFFSET
+                + class_index * REGULAR_TOPOLOGY_TABLE_STRIDE
+                + index
+        ];
+        indices[first_index + index] = first_vertex + local_vertex;
+    }
+    atomicAdd(&emission.emitted_vertices, vertex_count);
+    atomicAdd(&emission.emitted_indices, index_count);
+}

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_gpu.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_gpu.rs
@@ -8,6 +8,9 @@ use wgpu::util::DeviceExt;
 pub const TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE: u32 = 64;
 pub const TRANSVOXEL_CLASSIFY_WORKGROUPS: u32 =
     (PAGE_CELL_COUNT as u32).div_ceil(TRANSVOXEL_CLASSIFY_WORKGROUP_SIZE);
+pub const TRANSVOXEL_SCAN_WORKGROUP_SIZE: u32 = 256;
+pub const TRANSVOXEL_SCAN_BLOCKS: u32 =
+    (PAGE_CELL_COUNT as u32).div_ceil(TRANSVOXEL_SCAN_WORKGROUP_SIZE);
 
 #[repr(C, align(16))]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
@@ -17,22 +20,31 @@ pub struct GpuTransvoxelDispatch {
     pub generation_low: u32,
     pub generation_high: u32,
     pub cell_count: u32,
-    pub _pad0: u32,
-    pub _pad1: u32,
-    pub _pad2: u32,
+    pub max_vertices: u32,
+    pub max_indices: u32,
+    pub scan_block_count: u32,
 }
 
 impl GpuTransvoxelDispatch {
     pub const fn new(generation: u64, dirty_microbricks: u64) -> Self {
+        Self::with_limits(generation, dirty_microbricks, u32::MAX, u32::MAX)
+    }
+
+    pub const fn with_limits(
+        generation: u64,
+        dirty_microbricks: u64,
+        max_vertices: u32,
+        max_indices: u32,
+    ) -> Self {
         Self {
             dirty_microbricks_low: dirty_microbricks as u32,
             dirty_microbricks_high: (dirty_microbricks >> 32) as u32,
             generation_low: generation as u32,
             generation_high: (generation >> 32) as u32,
             cell_count: PAGE_CELL_COUNT as u32,
-            _pad0: 0,
-            _pad1: 0,
-            _pad2: 0,
+            max_vertices,
+            max_indices,
+            scan_block_count: TRANSVOXEL_SCAN_BLOCKS,
         }
     }
 
@@ -244,6 +256,24 @@ impl TransvoxelGpuClassifier {
         generation: u64,
         dirty_microbricks: u64,
     ) -> Result<wgpu::SubmissionIndex, TransvoxelGpuError> {
+        self.prepare(
+            queue,
+            samples,
+            GpuTransvoxelDispatch::new(generation, dirty_microbricks),
+        )?;
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Planetary Transvoxel Classify Encoder"),
+        });
+        self.encode(&mut encoder);
+        Ok(queue.submit([encoder.finish()]))
+    }
+
+    pub(crate) fn prepare(
+        &self,
+        queue: &wgpu::Queue,
+        samples: &[CellWord],
+        dispatch: GpuTransvoxelDispatch,
+    ) -> Result<(), TransvoxelGpuError> {
         if samples.len() != EXTRACTION_SAMPLE_COUNT {
             return Err(TransvoxelGpuError::SampleCount {
                 actual: samples.len(),
@@ -251,15 +281,11 @@ impl TransvoxelGpuClassifier {
             });
         }
         queue.write_buffer(&self.sample_buffer, 0, bytemuck::cast_slice(samples));
-        queue.write_buffer(
-            &self.dispatch_buffer,
-            0,
-            bytemuck::bytes_of(&GpuTransvoxelDispatch::new(generation, dirty_microbricks)),
-        );
+        queue.write_buffer(&self.dispatch_buffer, 0, bytemuck::bytes_of(&dispatch));
+        Ok(())
+    }
 
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("Planetary Transvoxel Classify Encoder"),
-        });
+    pub(crate) fn encode(&self, encoder: &mut wgpu::CommandEncoder) {
         encoder.clear_buffer(&self.counters_buffer, 0, None);
         {
             let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -270,7 +296,14 @@ impl TransvoxelGpuClassifier {
             pass.set_bind_group(0, &self.bind_group, &[]);
             pass.dispatch_workgroups(TRANSVOXEL_CLASSIFY_WORKGROUPS, 1, 1);
         }
-        Ok(queue.submit([encoder.finish()]))
+    }
+
+    pub(crate) fn dispatch_buffer(&self) -> &wgpu::Buffer {
+        &self.dispatch_buffer
+    }
+
+    pub(crate) fn sample_buffer(&self) -> &wgpu::Buffer {
+        &self.sample_buffer
     }
 
     pub fn output_buffer(&self) -> &wgpu::Buffer {
@@ -380,6 +413,8 @@ const fn counters_buffer_bytes() -> u64 {
 pub enum TransvoxelGpuError {
     #[error("Transvoxel classification received {actual} samples; expected {expected}")]
     SampleCount { actual: usize, expected: usize },
+    #[error("Transvoxel extraction capacities must be nonzero (vertices={max_vertices}, indices={max_indices})")]
+    InvalidExtractionCapacity { max_vertices: u32, max_indices: u32 },
     #[error(
         "Transvoxel classification requires {required} {name}, but the device exposes {available}"
     )]

--- a/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel_emission.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel_emission.rs
@@ -1,0 +1,464 @@
+use bytemuck::Pod;
+use helio_pass_planetary_voxel::{
+    regular_case_from_fixture, ExtractionFixture, ExtractionFixtureKind, GpuTerrainVertex,
+    GpuTransvoxelCellOffset, GpuTransvoxelEmissionCounters, GpuTransvoxelScanBlock,
+    TransvoxelGpuExtractor, TransvoxelGpuExtractorConfig, TRANSVOXEL_REGULAR_CORNERS,
+    TRANSVOXEL_SCAN_WORKGROUP_SIZE,
+};
+use helio_planet_voxel_core::{PageKey, PAGE_CELL_COUNT, PAGE_EDGE};
+use std::sync::mpsc;
+
+#[test]
+fn headless_transvoxel_emission_matches_cpu_geometry_and_overflow_contract() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!(
+                "GPU_VALIDATION_SKIPPED_NO_ADAPTER: no primary or fallback adapter available"
+            );
+            return;
+        };
+        let adapter_info = adapter.get_info();
+        eprintln!(
+            "GPU_VALIDATION_ADAPTER: name={:?} backend={:?} device_type={:?}",
+            adapter_info.name, adapter_info.backend, adapter_info.device_type
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planetary Transvoxel Emission Validation Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a validation device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("planetary Transvoxel emission GPU validation error: {error:?}");
+        }));
+
+        let mut extractor =
+            TransvoxelGpuExtractor::new(&device, TransvoxelGpuExtractorConfig::default()).unwrap();
+        assert_eq!(extractor.resource_stats().buffers, 12);
+        assert_eq!(extractor.resource_stats().allocated_bytes, 15_771_248);
+        let resources = extractor.resource_stats();
+        extractor.resize(3840, 2160);
+        assert_eq!(extractor.resource_stats(), resources);
+
+        for (fixture_index, kind) in ExtractionFixtureKind::ALL.into_iter().enumerate() {
+            let generation = 1_000 + fixture_index as u64;
+            let fixture = fixture(kind);
+            let expected = expected_mesh(&fixture, u64::MAX);
+            extractor
+                .dispatch(&device, &queue, fixture.samples(), generation, u64::MAX)
+                .unwrap();
+            let counters = read_one::<GpuTransvoxelEmissionCounters>(
+                &device,
+                &queue,
+                extractor.counters_buffer(),
+            );
+            assert_eq!(counters.completed, 1, "{} completed", kind.name());
+            assert!(!counters.overflowed(), "{} overflow", kind.name());
+            assert_eq!(
+                counters.required_vertices as usize,
+                expected.vertices.len(),
+                "{} vertex count",
+                kind.name()
+            );
+            assert_eq!(
+                counters.required_indices as usize,
+                expected.indices.len(),
+                "{} index count",
+                kind.name()
+            );
+            assert_eq!(counters.emitted_vertices, counters.required_vertices);
+            assert_eq!(counters.emitted_indices, counters.required_indices);
+
+            let actual_vertices: Vec<GpuTerrainVertex> = read_buffer(
+                &device,
+                &queue,
+                extractor.vertices_buffer(),
+                counters.required_vertices as u64 * size_of::<GpuTerrainVertex>() as u64,
+            );
+            let actual_indices: Vec<u32> = read_buffer(
+                &device,
+                &queue,
+                extractor.indices_buffer(),
+                counters.required_indices as u64 * size_of::<u32>() as u64,
+            );
+            assert_vertices_close(kind, &actual_vertices, &expected.vertices);
+            assert_eq!(actual_indices, expected.indices, "{} indices", kind.name());
+
+            let offsets: Vec<GpuTransvoxelCellOffset> = read_buffer(
+                &device,
+                &queue,
+                extractor.offsets_buffer(),
+                PAGE_CELL_COUNT as u64 * size_of::<GpuTransvoxelCellOffset>() as u64,
+            );
+            let blocks: Vec<GpuTransvoxelScanBlock> = read_buffer(
+                &device,
+                &queue,
+                extractor.blocks_buffer(),
+                128 * size_of::<GpuTransvoxelScanBlock>() as u64,
+            );
+            for (linear, offset) in offsets.iter().enumerate() {
+                assert_eq!(
+                    offset.generation(),
+                    generation,
+                    "{} cell {linear}",
+                    kind.name()
+                );
+                let block = blocks[linear / TRANSVOXEL_SCAN_WORKGROUP_SIZE as usize];
+                assert_eq!(
+                    block.first_vertex + offset.first_vertex,
+                    expected.cell_ranges[linear].unwrap().0,
+                    "{} vertex range cell {linear}",
+                    kind.name()
+                );
+                assert_eq!(
+                    block.first_index + offset.first_index,
+                    expected.cell_ranges[linear].unwrap().1,
+                    "{} index range cell {linear}",
+                    kind.name()
+                );
+            }
+
+            extractor
+                .dispatch(&device, &queue, fixture.samples(), generation, u64::MAX)
+                .unwrap();
+            let repeated_vertices: Vec<GpuTerrainVertex> = read_buffer(
+                &device,
+                &queue,
+                extractor.vertices_buffer(),
+                counters.required_vertices as u64 * size_of::<GpuTerrainVertex>() as u64,
+            );
+            let repeated_indices: Vec<u32> = read_buffer(
+                &device,
+                &queue,
+                extractor.indices_buffer(),
+                counters.required_indices as u64 * size_of::<u32>() as u64,
+            );
+            assert_eq!(
+                bytemuck::cast_slice::<GpuTerrainVertex, u8>(&repeated_vertices),
+                bytemuck::cast_slice::<GpuTerrainVertex, u8>(&actual_vertices),
+                "{} deterministic vertices",
+                kind.name()
+            );
+            assert_eq!(
+                repeated_indices,
+                actual_indices,
+                "{} deterministic indices",
+                kind.name()
+            );
+        }
+
+        let fixture = fixture(ExtractionFixtureKind::Plane);
+        let dirty_generation = 1_500;
+        let dirty_microbricks = 1_u64 << 12;
+        let dirty_expected = expected_mesh(&fixture, dirty_microbricks);
+        extractor
+            .dispatch(
+                &device,
+                &queue,
+                fixture.samples(),
+                dirty_generation,
+                dirty_microbricks,
+            )
+            .unwrap();
+        let dirty_counters =
+            read_one::<GpuTransvoxelEmissionCounters>(&device, &queue, extractor.counters_buffer());
+        assert!(!dirty_counters.overflowed());
+        assert_eq!(
+            dirty_counters.emitted_vertices as usize,
+            dirty_expected.vertices.len()
+        );
+        assert_eq!(
+            dirty_counters.emitted_indices as usize,
+            dirty_expected.indices.len()
+        );
+        assert!(dirty_counters.emitted_vertices > 0);
+        let dirty_vertices: Vec<GpuTerrainVertex> = read_buffer(
+            &device,
+            &queue,
+            extractor.vertices_buffer(),
+            u64::from(dirty_counters.emitted_vertices) * size_of::<GpuTerrainVertex>() as u64,
+        );
+        let dirty_indices: Vec<u32> = read_buffer(
+            &device,
+            &queue,
+            extractor.indices_buffer(),
+            u64::from(dirty_counters.emitted_indices) * size_of::<u32>() as u64,
+        );
+        assert_vertices_close(
+            ExtractionFixtureKind::Plane,
+            &dirty_vertices,
+            &dirty_expected.vertices,
+        );
+        assert_eq!(dirty_indices, dirty_expected.indices);
+        let dirty_offsets: Vec<GpuTransvoxelCellOffset> = read_buffer(
+            &device,
+            &queue,
+            extractor.offsets_buffer(),
+            PAGE_CELL_COUNT as u64 * size_of::<GpuTransvoxelCellOffset>() as u64,
+        );
+        for (linear, (offset, expected_range)) in dirty_offsets
+            .iter()
+            .zip(&dirty_expected.cell_ranges)
+            .enumerate()
+        {
+            if expected_range.is_some() {
+                assert_eq!(offset.generation(), dirty_generation, "dirty cell {linear}");
+            } else {
+                assert_ne!(offset.generation(), dirty_generation, "stale cell {linear}");
+            }
+        }
+
+        let tiny =
+            TransvoxelGpuExtractor::new(&device, TransvoxelGpuExtractorConfig::new(1, 1).unwrap())
+                .unwrap();
+        tiny.dispatch(&device, &queue, fixture.samples(), 2_000, u64::MAX)
+            .unwrap();
+        let counters =
+            read_one::<GpuTransvoxelEmissionCounters>(&device, &queue, tiny.counters_buffer());
+        assert_eq!(counters.completed, 1);
+        assert!(counters.vertex_overflow != 0);
+        assert!(counters.index_overflow != 0);
+        assert_eq!(counters.emitted_vertices, 0);
+        assert_eq!(counters.emitted_indices, 0);
+        assert!(counters.required_vertices > 1);
+        assert!(counters.required_indices > 1);
+    });
+}
+
+struct ExpectedMesh {
+    vertices: Vec<GpuTerrainVertex>,
+    indices: Vec<u32>,
+    cell_ranges: Vec<Option<(u32, u32)>>,
+}
+
+fn expected_mesh(fixture: &ExtractionFixture, dirty_microbricks: u64) -> ExpectedMesh {
+    let mut mesh = ExpectedMesh {
+        vertices: Vec::new(),
+        indices: Vec::new(),
+        cell_ranges: vec![None; PAGE_CELL_COUNT],
+    };
+    for z in 0..PAGE_EDGE as u8 {
+        for y in 0..PAGE_EDGE as u8 {
+            for x in 0..PAGE_EDGE as u8 {
+                let linear = usize::from(x)
+                    + usize::from(y) * PAGE_EDGE
+                    + usize::from(z) * PAGE_EDGE * PAGE_EDGE;
+                let microbrick = u32::from(x / 8) + u32::from(y / 8) * 4 + u32::from(z / 8) * 16;
+                if dirty_microbricks & (1_u64 << microbrick) == 0 {
+                    continue;
+                }
+                let first_vertex = mesh.vertices.len() as u32;
+                let first_index = mesh.indices.len() as u32;
+                mesh.cell_ranges[linear] = Some((first_vertex, first_index));
+                let fixture_case = fixture.cell_case([x, y, z]).unwrap();
+                let topology = regular_case_from_fixture(fixture_case);
+                for vertex_index in 0..topology.vertex_count() {
+                    let code = topology.vertex(vertex_index).unwrap();
+                    let [first_corner, second_corner] = code.endpoints();
+                    let cell = [i32::from(x), i32::from(y), i32::from(z)];
+                    let first = add(cell, TRANSVOXEL_REGULAR_CORNERS[usize::from(first_corner)]);
+                    let second = add(cell, TRANSVOXEL_REGULAR_CORNERS[usize::from(second_corner)]);
+                    let first_word = fixture.sample(first).unwrap();
+                    let second_word = fixture.sample(second).unwrap();
+                    let first_density = f32::from(first_word.density());
+                    let second_density = f32::from(second_word.density());
+                    let denominator = first_density - second_density;
+                    let interpolation = if denominator.abs() > 1.0e-12 {
+                        (first_density / denominator).clamp(0.0, 1.0)
+                    } else {
+                        0.5
+                    };
+                    let first_position = first.map(|axis| axis as f32);
+                    let second_position = second.map(|axis| axis as f32);
+                    let position = mix(first_position, second_position, interpolation);
+                    let normal = normalize_or_up(mix(
+                        gradient(fixture, first),
+                        gradient(fixture, second),
+                        interpolation,
+                    ));
+                    let material = if first_density <= 0.0 {
+                        first_word.material()
+                    } else {
+                        second_word.material()
+                    };
+                    mesh.vertices.push(GpuTerrainVertex {
+                        position,
+                        material: u32::from(material),
+                        normal,
+                        flags: 0,
+                    });
+                }
+                for triangle in 0..topology.triangle_count() {
+                    for local_vertex in topology.triangle(triangle).unwrap() {
+                        mesh.indices.push(first_vertex + u32::from(local_vertex));
+                    }
+                }
+            }
+        }
+    }
+    mesh
+}
+
+fn gradient(fixture: &ExtractionFixture, position: [i32; 3]) -> [f32; 3] {
+    let mut result = [0.0; 3];
+    for axis in 0..3 {
+        let mut lower = position;
+        let mut upper = position;
+        result[axis] = if position[axis] <= -1 {
+            upper[axis] += 1;
+            density_at(fixture, upper) - density_at(fixture, position)
+        } else if position[axis] >= PAGE_EDGE as i32 {
+            lower[axis] -= 1;
+            density_at(fixture, position) - density_at(fixture, lower)
+        } else {
+            lower[axis] -= 1;
+            upper[axis] += 1;
+            (density_at(fixture, upper) - density_at(fixture, lower)) * 0.5
+        };
+    }
+    result
+}
+
+fn density_at(fixture: &ExtractionFixture, position: [i32; 3]) -> f32 {
+    f32::from(fixture.sample(position).unwrap().density())
+}
+
+fn add(left: [i32; 3], right: [u8; 3]) -> [i32; 3] {
+    [
+        left[0] + i32::from(right[0]),
+        left[1] + i32::from(right[1]),
+        left[2] + i32::from(right[2]),
+    ]
+}
+
+fn mix(first: [f32; 3], second: [f32; 3], amount: f32) -> [f32; 3] {
+    [
+        first[0] + (second[0] - first[0]) * amount,
+        first[1] + (second[1] - first[1]) * amount,
+        first[2] + (second[2] - first[2]) * amount,
+    ]
+}
+
+fn normalize_or_up(value: [f32; 3]) -> [f32; 3] {
+    let squared_length = value.into_iter().map(|axis| axis * axis).sum::<f32>();
+    if squared_length > 1.0e-12 {
+        let inverse_length = squared_length.sqrt().recip();
+        value.map(|axis| axis * inverse_length)
+    } else {
+        [0.0, 1.0, 0.0]
+    }
+}
+
+fn assert_vertices_close(
+    kind: ExtractionFixtureKind,
+    actual: &[GpuTerrainVertex],
+    expected: &[GpuTerrainVertex],
+) {
+    assert_eq!(actual.len(), expected.len(), "{} vertices", kind.name());
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        assert_eq!(
+            actual.material,
+            expected.material,
+            "{} material {index}",
+            kind.name()
+        );
+        assert_eq!(
+            actual.flags,
+            expected.flags,
+            "{} flags {index}",
+            kind.name()
+        );
+        for axis in 0..3 {
+            assert!(
+                (actual.position[axis] - expected.position[axis]).abs() <= 1.0e-5,
+                "{} position {index}:{axis}: {:?} != {:?}",
+                kind.name(),
+                actual.position,
+                expected.position
+            );
+            assert!(
+                (actual.normal[axis] - expected.normal[axis]).abs() <= 2.0e-4,
+                "{} normal {index}:{axis}: {:?} != {:?}",
+                kind.name(),
+                actual.normal,
+                expected.normal
+            );
+        }
+    }
+}
+
+fn fixture(kind: ExtractionFixtureKind) -> ExtractionFixture {
+    let page_xyz = match kind {
+        ExtractionFixtureKind::Plane
+        | ExtractionFixtureKind::ThinSlab
+        | ExtractionFixtureKind::MaterialSeam => [0, -1, 0],
+        ExtractionFixtureKind::Sphere
+        | ExtractionFixtureKind::Cave
+        | ExtractionFixtureKind::SharpCorner => [0, 0, 0],
+    };
+    ExtractionFixture::new(kind, PageKey::new(0, page_xyz)).unwrap()
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}
+
+fn read_one<T: Pod + Copy>(device: &wgpu::Device, queue: &wgpu::Queue, source: &wgpu::Buffer) -> T {
+    read_buffer(device, queue, source, size_of::<T>() as u64)[0]
+}
+
+fn read_buffer<T: Pod + Copy>(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source: &wgpu::Buffer,
+    size: u64,
+) -> Vec<T> {
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planetary Transvoxel Emission Readback"),
+        size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planetary Transvoxel Emission Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(source, 0, &readback, 0, size);
+    queue.submit([encoder.finish()]);
+    let slice = readback.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv()
+        .expect("GPU readback callback must run")
+        .expect("GPU readback mapping must succeed");
+    let mapped = slice
+        .get_mapped_range()
+        .expect("GPU readback range must be available");
+    let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
+    drop(mapped);
+    readback.unmap();
+    values
+}
+
+const fn size_of<T>() -> usize {
+    core::mem::size_of::<T>()
+}

--- a/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
+++ b/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
@@ -1,8 +1,10 @@
 use helio_pass_planetary_voxel::{
     GpuExtractionCounters, GpuExtractionRange, GpuExtractionRequest, GpuLookupQuery,
     GpuLookupResult, GpuPageTableEntry, GpuResidencyCounters, GpuResidencyUniform,
-    GpuTerrainMeshlet, GpuTerrainVertex, GpuTransvoxelCell, GpuTransvoxelClassifyCounters,
-    GpuTransvoxelDispatch, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL, TRANSVOXEL_CLASSIFY_WGSL,
+    GpuTerrainMeshlet, GpuTerrainVertex, GpuTransvoxelCell, GpuTransvoxelCellOffset,
+    GpuTransvoxelClassifyCounters, GpuTransvoxelDispatch, GpuTransvoxelEmissionCounters,
+    GpuTransvoxelScanBlock, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL, TRANSVOXEL_CLASSIFY_WGSL,
+    TRANSVOXEL_EMIT_WGSL,
 };
 use std::mem::{align_of, offset_of, size_of};
 use wgpu::naga::{
@@ -321,9 +323,9 @@ fn transvoxel_classifier_layouts_match_wgsl_exactly() {
                 ("generation_low".into(), 8),
                 ("generation_high".into(), 12),
                 ("cell_count".into(), 16),
-                ("_pad0".into(), 20),
-                ("_pad1".into(), 24),
-                ("_pad2".into(), 28),
+                ("max_vertices".into(), 20),
+                ("max_indices".into(), 24),
+                ("scan_block_count".into(), 28),
             ],
         )
     );
@@ -354,6 +356,76 @@ fn transvoxel_classifier_layouts_match_wgsl_exactly() {
                 ("active_cells".into(), 4),
                 ("vertices".into(), 8),
                 ("triangles".into(), 12),
+            ],
+        )
+    );
+}
+
+#[test]
+fn transvoxel_emission_layouts_match_wgsl_exactly() {
+    let module = wgsl::parse_str(TRANSVOXEL_EMIT_WGSL).expect("Transvoxel emission WGSL parses");
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .expect("Transvoxel emission WGSL validates");
+
+    assert_eq!(align_of::<GpuTransvoxelCellOffset>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelCellOffset>(), 16);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_EMIT_WGSL, "GpuTransvoxelCellOffset"),
+        (
+            16,
+            vec![
+                ("first_vertex".into(), 0),
+                ("first_index".into(), 4),
+                ("generation_low".into(), 8),
+                ("generation_high".into(), 12),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelScanBlock>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelScanBlock>(), 16);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_EMIT_WGSL, "GpuTransvoxelScanBlock"),
+        (
+            16,
+            vec![
+                ("vertex_count".into(), 0),
+                ("index_count".into(), 4),
+                ("first_vertex".into(), 8),
+                ("first_index".into(), 12),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelEmissionCounters>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelEmissionCounters>(), 32);
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_EMIT_WGSL, "GpuTransvoxelEmissionCounters"),
+        (
+            32,
+            vec![
+                ("required_vertices".into(), 0),
+                ("required_indices".into(), 4),
+                ("emitted_vertices".into(), 8),
+                ("emitted_indices".into(), 12),
+                ("vertex_overflow".into(), 16),
+                ("index_overflow".into(), 20),
+                ("completed".into(), 24),
+                ("_pad".into(), 28),
+            ],
+        )
+    );
+
+    assert_eq!(
+        wgsl_struct_in(TRANSVOXEL_EMIT_WGSL, "GpuTerrainVertex"),
+        (
+            size_of::<GpuTerrainVertex>() as u32,
+            vec![
+                ("position".into(), 0),
+                ("material".into(), 12),
+                ("normal".into(), 16),
+                ("flags".into(), 28),
             ],
         )
     );


### PR DESCRIPTION
Part of #96.

Adds deterministic, bounded regular-cell GPU Transvoxel geometry emission on top of the validated classifier.

Implementation:
- two-level GPU prefix scan gives every cell stable vertex/index ranges
- interpolates real positions from signed densities and emits material plus gradient normals
- fixed worst-case regular-page capacity with explicit adapter-limit validation
- all-or-nothing overflow suppresses partial meshes
- full 64-bit generation checks protect stale cell/offset records
- one-microbrick extraction emits only the selected 8x8x8 region without clearing full output buffers
- vertex/index buffers are directly usable as WGPU VERTEX/INDEX resources

Validation on RTX 3060:
- all six canonical fixture meshes match CPU positions, materials, normals, indices, counts, and cell ranges
- repeat dispatches are byte-deterministic
- tiny-capacity validation proves overflow emits zero partial geometry
- `cargo test -p helio-pass-planetary-voxel --locked`
- `cargo clippy -p helio-pass-planetary-voxel --all-targets --locked -- -D warnings`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --locked`

Planetary path only; no render-graph or legacy-demo changes. Issue #96 remains open for transition-cell seams, topology/error metrics, meshlets, and the dual-contouring bake-off.