### PR TITLE
Add bounded GPU Transvoxel transition emission

### DIFF
--- a/crates/helio-pass-planetary-voxel/src/lib.rs
+++ b/crates/helio-pass-planetary-voxel/src/lib.rs
@@ -14,6 +14,7 @@ mod transvoxel;
 mod transvoxel_emit;
 mod transvoxel_gpu;
 mod transvoxel_transition;
+mod transvoxel_transition_gpu;
 
 pub use config::*;
 pub use extraction::*;
@@ -24,8 +25,10 @@ pub use transvoxel::*;
 pub use transvoxel_emit::*;
 pub use transvoxel_gpu::*;
 pub use transvoxel_transition::*;
+pub use transvoxel_transition_gpu::*;
 
 pub const EXTRACTION_LAYOUT_WGSL: &str = include_str!("extraction_layout.wgsl");
 pub const RESIDENCY_WGSL: &str = include_str!("residency.wgsl");
 pub const TRANSVOXEL_CLASSIFY_WGSL: &str = include_str!("transvoxel_classify.wgsl");
 pub const TRANSVOXEL_EMIT_WGSL: &str = include_str!("transvoxel_emit.wgsl");
+pub const TRANSVOXEL_TRANSITION_GPU_WGSL: &str = include_str!("transvoxel_transition_gpu.wgsl");

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_transition.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_transition.rs
@@ -17,6 +17,11 @@ pub const TRANSITION_FACE_CELL_EDGE: usize = PAGE_EDGE;
 pub const TRANSITION_FACE_SAMPLE_EDGE: usize = PAGE_EDGE * 2 + 1;
 pub const TRANSITION_FACE_SAMPLE_COUNT: usize =
     TRANSITION_FACE_SAMPLE_EDGE * TRANSITION_FACE_SAMPLE_EDGE;
+pub const TRANSITION_FACE_SLAB_EDGE: usize = TRANSITION_FACE_SAMPLE_EDGE + 2;
+pub const TRANSITION_FACE_SLAB_LAYERS: usize = 3;
+pub const TRANSITION_FACE_SLAB_SAMPLE_COUNT: usize =
+    TRANSITION_FACE_SLAB_EDGE * TRANSITION_FACE_SLAB_EDGE * TRANSITION_FACE_SLAB_LAYERS;
+pub const TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT: usize = TRANSITION_FACE_SLAB_SAMPLE_COUNT * 6;
 pub const TRANSITION_CELL_WIDTH_COARSE_CELLS: f32 = 0.25;
 
 /// Row-major sample positions from Figure 4.16, in half-coarse-cell units.
@@ -315,11 +320,32 @@ impl TransvoxelTransitionFaceFixture {
         {
             return None;
         }
-        let position = self.canonical_position(face_sample);
+        let position =
+            self.canonical_position([i32::from(face_sample[0]), i32::from(face_sample[1])], 0);
         Some(TransvoxelTransitionSample {
             cell: self.kind.sample_canonical(position),
             gradient: self.gradient(position),
         })
+    }
+
+    /// Returns one face-local scalar slab in `(u, v, outward)` order. The
+    /// logical face grid occupies coordinates 1..=65 in u/v and layer 1;
+    /// the surrounding samples are the central-difference halo consumed by
+    /// the GPU transition extractor.
+    pub fn slab_samples(&self) -> Box<[CellWord]> {
+        let mut samples = Vec::with_capacity(TRANSITION_FACE_SLAB_SAMPLE_COUNT);
+        for outward in -1..=1 {
+            for v in -1..=TRANSITION_FACE_SAMPLE_EDGE as i32 {
+                for u in -1..=TRANSITION_FACE_SAMPLE_EDGE as i32 {
+                    samples.push(
+                        self.kind
+                            .sample_canonical(self.canonical_position([u, v], outward)),
+                    );
+                }
+            }
+        }
+        debug_assert_eq!(samples.len(), TRANSITION_FACE_SLAB_SAMPLE_COUNT);
+        samples.into_boxed_slice()
     }
 
     pub fn cell(&self, cell_uv: [u8; 2]) -> Option<TransvoxelTransitionCell> {
@@ -370,14 +396,15 @@ impl TransvoxelTransitionFaceFixture {
         mesh
     }
 
-    fn canonical_position(&self, face_sample: [u8; 2]) -> [i64; 3] {
+    fn canonical_position(&self, face_sample: [i32; 2], outward_layer: i32) -> [i64; 3] {
         let basis = transition_face_integer_basis(self.face);
         let page_span = self.coarse_scale * PAGE_EDGE as i64;
         let mut position = self.page_min;
         for (axis, coordinate) in position.iter_mut().enumerate() {
             *coordinate += i64::from(basis.origin[axis]) * page_span
                 + i64::from(basis.u_axis[axis]) * i64::from(face_sample[0]) * self.fine_scale
-                + i64::from(basis.v_axis[axis]) * i64::from(face_sample[1]) * self.fine_scale;
+                + i64::from(basis.v_axis[axis]) * i64::from(face_sample[1]) * self.fine_scale
+                + i64::from(basis.outward[axis]) * i64::from(outward_layer) * self.fine_scale;
         }
         position
     }
@@ -430,6 +457,7 @@ struct IntegerFaceBasis {
     origin: [i8; 3],
     u_axis: [i8; 3],
     v_axis: [i8; 3],
+    outward: [i8; 3],
 }
 
 const fn transition_face_integer_basis(face: TransitionFace) -> IntegerFaceBasis {
@@ -438,31 +466,37 @@ const fn transition_face_integer_basis(face: TransitionFace) -> IntegerFaceBasis
             origin: [0, 0, 1],
             u_axis: [0, 1, 0],
             v_axis: [0, 0, -1],
+            outward: [-1, 0, 0],
         },
         TransitionFace::PositiveX => IntegerFaceBasis {
             origin: [1, 0, 0],
             u_axis: [0, 1, 0],
             v_axis: [0, 0, 1],
+            outward: [1, 0, 0],
         },
         TransitionFace::NegativeY => IntegerFaceBasis {
             origin: [1, 0, 0],
             u_axis: [0, 0, 1],
             v_axis: [-1, 0, 0],
+            outward: [0, -1, 0],
         },
         TransitionFace::PositiveY => IntegerFaceBasis {
             origin: [0, 1, 0],
             u_axis: [0, 0, 1],
             v_axis: [1, 0, 0],
+            outward: [0, 1, 0],
         },
         TransitionFace::NegativeZ => IntegerFaceBasis {
             origin: [0, 1, 0],
             u_axis: [1, 0, 0],
             v_axis: [0, -1, 0],
+            outward: [0, 0, -1],
         },
         TransitionFace::PositiveZ => IntegerFaceBasis {
             origin: [0, 0, 1],
             u_axis: [1, 0, 0],
             v_axis: [0, 1, 0],
+            outward: [0, 0, 1],
         },
     }
 }
@@ -600,6 +634,19 @@ mod tests {
         assert!(fixture.full_resolution_sample([65, 0]).is_none());
         assert!(fixture.cell([31, 31]).is_some());
         assert!(fixture.cell([32, 0]).is_none());
+        let slab = fixture.slab_samples();
+        assert_eq!(slab.len(), TRANSITION_FACE_SLAB_SAMPLE_COUNT);
+        for v in 0..TRANSITION_FACE_SAMPLE_EDGE as u8 {
+            for u in 0..TRANSITION_FACE_SAMPLE_EDGE as u8 {
+                let slab_index = usize::from(u + 1)
+                    + usize::from(v + 1) * TRANSITION_FACE_SLAB_EDGE
+                    + TRANSITION_FACE_SLAB_EDGE * TRANSITION_FACE_SLAB_EDGE;
+                assert_eq!(
+                    slab[slab_index],
+                    fixture.full_resolution_sample([u, v]).unwrap().cell
+                );
+            }
+        }
 
         for v in 0..32_u8 {
             for u in 0..31_u8 {

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_transition_gpu.rs
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_transition_gpu.rs
@@ -1,0 +1,680 @@
+use crate::{
+    transvoxel::generated, GpuTerrainVertex, GpuTransvoxelCellOffset, GpuTransvoxelScanBlock,
+    TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT, TRANSVOXEL_TRANSITION_GPU_WGSL,
+};
+use bytemuck::{Pod, Zeroable};
+use helio_planet_voxel_core::{CellWord, TRANSITION_FACE_MASK};
+use wgpu::util::DeviceExt;
+
+pub const TRANSVOXEL_TRANSITION_FACE_COUNT: u32 = 6;
+pub const TRANSVOXEL_TRANSITION_CELLS_PER_FACE: u32 = 32 * 32;
+pub const TRANSVOXEL_TRANSITION_CELL_COUNT: u32 =
+    TRANSVOXEL_TRANSITION_FACE_COUNT * TRANSVOXEL_TRANSITION_CELLS_PER_FACE;
+pub const TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUP_SIZE: u32 = 64;
+pub const TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUPS: u32 =
+    TRANSVOXEL_TRANSITION_CELL_COUNT / TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUP_SIZE;
+pub const TRANSVOXEL_TRANSITION_SCAN_WORKGROUP_SIZE: u32 = 256;
+pub const TRANSVOXEL_TRANSITION_SCAN_BLOCKS: u32 =
+    TRANSVOXEL_TRANSITION_CELL_COUNT / TRANSVOXEL_TRANSITION_SCAN_WORKGROUP_SIZE;
+pub const TRANSVOXEL_TRANSITION_MAX_VERTICES: u32 = TRANSVOXEL_TRANSITION_CELL_COUNT * 12;
+pub const TRANSVOXEL_TRANSITION_MAX_INDICES: u32 = TRANSVOXEL_TRANSITION_CELL_COUNT * 12 * 3;
+
+const TRANSITION_CLASS_TABLE_VALUES: usize = 512;
+const TRANSITION_GEOMETRY_TABLE_VALUES: usize = 56;
+const TRANSITION_VERTEX_TABLE_VALUES: usize = 512 * 12;
+const TRANSITION_TOPOLOGY_TABLE_VALUES: usize = 56 * 36;
+const TRANSITION_TABLE_VALUES: usize = TRANSITION_CLASS_TABLE_VALUES
+    + TRANSITION_GEOMETRY_TABLE_VALUES
+    + TRANSITION_VERTEX_TABLE_VALUES
+    + TRANSITION_TOPOLOGY_TABLE_VALUES;
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelTransitionDispatch {
+    pub transition_mask: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub cell_count: u32,
+    pub max_vertices: u32,
+    pub max_indices: u32,
+    pub scan_block_count: u32,
+    pub _pad: u32,
+}
+
+impl GpuTransvoxelTransitionDispatch {
+    pub const fn new(
+        transition_mask: u8,
+        generation: u64,
+        config: TransvoxelGpuTransitionExtractorConfig,
+    ) -> Self {
+        Self {
+            transition_mask: transition_mask as u32,
+            generation_low: generation as u32,
+            generation_high: (generation >> 32) as u32,
+            cell_count: TRANSVOXEL_TRANSITION_CELL_COUNT,
+            max_vertices: config.max_vertices,
+            max_indices: config.max_indices,
+            scan_block_count: TRANSVOXEL_TRANSITION_SCAN_BLOCKS,
+            _pad: 0,
+        }
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelTransitionCell {
+    pub packed_case_class_counts: u32,
+    pub generation_low: u32,
+    pub generation_high: u32,
+    pub _pad: u32,
+}
+
+impl GpuTransvoxelTransitionCell {
+    const VALID: u32 = 1 << 31;
+
+    pub const fn new(
+        case_index: u16,
+        class_code: u8,
+        vertex_count: u8,
+        triangle_count: u8,
+        generation: u64,
+    ) -> Self {
+        Self {
+            packed_case_class_counts: case_index as u32
+                | ((class_code as u32) << 9)
+                | ((vertex_count as u32) << 17)
+                | ((triangle_count as u32) << 21)
+                | Self::VALID,
+            generation_low: generation as u32,
+            generation_high: (generation >> 32) as u32,
+            _pad: 0,
+        }
+    }
+
+    pub const fn case_index(self) -> u16 {
+        (self.packed_case_class_counts & 0x1ff) as u16
+    }
+
+    pub const fn class_code(self) -> u8 {
+        ((self.packed_case_class_counts >> 9) & 0xff) as u8
+    }
+
+    pub const fn class_index(self) -> u8 {
+        self.class_code() & 0x7f
+    }
+
+    pub const fn reverse_winding(self) -> bool {
+        self.class_code() & 0x80 != 0
+    }
+
+    pub const fn vertex_count(self) -> u8 {
+        ((self.packed_case_class_counts >> 17) & 0x0f) as u8
+    }
+
+    pub const fn triangle_count(self) -> u8 {
+        ((self.packed_case_class_counts >> 21) & 0x0f) as u8
+    }
+
+    pub const fn generation(self) -> u64 {
+        self.generation_low as u64 | ((self.generation_high as u64) << 32)
+    }
+
+    pub const fn is_valid_for(self, generation: u64) -> bool {
+        self.packed_case_class_counts & Self::VALID != 0 && self.generation() == generation
+    }
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Pod, Zeroable)]
+pub struct GpuTransvoxelTransitionCounters {
+    pub active_cells: u32,
+    pub active_faces: u32,
+    pub required_vertices: u32,
+    pub required_indices: u32,
+    pub emitted_vertices: u32,
+    pub emitted_indices: u32,
+    pub vertex_overflow: u32,
+    pub index_overflow: u32,
+    pub completed: u32,
+    pub _pad: [u32; 3],
+}
+
+impl GpuTransvoxelTransitionCounters {
+    pub const fn overflowed(self) -> bool {
+        self.vertex_overflow != 0 || self.index_overflow != 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransvoxelGpuTransitionExtractorConfig {
+    pub max_vertices: u32,
+    pub max_indices: u32,
+}
+
+impl TransvoxelGpuTransitionExtractorConfig {
+    pub fn new(max_vertices: u32, max_indices: u32) -> Result<Self, TransvoxelTransitionGpuError> {
+        if max_vertices == 0 || max_indices == 0 {
+            return Err(TransvoxelTransitionGpuError::InvalidExtractionCapacity {
+                max_vertices,
+                max_indices,
+            });
+        }
+        Ok(Self {
+            max_vertices,
+            max_indices,
+        })
+    }
+}
+
+impl Default for TransvoxelGpuTransitionExtractorConfig {
+    fn default() -> Self {
+        Self {
+            max_vertices: TRANSVOXEL_TRANSITION_MAX_VERTICES,
+            max_indices: TRANSVOXEL_TRANSITION_MAX_INDICES,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TransvoxelTransitionExtractorResourceStats {
+    pub buffers: u32,
+    pub allocated_bytes: u64,
+}
+
+/// Fixed-capacity GPU transition classifier, prefix allocator, and emitter.
+/// Every dispatch processes at most six 32x32 coarse-page faces. Capacity
+/// overflow suppresses the whole result instead of publishing a partial seam.
+pub struct TransvoxelGpuTransitionExtractor {
+    classify_pipeline: wgpu::ComputePipeline,
+    scan_cells_pipeline: wgpu::ComputePipeline,
+    scan_blocks_pipeline: wgpu::ComputePipeline,
+    emit_pipeline: wgpu::ComputePipeline,
+    classify_bind_group: wgpu::BindGroup,
+    scan_cells_bind_group: wgpu::BindGroup,
+    scan_blocks_bind_group: wgpu::BindGroup,
+    emit_bind_group: wgpu::BindGroup,
+    dispatch_buffer: wgpu::Buffer,
+    sample_buffer: wgpu::Buffer,
+    cells_buffer: wgpu::Buffer,
+    offsets_buffer: wgpu::Buffer,
+    blocks_buffer: wgpu::Buffer,
+    vertices_buffer: wgpu::Buffer,
+    indices_buffer: wgpu::Buffer,
+    counters_buffer: wgpu::Buffer,
+    config: TransvoxelGpuTransitionExtractorConfig,
+    resource_stats: TransvoxelTransitionExtractorResourceStats,
+}
+
+impl TransvoxelGpuTransitionExtractor {
+    pub fn new(
+        device: &wgpu::Device,
+        config: TransvoxelGpuTransitionExtractorConfig,
+    ) -> Result<Self, TransvoxelTransitionGpuError> {
+        validate_limits(&device.limits(), config)?;
+        let dispatch_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Dispatch"),
+            size: dispatch_buffer_bytes(),
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let sample_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Scalar Slabs"),
+            size: sample_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let tables = packed_transition_tables();
+        let tables_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+            label: Some("Planetary Transvoxel Transition Tables"),
+            contents: bytemuck::cast_slice(&tables),
+            usage: wgpu::BufferUsages::STORAGE,
+        });
+        let cells_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Cells"),
+            size: cells_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let offsets_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Offsets"),
+            size: offsets_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let blocks_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Scan Blocks"),
+            size: blocks_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let vertices_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Vertices"),
+            size: vertices_buffer_bytes(config),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::VERTEX
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let indices_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Indices"),
+            size: indices_buffer_bytes(config),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::INDEX
+                | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let counters_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Transvoxel Transition Counters"),
+            size: counters_buffer_bytes(),
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Planetary Transvoxel Transition GPU Shader"),
+            source: wgpu::ShaderSource::Wgsl(TRANSVOXEL_TRANSITION_GPU_WGSL.into()),
+        });
+        let classify_pipeline = compute_pipeline(device, &shader, "classify_transition_cells");
+        let scan_cells_pipeline = compute_pipeline(device, &shader, "scan_transition_cells");
+        let scan_blocks_pipeline = compute_pipeline(device, &shader, "scan_transition_blocks");
+        let emit_pipeline = compute_pipeline(device, &shader, "emit_transition_cells");
+        let classify_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Transition Classify Bind Group"),
+            layout: &classify_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, &dispatch_buffer),
+                entry(1, &sample_buffer),
+                entry(2, &tables_buffer),
+                entry(3, &cells_buffer),
+                entry(8, &counters_buffer),
+            ],
+        });
+        let scan_cells_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Transition Cell Scan Bind Group"),
+            layout: &scan_cells_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, &dispatch_buffer),
+                entry(3, &cells_buffer),
+                entry(4, &offsets_buffer),
+                entry(5, &blocks_buffer),
+            ],
+        });
+        let scan_blocks_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Transition Block Scan Bind Group"),
+            layout: &scan_blocks_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, &dispatch_buffer),
+                entry(5, &blocks_buffer),
+                entry(8, &counters_buffer),
+            ],
+        });
+        let emit_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("Planetary Transvoxel Transition Emit Bind Group"),
+            layout: &emit_pipeline.get_bind_group_layout(0),
+            entries: &[
+                entry(0, &dispatch_buffer),
+                entry(1, &sample_buffer),
+                entry(2, &tables_buffer),
+                entry(3, &cells_buffer),
+                entry(4, &offsets_buffer),
+                entry(5, &blocks_buffer),
+                entry(6, &vertices_buffer),
+                entry(7, &indices_buffer),
+                entry(8, &counters_buffer),
+            ],
+        });
+        let resource_stats = TransvoxelTransitionExtractorResourceStats {
+            buffers: 9,
+            allocated_bytes: dispatch_buffer_bytes()
+                + sample_buffer_bytes()
+                + tables_buffer_bytes()
+                + cells_buffer_bytes()
+                + offsets_buffer_bytes()
+                + blocks_buffer_bytes()
+                + vertices_buffer_bytes(config)
+                + indices_buffer_bytes(config)
+                + counters_buffer_bytes(),
+        };
+        Ok(Self {
+            classify_pipeline,
+            scan_cells_pipeline,
+            scan_blocks_pipeline,
+            emit_pipeline,
+            classify_bind_group,
+            scan_cells_bind_group,
+            scan_blocks_bind_group,
+            emit_bind_group,
+            dispatch_buffer,
+            sample_buffer,
+            cells_buffer,
+            offsets_buffer,
+            blocks_buffer,
+            vertices_buffer,
+            indices_buffer,
+            counters_buffer,
+            config,
+            resource_stats,
+        })
+    }
+
+    pub fn dispatch(
+        &self,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        face_slabs: &[CellWord],
+        transition_mask: u8,
+        generation: u64,
+    ) -> Result<wgpu::SubmissionIndex, TransvoxelTransitionGpuError> {
+        if face_slabs.len() != TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT {
+            return Err(TransvoxelTransitionGpuError::SampleCount {
+                actual: face_slabs.len(),
+                expected: TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT,
+            });
+        }
+        if transition_mask & !TRANSITION_FACE_MASK != 0 {
+            return Err(TransvoxelTransitionGpuError::TransitionMask(
+                transition_mask,
+            ));
+        }
+        let dispatch =
+            GpuTransvoxelTransitionDispatch::new(transition_mask, generation, self.config);
+        queue.write_buffer(&self.sample_buffer, 0, bytemuck::cast_slice(face_slabs));
+        queue.write_buffer(&self.dispatch_buffer, 0, bytemuck::bytes_of(&dispatch));
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Planetary Transvoxel Transition Extraction Encoder"),
+        });
+        encoder.clear_buffer(&self.counters_buffer, 0, None);
+        encode_dispatch(
+            &mut encoder,
+            &self.classify_pipeline,
+            &self.classify_bind_group,
+            TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUPS,
+            "Planetary Transvoxel Transition Classification",
+        );
+        encode_dispatch(
+            &mut encoder,
+            &self.scan_cells_pipeline,
+            &self.scan_cells_bind_group,
+            TRANSVOXEL_TRANSITION_SCAN_BLOCKS,
+            "Planetary Transvoxel Transition Cell Scan",
+        );
+        encode_dispatch(
+            &mut encoder,
+            &self.scan_blocks_pipeline,
+            &self.scan_blocks_bind_group,
+            1,
+            "Planetary Transvoxel Transition Block Scan",
+        );
+        encode_dispatch(
+            &mut encoder,
+            &self.emit_pipeline,
+            &self.emit_bind_group,
+            TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUPS,
+            "Planetary Transvoxel Transition Emission",
+        );
+        Ok(queue.submit([encoder.finish()]))
+    }
+
+    pub fn cells_buffer(&self) -> &wgpu::Buffer {
+        &self.cells_buffer
+    }
+
+    pub fn offsets_buffer(&self) -> &wgpu::Buffer {
+        &self.offsets_buffer
+    }
+
+    pub fn blocks_buffer(&self) -> &wgpu::Buffer {
+        &self.blocks_buffer
+    }
+
+    pub fn vertices_buffer(&self) -> &wgpu::Buffer {
+        &self.vertices_buffer
+    }
+
+    pub fn indices_buffer(&self) -> &wgpu::Buffer {
+        &self.indices_buffer
+    }
+
+    pub fn counters_buffer(&self) -> &wgpu::Buffer {
+        &self.counters_buffer
+    }
+
+    pub const fn config(&self) -> TransvoxelGpuTransitionExtractorConfig {
+        self.config
+    }
+
+    pub const fn resource_stats(&self) -> TransvoxelTransitionExtractorResourceStats {
+        self.resource_stats
+    }
+
+    pub fn resize(&mut self, _width: u32, _height: u32) {}
+}
+
+fn compute_pipeline(
+    device: &wgpu::Device,
+    shader: &wgpu::ShaderModule,
+    entry_point: &str,
+) -> wgpu::ComputePipeline {
+    device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some(entry_point),
+        layout: None,
+        module: shader,
+        entry_point: Some(entry_point),
+        compilation_options: Default::default(),
+        cache: None,
+    })
+}
+
+fn entry(binding: u32, buffer: &wgpu::Buffer) -> wgpu::BindGroupEntry<'_> {
+    wgpu::BindGroupEntry {
+        binding,
+        resource: buffer.as_entire_binding(),
+    }
+}
+
+fn encode_dispatch(
+    encoder: &mut wgpu::CommandEncoder,
+    pipeline: &wgpu::ComputePipeline,
+    bind_group: &wgpu::BindGroup,
+    workgroups: u32,
+    label: &'static str,
+) {
+    let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+        label: Some(label),
+        timestamp_writes: None,
+    });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, bind_group, &[]);
+    pass.dispatch_workgroups(workgroups, 1, 1);
+}
+
+fn packed_transition_tables() -> Vec<u32> {
+    let mut tables = Vec::with_capacity(TRANSITION_TABLE_VALUES);
+    tables.extend(generated::TRANSITION_CELL_CLASS.map(u32::from));
+    tables.extend(generated::TRANSITION_CELL_GEOMETRY_COUNTS.map(u32::from));
+    for row in generated::TRANSITION_VERTEX_DATA {
+        tables.extend(row.map(u32::from));
+    }
+    for row in generated::TRANSITION_CELL_VERTEX_INDEX {
+        tables.extend(row.map(u32::from));
+    }
+    tables
+}
+
+fn validate_limits(
+    limits: &wgpu::Limits,
+    config: TransvoxelGpuTransitionExtractorConfig,
+) -> Result<(), TransvoxelTransitionGpuError> {
+    TransvoxelGpuTransitionExtractorConfig::new(config.max_vertices, config.max_indices)?;
+    if limits.max_storage_buffers_per_shader_stage < 8 {
+        return Err(TransvoxelTransitionGpuError::DeviceLimit {
+            name: "storage buffers per shader stage",
+            required: 8,
+            available: u64::from(limits.max_storage_buffers_per_shader_stage),
+        });
+    }
+    if limits.max_uniform_buffers_per_shader_stage < 1 {
+        return Err(TransvoxelTransitionGpuError::DeviceLimit {
+            name: "uniform buffers per shader stage",
+            required: 1,
+            available: u64::from(limits.max_uniform_buffers_per_shader_stage),
+        });
+    }
+    let compute_width = limits
+        .max_compute_invocations_per_workgroup
+        .min(limits.max_compute_workgroup_size_x);
+    if compute_width < TRANSVOXEL_TRANSITION_SCAN_WORKGROUP_SIZE {
+        return Err(TransvoxelTransitionGpuError::DeviceLimit {
+            name: "compute workgroup width",
+            required: u64::from(TRANSVOXEL_TRANSITION_SCAN_WORKGROUP_SIZE),
+            available: u64::from(compute_width),
+        });
+    }
+    if limits.max_compute_workgroups_per_dimension < TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUPS {
+        return Err(TransvoxelTransitionGpuError::DeviceLimit {
+            name: "compute workgroups per dimension",
+            required: u64::from(TRANSVOXEL_TRANSITION_CLASSIFY_WORKGROUPS),
+            available: u64::from(limits.max_compute_workgroups_per_dimension),
+        });
+    }
+    let available = limits
+        .max_buffer_size
+        .min(limits.max_storage_buffer_binding_size);
+    for (name, required) in [
+        ("transition scalar slabs", sample_buffer_bytes()),
+        ("transition tables", tables_buffer_bytes()),
+        ("transition cells", cells_buffer_bytes()),
+        ("transition offsets", offsets_buffer_bytes()),
+        ("transition scan blocks", blocks_buffer_bytes()),
+        ("transition vertices", vertices_buffer_bytes(config)),
+        ("transition indices", indices_buffer_bytes(config)),
+        ("transition counters", counters_buffer_bytes()),
+    ] {
+        if required > available {
+            return Err(TransvoxelTransitionGpuError::DeviceLimit {
+                name,
+                required,
+                available,
+            });
+        }
+    }
+    if dispatch_buffer_bytes() > limits.max_uniform_buffer_binding_size {
+        return Err(TransvoxelTransitionGpuError::DeviceLimit {
+            name: "transition dispatch uniform",
+            required: dispatch_buffer_bytes(),
+            available: limits.max_uniform_buffer_binding_size,
+        });
+    }
+    Ok(())
+}
+
+const fn dispatch_buffer_bytes() -> u64 {
+    core::mem::size_of::<GpuTransvoxelTransitionDispatch>() as u64
+}
+
+const fn sample_buffer_bytes() -> u64 {
+    (TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT * core::mem::size_of::<CellWord>()) as u64
+}
+
+const fn tables_buffer_bytes() -> u64 {
+    (TRANSITION_TABLE_VALUES * core::mem::size_of::<u32>()) as u64
+}
+
+const fn cells_buffer_bytes() -> u64 {
+    TRANSVOXEL_TRANSITION_CELL_COUNT as u64
+        * core::mem::size_of::<GpuTransvoxelTransitionCell>() as u64
+}
+
+const fn offsets_buffer_bytes() -> u64 {
+    TRANSVOXEL_TRANSITION_CELL_COUNT as u64 * core::mem::size_of::<GpuTransvoxelCellOffset>() as u64
+}
+
+const fn blocks_buffer_bytes() -> u64 {
+    TRANSVOXEL_TRANSITION_SCAN_BLOCKS as u64 * core::mem::size_of::<GpuTransvoxelScanBlock>() as u64
+}
+
+const fn vertices_buffer_bytes(config: TransvoxelGpuTransitionExtractorConfig) -> u64 {
+    config.max_vertices as u64 * core::mem::size_of::<GpuTerrainVertex>() as u64
+}
+
+const fn indices_buffer_bytes(config: TransvoxelGpuTransitionExtractorConfig) -> u64 {
+    config.max_indices as u64 * core::mem::size_of::<u32>() as u64
+}
+
+const fn counters_buffer_bytes() -> u64 {
+    core::mem::size_of::<GpuTransvoxelTransitionCounters>() as u64
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum TransvoxelTransitionGpuError {
+    #[error(
+        "Transvoxel transition extraction received {actual} scalar samples; expected {expected}"
+    )]
+    SampleCount { actual: usize, expected: usize },
+    #[error("transition mask {0:#010b} uses bits outside the six page faces")]
+    TransitionMask(u8),
+    #[error("Transvoxel transition capacities must be nonzero (vertices={max_vertices}, indices={max_indices})")]
+    InvalidExtractionCapacity { max_vertices: u32, max_indices: u32 },
+    #[error("Transvoxel transition extraction requires {required} {name}, but the device exposes {available}")]
+    DeviceLimit {
+        name: &'static str,
+        required: u64,
+        available: u64,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worst_case_transition_budget_is_fixed_and_exact() {
+        let config = TransvoxelGpuTransitionExtractorConfig::default();
+        assert_eq!(TRANSVOXEL_TRANSITION_CELL_COUNT, 6_144);
+        assert_eq!(TRANSVOXEL_TRANSITION_SCAN_BLOCKS, 24);
+        assert_eq!(TRANSVOXEL_TRANSITION_MAX_VERTICES, 73_728);
+        assert_eq!(TRANSVOXEL_TRANSITION_MAX_INDICES, 221_184);
+        assert_eq!(dispatch_buffer_bytes(), 32);
+        assert_eq!(sample_buffer_bytes(), 323_208);
+        assert_eq!(tables_buffer_bytes(), 34_912);
+        assert_eq!(cells_buffer_bytes(), 98_304);
+        assert_eq!(offsets_buffer_bytes(), 98_304);
+        assert_eq!(blocks_buffer_bytes(), 384);
+        assert_eq!(vertices_buffer_bytes(config), 2_359_296);
+        assert_eq!(indices_buffer_bytes(config), 884_736);
+        assert_eq!(counters_buffer_bytes(), 48);
+    }
+
+    #[test]
+    fn packed_transition_cell_preserves_case_class_counts_and_generation() {
+        let cell = GpuTransvoxelTransitionCell::new(0x1fe, 0xb7, 12, 12, u64::MAX - 5);
+        assert_eq!(cell.case_index(), 0x1fe);
+        assert_eq!(cell.class_code(), 0xb7);
+        assert_eq!(cell.class_index(), 0x37);
+        assert!(cell.reverse_winding());
+        assert_eq!(cell.vertex_count(), 12);
+        assert_eq!(cell.triangle_count(), 12);
+        assert_eq!(cell.generation(), u64::MAX - 5);
+        assert!(cell.is_valid_for(u64::MAX - 5));
+        assert!(!cell.is_valid_for(u64::MAX - 4));
+        assert!(!GpuTransvoxelTransitionCell::default().is_valid_for(0));
+    }
+
+    #[test]
+    fn zero_capacity_is_rejected() {
+        assert!(matches!(
+            TransvoxelGpuTransitionExtractorConfig::new(0, 1),
+            Err(TransvoxelTransitionGpuError::InvalidExtractionCapacity { .. })
+        ));
+        assert!(matches!(
+            TransvoxelGpuTransitionExtractorConfig::new(1, 0),
+            Err(TransvoxelTransitionGpuError::InvalidExtractionCapacity { .. })
+        ));
+    }
+}

--- a/crates/helio-pass-planetary-voxel/src/transvoxel_transition_gpu.wgsl
+++ b/crates/helio-pass-planetary-voxel/src/transvoxel_transition_gpu.wgsl
@@ -1,0 +1,454 @@
+const FACE_COUNT: u32 = 6u;
+const FACE_CELL_EDGE: u32 = 32u;
+const CELLS_PER_FACE: u32 = 1024u;
+const CELL_COUNT: u32 = 6144u;
+const SLAB_EDGE: u32 = 67u;
+const SLAB_LAYER_STRIDE: u32 = 4489u;
+const SLAB_FACE_STRIDE: u32 = 13467u;
+const SCAN_WORKGROUP_SIZE: u32 = 256u;
+
+const CLASS_TABLE_OFFSET: u32 = 0u;
+const GEOMETRY_TABLE_OFFSET: u32 = 512u;
+const VERTEX_TABLE_OFFSET: u32 = 568u;
+const VERTEX_TABLE_STRIDE: u32 = 12u;
+const TOPOLOGY_TABLE_OFFSET: u32 = 6712u;
+const TOPOLOGY_TABLE_STRIDE: u32 = 36u;
+
+const CASE_WEIGHTS: array<u32, 9> = array<u32, 9>(
+    0x001u, 0x002u, 0x004u,
+    0x080u, 0x100u, 0x008u,
+    0x040u, 0x020u, 0x010u,
+);
+
+const FULL_SAMPLE_UV: array<vec2<u32>, 9> = array<vec2<u32>, 9>(
+    vec2<u32>(0u, 0u), vec2<u32>(1u, 0u), vec2<u32>(2u, 0u),
+    vec2<u32>(0u, 1u), vec2<u32>(1u, 1u), vec2<u32>(2u, 1u),
+    vec2<u32>(0u, 2u), vec2<u32>(1u, 2u), vec2<u32>(2u, 2u),
+);
+
+const DUPLICATE_FULL_CORNERS: array<u32, 4> = array<u32, 4>(0u, 2u, 6u, 8u);
+
+const FACE_ORIGINS: array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+    vec3<f32>(0.0, 0.0, 32.0),
+    vec3<f32>(32.0, 0.0, 0.0),
+    vec3<f32>(32.0, 0.0, 0.0),
+    vec3<f32>(0.0, 32.0, 0.0),
+    vec3<f32>(0.0, 32.0, 0.0),
+    vec3<f32>(0.0, 0.0, 32.0),
+);
+
+const FACE_U_AXES: array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+    vec3<f32>(1.0, 0.0, 0.0),
+    vec3<f32>(1.0, 0.0, 0.0),
+);
+
+const FACE_V_AXES: array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+    vec3<f32>(0.0, 0.0, -1.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+    vec3<f32>(-1.0, 0.0, 0.0),
+    vec3<f32>(1.0, 0.0, 0.0),
+    vec3<f32>(0.0, -1.0, 0.0),
+    vec3<f32>(0.0, 1.0, 0.0),
+);
+
+const FACE_OUTWARD_AXES: array<vec3<f32>, 6> = array<vec3<f32>, 6>(
+    vec3<f32>(-1.0, 0.0, 0.0),
+    vec3<f32>(1.0, 0.0, 0.0),
+    vec3<f32>(0.0, -1.0, 0.0),
+    vec3<f32>(0.0, 1.0, 0.0),
+    vec3<f32>(0.0, 0.0, -1.0),
+    vec3<f32>(0.0, 0.0, 1.0),
+);
+
+struct GpuTransvoxelTransitionDispatch {
+    transition_mask: u32,
+    generation_low: u32,
+    generation_high: u32,
+    cell_count: u32,
+    max_vertices: u32,
+    max_indices: u32,
+    scan_block_count: u32,
+    _pad: u32,
+};
+
+struct GpuTransvoxelTransitionCell {
+    packed_case_class_counts: u32,
+    generation_low: u32,
+    generation_high: u32,
+    _pad: u32,
+};
+
+struct GpuTransvoxelCellOffset {
+    first_vertex: u32,
+    first_index: u32,
+    generation_low: u32,
+    generation_high: u32,
+};
+
+struct GpuTransvoxelScanBlock {
+    vertex_count: u32,
+    index_count: u32,
+    first_vertex: u32,
+    first_index: u32,
+};
+
+struct GpuTerrainVertex {
+    position: vec3<f32>,
+    material: u32,
+    normal: vec3<f32>,
+    flags: u32,
+};
+
+struct GpuTransvoxelTransitionCounters {
+    active_cells: atomic<u32>,
+    active_faces: atomic<u32>,
+    required_vertices: atomic<u32>,
+    required_indices: atomic<u32>,
+    emitted_vertices: atomic<u32>,
+    emitted_indices: atomic<u32>,
+    vertex_overflow: atomic<u32>,
+    index_overflow: atomic<u32>,
+    completed: atomic<u32>,
+    _pad: array<u32, 3>,
+};
+
+@group(0) @binding(0)
+var<uniform> dispatch: GpuTransvoxelTransitionDispatch;
+@group(0) @binding(1)
+var<storage, read> samples: array<u32>;
+@group(0) @binding(2)
+var<storage, read> tables: array<u32>;
+@group(0) @binding(3)
+var<storage, read_write> cells: array<GpuTransvoxelTransitionCell>;
+@group(0) @binding(4)
+var<storage, read_write> cell_offsets: array<GpuTransvoxelCellOffset>;
+@group(0) @binding(5)
+var<storage, read_write> scan_blocks: array<GpuTransvoxelScanBlock>;
+@group(0) @binding(6)
+var<storage, read_write> vertices: array<GpuTerrainVertex>;
+@group(0) @binding(7)
+var<storage, read_write> indices: array<u32>;
+@group(0) @binding(8)
+var<storage, read_write> counters: GpuTransvoxelTransitionCounters;
+
+var<workgroup> vertex_scan: array<u32, 256>;
+var<workgroup> index_scan: array<u32, 256>;
+
+fn density(word: u32) -> f32 {
+    let density_bits = word & 0xffffu;
+    let sign_extension = select(0u, 0xffff0000u, (density_bits & 0x8000u) != 0u);
+    return f32(bitcast<i32>(density_bits | sign_extension));
+}
+
+fn is_solid(word: u32) -> bool {
+    return density(word) <= 0.0;
+}
+
+fn slab_index(face: u32, u: u32, v: u32, layer: u32) -> u32 {
+    return face * SLAB_FACE_STRIDE + u + v * SLAB_EDGE + layer * SLAB_LAYER_STRIDE;
+}
+
+fn sample_word(face: u32, u: u32, v: u32, layer: u32) -> u32 {
+    return samples[slab_index(face, u, v, layer)];
+}
+
+fn cell_is_current(cell: GpuTransvoxelTransitionCell) -> bool {
+    return (cell.packed_case_class_counts & 0x80000000u) != 0u
+        && cell.generation_low == dispatch.generation_low
+        && cell.generation_high == dispatch.generation_high;
+}
+
+fn cell_vertex_count(cell: GpuTransvoxelTransitionCell) -> u32 {
+    return (cell.packed_case_class_counts >> 17u) & 0x0fu;
+}
+
+fn cell_triangle_count(cell: GpuTransvoxelTransitionCell) -> u32 {
+    return (cell.packed_case_class_counts >> 21u) & 0x0fu;
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn classify_transition_cells(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let linear = global_id.x;
+    if linear == 0u {
+        atomicStore(&counters.active_faces, countOneBits(dispatch.transition_mask & 0x3fu));
+    }
+    if linear >= dispatch.cell_count || linear >= CELL_COUNT {
+        return;
+    }
+    let face = linear / CELLS_PER_FACE;
+    if (dispatch.transition_mask & (1u << face)) == 0u {
+        cells[linear] = GpuTransvoxelTransitionCell(0u, 0u, 0u, 0u);
+        return;
+    }
+    let face_cell = linear % CELLS_PER_FACE;
+    let cell_u = face_cell % FACE_CELL_EDGE;
+    let cell_v = face_cell / FACE_CELL_EDGE;
+    var case_index = 0u;
+    for (var sample = 0u; sample < 9u; sample += 1u) {
+        let uv = FULL_SAMPLE_UV[sample];
+        let word = sample_word(face, cell_u * 2u + uv.x + 1u, cell_v * 2u + uv.y + 1u, 1u);
+        if is_solid(word) {
+            case_index |= CASE_WEIGHTS[sample];
+        }
+    }
+    let class_code = tables[CLASS_TABLE_OFFSET + case_index];
+    let class_index = class_code & 0x7fu;
+    let geometry_counts = tables[GEOMETRY_TABLE_OFFSET + class_index];
+    let vertex_count = geometry_counts >> 4u;
+    let triangle_count = geometry_counts & 0x0fu;
+    cells[linear] = GpuTransvoxelTransitionCell(
+        case_index
+            | (class_code << 9u)
+            | (vertex_count << 17u)
+            | (triangle_count << 21u)
+            | 0x80000000u,
+        dispatch.generation_low,
+        dispatch.generation_high,
+        0u,
+    );
+    if vertex_count != 0u {
+        atomicAdd(&counters.active_cells, 1u);
+    }
+}
+
+fn inclusive_scan(local_index: u32) {
+    var step = 1u;
+    loop {
+        if step >= SCAN_WORKGROUP_SIZE {
+            break;
+        }
+        var add_vertices = 0u;
+        var add_indices = 0u;
+        if local_index >= step {
+            add_vertices = vertex_scan[local_index - step];
+            add_indices = index_scan[local_index - step];
+        }
+        workgroupBarrier();
+        vertex_scan[local_index] += add_vertices;
+        index_scan[local_index] += add_indices;
+        workgroupBarrier();
+        step <<= 1u;
+    }
+}
+
+@compute @workgroup_size(256, 1, 1)
+fn scan_transition_cells(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+) {
+    let linear = global_id.x;
+    let local_index = local_id.x;
+    var vertex_count = 0u;
+    var index_count = 0u;
+    var current = false;
+    if linear < dispatch.cell_count && linear < CELL_COUNT {
+        let cell = cells[linear];
+        let face = linear / CELLS_PER_FACE;
+        current = (dispatch.transition_mask & (1u << face)) != 0u
+            && cell_is_current(cell);
+        if current {
+            vertex_count = cell_vertex_count(cell);
+            index_count = cell_triangle_count(cell) * 3u;
+        }
+    }
+    vertex_scan[local_index] = vertex_count;
+    index_scan[local_index] = index_count;
+    workgroupBarrier();
+    inclusive_scan(local_index);
+
+    if current {
+        cell_offsets[linear] = GpuTransvoxelCellOffset(
+            vertex_scan[local_index] - vertex_count,
+            index_scan[local_index] - index_count,
+            dispatch.generation_low,
+            dispatch.generation_high,
+        );
+    }
+    if local_index == SCAN_WORKGROUP_SIZE - 1u {
+        scan_blocks[workgroup_id.x] = GpuTransvoxelScanBlock(
+            vertex_scan[local_index],
+            index_scan[local_index],
+            0u,
+            0u,
+        );
+    }
+}
+
+@compute @workgroup_size(256, 1, 1)
+fn scan_transition_blocks(@builtin(local_invocation_id) local_id: vec3<u32>) {
+    let local_index = local_id.x;
+    var vertex_count = 0u;
+    var index_count = 0u;
+    if local_index < dispatch.scan_block_count {
+        let block = scan_blocks[local_index];
+        vertex_count = block.vertex_count;
+        index_count = block.index_count;
+    }
+    vertex_scan[local_index] = vertex_count;
+    index_scan[local_index] = index_count;
+    workgroupBarrier();
+    inclusive_scan(local_index);
+
+    if local_index < dispatch.scan_block_count {
+        scan_blocks[local_index].first_vertex = vertex_scan[local_index] - vertex_count;
+        scan_blocks[local_index].first_index = index_scan[local_index] - index_count;
+    }
+    if local_index == SCAN_WORKGROUP_SIZE - 1u {
+        let required_vertices = vertex_scan[local_index];
+        let required_indices = index_scan[local_index];
+        atomicStore(&counters.required_vertices, required_vertices);
+        atomicStore(&counters.required_indices, required_indices);
+        atomicStore(&counters.vertex_overflow, select(0u, 1u, required_vertices > dispatch.max_vertices));
+        atomicStore(&counters.index_overflow, select(0u, 1u, required_indices > dispatch.max_indices));
+        atomicStore(&counters.completed, 1u);
+    }
+}
+
+fn full_corner(corner: u32) -> u32 {
+    if corner < 9u {
+        return corner;
+    }
+    return DUPLICATE_FULL_CORNERS[corner - 9u];
+}
+
+fn corner_depth(corner: u32) -> f32 {
+    return select(1.0, 0.0, corner < 9u);
+}
+
+fn sample_gradient(face: u32, u: u32, v: u32) -> vec3<f32> {
+    let du = density(sample_word(face, u + 1u, v, 1u))
+        - density(sample_word(face, u - 1u, v, 1u));
+    let dv = density(sample_word(face, u, v + 1u, 1u))
+        - density(sample_word(face, u, v - 1u, 1u));
+    let outward = density(sample_word(face, u, v, 2u))
+        - density(sample_word(face, u, v, 0u));
+    return FACE_U_AXES[face] * du
+        + FACE_V_AXES[face] * dv
+        + FACE_OUTWARD_AXES[face] * outward;
+}
+
+fn normalized_or_outward(value: vec3<f32>, outward: vec3<f32>) -> vec3<f32> {
+    let squared_length = dot(value, value);
+    if squared_length <= 1.0e-12 {
+        return outward;
+    }
+    return value * inverseSqrt(squared_length);
+}
+
+@compute @workgroup_size(64, 1, 1)
+fn emit_transition_cells(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    let linear = global_id.x;
+    if linear >= dispatch.cell_count || linear >= CELL_COUNT {
+        return;
+    }
+    let face = linear / CELLS_PER_FACE;
+    if (dispatch.transition_mask & (1u << face)) == 0u {
+        return;
+    }
+    if atomicLoad(&counters.vertex_overflow) != 0u
+        || atomicLoad(&counters.index_overflow) != 0u {
+        return;
+    }
+    let cell = cells[linear];
+    if !cell_is_current(cell) {
+        return;
+    }
+    let local_offset = cell_offsets[linear];
+    if local_offset.generation_low != dispatch.generation_low
+        || local_offset.generation_high != dispatch.generation_high {
+        return;
+    }
+    let block = scan_blocks[linear / SCAN_WORKGROUP_SIZE];
+    let first_vertex = block.first_vertex + local_offset.first_vertex;
+    let first_index = block.first_index + local_offset.first_index;
+    let case_index = cell.packed_case_class_counts & 0x1ffu;
+    let class_code = (cell.packed_case_class_counts >> 9u) & 0xffu;
+    let class_index = class_code & 0x7fu;
+    let vertex_count = cell_vertex_count(cell);
+    let index_count = cell_triangle_count(cell) * 3u;
+    let face_cell = linear % CELLS_PER_FACE;
+    let cell_u = face_cell % FACE_CELL_EDGE;
+    let cell_v = face_cell / FACE_CELL_EDGE;
+    let origin = FACE_ORIGINS[face];
+    let u_axis = FACE_U_AXES[face];
+    let v_axis = FACE_V_AXES[face];
+    let outward_axis = FACE_OUTWARD_AXES[face];
+
+    for (var vertex = 0u; vertex < vertex_count; vertex += 1u) {
+        let code = tables[VERTEX_TABLE_OFFSET + case_index * VERTEX_TABLE_STRIDE + vertex];
+        let first_corner = (code >> 4u) & 0x0fu;
+        let second_corner = code & 0x0fu;
+        let first_full = full_corner(first_corner);
+        let second_full = full_corner(second_corner);
+        let first_uv = FULL_SAMPLE_UV[first_full];
+        let second_uv = FULL_SAMPLE_UV[second_full];
+        let first_u = cell_u * 2u + first_uv.x + 1u;
+        let first_v = cell_v * 2u + first_uv.y + 1u;
+        let second_u = cell_u * 2u + second_uv.x + 1u;
+        let second_v = cell_v * 2u + second_uv.y + 1u;
+        let first_word = sample_word(face, first_u, first_v, 1u);
+        let second_word = sample_word(face, second_u, second_v, 1u);
+        let first_density = density(first_word);
+        let second_density = density(second_word);
+        let denominator = first_density - second_density;
+        var interpolation = 0.5;
+        if abs(denominator) > 1.0e-12 {
+            interpolation = clamp(first_density / denominator, 0.0, 1.0);
+        }
+        let first_face_uv = vec2<f32>(first_uv) * 0.5;
+        let second_face_uv = vec2<f32>(second_uv) * 0.5;
+        let face_uv = vec2<f32>(f32(cell_u), f32(cell_v))
+            + mix(first_face_uv, second_face_uv, interpolation);
+        let depth_fraction = mix(
+            corner_depth(first_corner),
+            corner_depth(second_corner),
+            interpolation,
+        );
+        let normal = normalized_or_outward(
+            mix(
+                sample_gradient(face, first_u, first_v),
+                sample_gradient(face, second_u, second_v),
+                interpolation,
+            ),
+            outward_axis,
+        );
+        let primary = origin + u_axis * face_uv.x + v_axis * face_uv.y;
+        let inward_offset = -outward_axis * 0.25 * depth_fraction;
+        let projected_offset = inward_offset - normal * dot(inward_offset, normal);
+        let material = select(
+            (second_word >> 16u) & 0xffu,
+            (first_word >> 16u) & 0xffu,
+            first_density <= 0.0,
+        );
+        vertices[first_vertex + vertex] = GpuTerrainVertex(
+            primary + projected_offset,
+            material,
+            normal,
+            0u,
+        );
+    }
+
+    let inverse_case = (class_code & 0x80u) != 0u;
+    for (var index = 0u; index < index_count; index += 1u) {
+        var table_index = index;
+        if !inverse_case {
+            let triangle_corner = index % 3u;
+            if triangle_corner == 1u {
+                table_index += 1u;
+            } else if triangle_corner == 2u {
+                table_index -= 1u;
+            }
+        }
+        let local_vertex = tables[
+            TOPOLOGY_TABLE_OFFSET + class_index * TOPOLOGY_TABLE_STRIDE + table_index
+        ];
+        indices[first_index + index] = first_vertex + local_vertex;
+    }
+    atomicAdd(&counters.emitted_vertices, vertex_count);
+    atomicAdd(&counters.emitted_indices, index_count);
+}

--- a/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel_transitions.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_transvoxel_transitions.rs
@@ -1,0 +1,484 @@
+use bytemuck::Pod;
+use helio_pass_planetary_voxel::{
+    transition_case, ExtractionFixtureKind, GpuTerrainVertex, GpuTransvoxelCellOffset,
+    GpuTransvoxelScanBlock, GpuTransvoxelTransitionCell, GpuTransvoxelTransitionCounters,
+    TransitionFace, TransvoxelGpuTransitionExtractor, TransvoxelGpuTransitionExtractorConfig,
+    TransvoxelTransitionFaceFixture, TransvoxelTransitionGpuError,
+    TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT, TRANSITION_FACE_SLAB_EDGE,
+    TRANSITION_FACE_SLAB_SAMPLE_COUNT, TRANSITION_FULL_SAMPLE_UV,
+    TRANSVOXEL_TRANSITION_CASE_WEIGHTS, TRANSVOXEL_TRANSITION_CELLS_PER_FACE,
+    TRANSVOXEL_TRANSITION_CELL_COUNT, TRANSVOXEL_TRANSITION_SCAN_BLOCKS,
+};
+use helio_planet_voxel_core::{CellWord, PageKey};
+use std::{mem::size_of, sync::mpsc};
+
+#[test]
+fn headless_gpu_transition_emission_matches_cpu_on_all_six_faces() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!(
+                "GPU_VALIDATION_SKIPPED_NO_ADAPTER: no primary or fallback adapter available"
+            );
+            return;
+        };
+        let adapter_info = adapter.get_info();
+        eprintln!(
+            "GPU_VALIDATION_ADAPTER: name={:?} backend={:?} device_type={:?}",
+            adapter_info.name, adapter_info.backend, adapter_info.device_type
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planetary Transvoxel Transition Validation Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a validation device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("planetary Transvoxel transition GPU validation error: {error:?}");
+        }));
+
+        let mut extractor = TransvoxelGpuTransitionExtractor::new(
+            &device,
+            TransvoxelGpuTransitionExtractorConfig::default(),
+        )
+        .unwrap();
+        assert_eq!(extractor.resource_stats().buffers, 9);
+        assert_eq!(extractor.resource_stats().allocated_bytes, 3_799_224);
+        let resources = extractor.resource_stats();
+        extractor.resize(3840, 2160);
+        assert_eq!(extractor.resource_stats(), resources);
+
+        let cases = [
+            (
+                ExtractionFixtureKind::Plane,
+                PageKey::new(1, [0, -1, 0]),
+                0x3f,
+            ),
+            (
+                ExtractionFixtureKind::Sphere,
+                PageKey::new(1, [-1, -1, -1]),
+                0x2a,
+            ),
+            (
+                ExtractionFixtureKind::Sphere,
+                PageKey::new(1, [0, 0, 0]),
+                0x15,
+            ),
+        ];
+
+        for (case_number, (kind, page, mask)) in cases.into_iter().enumerate() {
+            let generation = 10_000 + case_number as u64;
+            let (slabs, fixtures) = fixtures_and_slabs(kind, page);
+            let expected = expected_mesh(&fixtures, mask);
+            extractor
+                .dispatch(&device, &queue, &slabs, mask, generation)
+                .unwrap();
+            let counters = read_one::<GpuTransvoxelTransitionCounters>(
+                &device,
+                &queue,
+                extractor.counters_buffer(),
+            );
+            assert_eq!(counters.completed, 1, "case {case_number}");
+            assert!(!counters.overflowed(), "case {case_number}");
+            assert_eq!(counters.active_faces, mask.count_ones());
+            assert_eq!(counters.active_cells, expected.active_cells);
+            assert_eq!(counters.required_vertices as usize, expected.vertices.len());
+            assert_eq!(counters.required_indices as usize, expected.indices.len());
+            assert_eq!(counters.emitted_vertices, counters.required_vertices);
+            assert_eq!(counters.emitted_indices, counters.required_indices);
+
+            let actual_vertices: Vec<GpuTerrainVertex> = read_buffer(
+                &device,
+                &queue,
+                extractor.vertices_buffer(),
+                u64::from(counters.required_vertices) * size_of::<GpuTerrainVertex>() as u64,
+            );
+            let actual_indices: Vec<u32> = read_buffer(
+                &device,
+                &queue,
+                extractor.indices_buffer(),
+                u64::from(counters.required_indices) * size_of::<u32>() as u64,
+            );
+            assert_vertices_close(&actual_vertices, &expected.vertices, case_number);
+            assert_eq!(
+                actual_indices, expected.indices,
+                "case {case_number} indices"
+            );
+
+            let actual_cells: Vec<GpuTransvoxelTransitionCell> = read_buffer(
+                &device,
+                &queue,
+                extractor.cells_buffer(),
+                u64::from(TRANSVOXEL_TRANSITION_CELL_COUNT)
+                    * size_of::<GpuTransvoxelTransitionCell>() as u64,
+            );
+            let offsets: Vec<GpuTransvoxelCellOffset> = read_buffer(
+                &device,
+                &queue,
+                extractor.offsets_buffer(),
+                u64::from(TRANSVOXEL_TRANSITION_CELL_COUNT)
+                    * size_of::<GpuTransvoxelCellOffset>() as u64,
+            );
+            let blocks: Vec<GpuTransvoxelScanBlock> = read_buffer(
+                &device,
+                &queue,
+                extractor.blocks_buffer(),
+                u64::from(TRANSVOXEL_TRANSITION_SCAN_BLOCKS)
+                    * size_of::<GpuTransvoxelScanBlock>() as u64,
+            );
+            for (linear, actual) in actual_cells.iter().copied().enumerate() {
+                let face_index = linear / TRANSVOXEL_TRANSITION_CELLS_PER_FACE as usize;
+                let active_face = mask & (1 << face_index) != 0;
+                if !active_face {
+                    assert!(!actual.is_valid_for(generation), "inactive cell {linear}");
+                    continue;
+                }
+                let face_cell = linear % TRANSVOXEL_TRANSITION_CELLS_PER_FACE as usize;
+                let u = (face_cell % 32) as u8;
+                let v = (face_cell / 32) as u8;
+                let cpu_cell = fixtures[face_index].cell([u, v]).unwrap();
+                let topology = cpu_cell.topology();
+                assert!(actual.is_valid_for(generation), "cell {linear}");
+                assert_eq!(actual.case_index(), cpu_cell.case_index(), "cell {linear}");
+                assert_eq!(
+                    actual.class_index(),
+                    topology.class_index(),
+                    "cell {linear}"
+                );
+                assert_eq!(
+                    actual.reverse_winding(),
+                    topology.reverse_winding(),
+                    "cell {linear}"
+                );
+                assert_eq!(
+                    usize::from(actual.vertex_count()),
+                    topology.vertex_count(),
+                    "cell {linear}"
+                );
+                assert_eq!(
+                    usize::from(actual.triangle_count()),
+                    topology.triangle_count(),
+                    "cell {linear}"
+                );
+                let (expected_vertex, expected_index) = expected.cell_offsets[linear].unwrap();
+                let block = blocks[linear / 256];
+                assert_eq!(
+                    block.first_vertex + offsets[linear].first_vertex,
+                    expected_vertex,
+                    "cell {linear} vertex offset"
+                );
+                assert_eq!(
+                    block.first_index + offsets[linear].first_index,
+                    expected_index,
+                    "cell {linear} index offset"
+                );
+                assert_eq!(offsets[linear].generation(), generation, "cell {linear}");
+            }
+
+            extractor
+                .dispatch(&device, &queue, &slabs, mask, generation)
+                .unwrap();
+            let repeated_vertices: Vec<GpuTerrainVertex> = read_buffer(
+                &device,
+                &queue,
+                extractor.vertices_buffer(),
+                u64::from(counters.required_vertices) * size_of::<GpuTerrainVertex>() as u64,
+            );
+            let repeated_indices: Vec<u32> = read_buffer(
+                &device,
+                &queue,
+                extractor.indices_buffer(),
+                u64::from(counters.required_indices) * size_of::<u32>() as u64,
+            );
+            assert_eq!(
+                bytemuck::cast_slice::<GpuTerrainVertex, u8>(&repeated_vertices),
+                bytemuck::cast_slice::<GpuTerrainVertex, u8>(&actual_vertices),
+                "case {case_number} deterministic vertices"
+            );
+            assert_eq!(
+                repeated_indices, actual_indices,
+                "case {case_number} deterministic indices"
+            );
+        }
+
+        let sweep_generation = 15_000;
+        let sweep_slabs = exhaustive_case_slabs();
+        extractor
+            .dispatch(
+                &device,
+                &queue,
+                &sweep_slabs,
+                TransitionFace::NegativeX.bit() | TransitionFace::PositiveX.bit(),
+                sweep_generation,
+            )
+            .unwrap();
+        let sweep_cells: Vec<GpuTransvoxelTransitionCell> = read_buffer(
+            &device,
+            &queue,
+            extractor.cells_buffer(),
+            u64::from(TRANSVOXEL_TRANSITION_CELL_COUNT)
+                * size_of::<GpuTransvoxelTransitionCell>() as u64,
+        );
+        for case_index in 0..512_u16 {
+            let (face, u, v) = sweep_case_location(case_index);
+            let linear = usize::from(face) * TRANSVOXEL_TRANSITION_CELLS_PER_FACE as usize
+                + usize::from(u)
+                + usize::from(v) * 32;
+            let actual = sweep_cells[linear];
+            let topology = transition_case(case_index).unwrap();
+            assert!(
+                actual.is_valid_for(sweep_generation),
+                "sweep case {case_index}"
+            );
+            assert_eq!(actual.case_index(), case_index, "sweep case {case_index}");
+            assert_eq!(
+                actual.class_index(),
+                topology.class_index(),
+                "sweep case {case_index} class"
+            );
+            assert_eq!(
+                actual.reverse_winding(),
+                topology.reverse_winding(),
+                "sweep case {case_index} winding"
+            );
+            assert_eq!(
+                usize::from(actual.vertex_count()),
+                topology.vertex_count(),
+                "sweep case {case_index} vertices"
+            );
+            assert_eq!(
+                usize::from(actual.triangle_count()),
+                topology.triangle_count(),
+                "sweep case {case_index} triangles"
+            );
+        }
+
+        extractor
+            .dispatch(&device, &queue, &sweep_slabs, 0, sweep_generation)
+            .unwrap();
+        let empty = read_one::<GpuTransvoxelTransitionCounters>(
+            &device,
+            &queue,
+            extractor.counters_buffer(),
+        );
+        assert_eq!(empty.completed, 1);
+        assert_eq!(empty.active_faces, 0);
+        assert_eq!(empty.active_cells, 0);
+        assert_eq!(empty.required_vertices, 0);
+        assert_eq!(empty.required_indices, 0);
+        assert_eq!(empty.emitted_vertices, 0);
+        assert_eq!(empty.emitted_indices, 0);
+        let invalidated_cells: Vec<GpuTransvoxelTransitionCell> = read_buffer(
+            &device,
+            &queue,
+            extractor.cells_buffer(),
+            u64::from(TRANSVOXEL_TRANSITION_CELL_COUNT)
+                * size_of::<GpuTransvoxelTransitionCell>() as u64,
+        );
+        assert!(invalidated_cells
+            .iter()
+            .all(|cell| !cell.is_valid_for(sweep_generation)));
+
+        let (slabs, _) =
+            fixtures_and_slabs(ExtractionFixtureKind::Plane, PageKey::new(1, [0, -1, 0]));
+        let tiny = TransvoxelGpuTransitionExtractor::new(
+            &device,
+            TransvoxelGpuTransitionExtractorConfig::new(1, 1).unwrap(),
+        )
+        .unwrap();
+        tiny.dispatch(&device, &queue, &slabs, 0x3f, 20_000)
+            .unwrap();
+        let counters =
+            read_one::<GpuTransvoxelTransitionCounters>(&device, &queue, tiny.counters_buffer());
+        assert_eq!(counters.completed, 1);
+        assert!(counters.vertex_overflow != 0);
+        assert!(counters.index_overflow != 0);
+        assert_eq!(counters.emitted_vertices, 0);
+        assert_eq!(counters.emitted_indices, 0);
+        assert!(counters.required_vertices > 1);
+        assert!(counters.required_indices > 1);
+
+        assert!(matches!(
+            extractor.dispatch(&device, &queue, &slabs[..3], 1, 1),
+            Err(TransvoxelTransitionGpuError::SampleCount { .. })
+        ));
+        assert!(matches!(
+            extractor.dispatch(&device, &queue, &slabs, 0x80, 1),
+            Err(TransvoxelTransitionGpuError::TransitionMask(0x80))
+        ));
+    });
+}
+
+fn exhaustive_case_slabs() -> Vec<CellWord> {
+    let air = CellWord::new(1, 0, 0);
+    let solid = CellWord::new(-1, 1, 0);
+    let mut slabs = vec![air; TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT];
+    for case_index in 0..512_u16 {
+        let (face, cell_u, cell_v) = sweep_case_location(case_index);
+        for (sample, uv) in TRANSITION_FULL_SAMPLE_UV.into_iter().enumerate() {
+            let slab_u = usize::from(cell_u) * 2 + usize::from(uv[0]) + 1;
+            let slab_v = usize::from(cell_v) * 2 + usize::from(uv[1]) + 1;
+            let index = usize::from(face) * TRANSITION_FACE_SLAB_SAMPLE_COUNT
+                + slab_u
+                + slab_v * TRANSITION_FACE_SLAB_EDGE
+                + TRANSITION_FACE_SLAB_EDGE * TRANSITION_FACE_SLAB_EDGE;
+            slabs[index] = if case_index & TRANSVOXEL_TRANSITION_CASE_WEIGHTS[sample] != 0 {
+                solid
+            } else {
+                air
+            };
+        }
+    }
+    slabs
+}
+
+fn sweep_case_location(case_index: u16) -> (u8, u8, u8) {
+    let face = (case_index / 256) as u8;
+    let slot = (case_index % 256) as u8;
+    (face, (slot % 16) * 2, (slot / 16) * 2)
+}
+
+struct ExpectedMesh {
+    vertices: Vec<GpuTerrainVertex>,
+    indices: Vec<u32>,
+    cell_offsets: Vec<Option<(u32, u32)>>,
+    active_cells: u32,
+}
+
+fn expected_mesh(fixtures: &[TransvoxelTransitionFaceFixture; 6], mask: u8) -> ExpectedMesh {
+    let mut expected = ExpectedMesh {
+        vertices: Vec::new(),
+        indices: Vec::new(),
+        cell_offsets: vec![None; TRANSVOXEL_TRANSITION_CELL_COUNT as usize],
+        active_cells: 0,
+    };
+    for face in TransitionFace::ALL {
+        if mask & face.bit() == 0 {
+            continue;
+        }
+        let fixture = fixtures[usize::from(face.index())];
+        let face_mesh = fixture.extract();
+        let base_vertex = expected.vertices.len() as u32;
+        let base_index = expected.indices.len() as u32;
+        for (face_cell, range) in face_mesh.cell_ranges.into_iter().enumerate() {
+            let range = range.unwrap();
+            let linear = usize::from(face.index()) * TRANSVOXEL_TRANSITION_CELLS_PER_FACE as usize
+                + face_cell;
+            expected.cell_offsets[linear] = Some((
+                base_vertex + range.first_vertex,
+                base_index + range.first_index,
+            ));
+            expected.active_cells += u32::from(range.vertex_count != 0);
+        }
+        expected
+            .vertices
+            .extend(face_mesh.vertices.into_iter().map(|vertex| vertex.vertex));
+        expected.indices.extend(
+            face_mesh
+                .indices
+                .into_iter()
+                .map(|index| base_vertex + index),
+        );
+    }
+    expected
+}
+
+fn fixtures_and_slabs(
+    kind: ExtractionFixtureKind,
+    page: PageKey,
+) -> (Vec<CellWord>, [TransvoxelTransitionFaceFixture; 6]) {
+    let fixtures = TransitionFace::ALL
+        .map(|face| TransvoxelTransitionFaceFixture::new(kind, page, face).unwrap());
+    let mut slabs = vec![CellWord::AIR; TRANSITION_ALL_FACE_SLAB_SAMPLE_COUNT];
+    for face in TransitionFace::ALL {
+        let face_index = usize::from(face.index());
+        let start = face_index * TRANSITION_FACE_SLAB_SAMPLE_COUNT;
+        slabs[start..start + TRANSITION_FACE_SLAB_SAMPLE_COUNT]
+            .copy_from_slice(&fixtures[face_index].slab_samples());
+    }
+    (slabs, fixtures)
+}
+
+fn assert_vertices_close(actual: &[GpuTerrainVertex], expected: &[GpuTerrainVertex], case: usize) {
+    assert_eq!(actual.len(), expected.len(), "case {case} vertices");
+    for (index, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        assert_eq!(
+            actual.material, expected.material,
+            "vertex {index} material"
+        );
+        assert_eq!(actual.flags, expected.flags, "vertex {index} flags");
+        for axis in 0..3 {
+            assert!(
+                (actual.position[axis] - expected.position[axis]).abs() <= 1.0e-5,
+                "case {case} vertex {index}:{axis} position {:?} != {:?}",
+                actual.position,
+                expected.position
+            );
+            assert!(
+                (actual.normal[axis] - expected.normal[axis]).abs() <= 2.0e-4,
+                "case {case} vertex {index}:{axis} normal {:?} != {:?}",
+                actual.normal,
+                expected.normal
+            );
+        }
+    }
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}
+
+fn read_one<T: Pod + Copy>(device: &wgpu::Device, queue: &wgpu::Queue, source: &wgpu::Buffer) -> T {
+    read_buffer(device, queue, source, size_of::<T>() as u64)[0]
+}
+
+fn read_buffer<T: Pod + Copy>(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source: &wgpu::Buffer,
+    size: u64,
+) -> Vec<T> {
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planetary Transvoxel Transition Readback"),
+        size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planetary Transvoxel Transition Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(source, 0, &readback, 0, size);
+    queue.submit([encoder.finish()]);
+    let slice = readback.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv()
+        .expect("GPU readback callback must run")
+        .expect("GPU readback mapping must succeed");
+    let mapped = slice
+        .get_mapped_range()
+        .expect("GPU readback range must be available");
+    let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
+    drop(mapped);
+    readback.unmap();
+    values
+}

--- a/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
+++ b/crates/helio-pass-planetary-voxel/tests/wgsl_layout.rs
@@ -3,8 +3,9 @@ use helio_pass_planetary_voxel::{
     GpuLookupResult, GpuPageTableEntry, GpuResidencyCounters, GpuResidencyUniform,
     GpuTerrainMeshlet, GpuTerrainVertex, GpuTransvoxelCell, GpuTransvoxelCellOffset,
     GpuTransvoxelClassifyCounters, GpuTransvoxelDispatch, GpuTransvoxelEmissionCounters,
-    GpuTransvoxelScanBlock, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL, TRANSVOXEL_CLASSIFY_WGSL,
-    TRANSVOXEL_EMIT_WGSL,
+    GpuTransvoxelScanBlock, GpuTransvoxelTransitionCell, GpuTransvoxelTransitionCounters,
+    GpuTransvoxelTransitionDispatch, EXTRACTION_LAYOUT_WGSL, RESIDENCY_WGSL,
+    TRANSVOXEL_CLASSIFY_WGSL, TRANSVOXEL_EMIT_WGSL, TRANSVOXEL_TRANSITION_GPU_WGSL,
 };
 use std::mem::{align_of, offset_of, size_of};
 use wgpu::naga::{
@@ -426,6 +427,79 @@ fn transvoxel_emission_layouts_match_wgsl_exactly() {
                 ("material".into(), 12),
                 ("normal".into(), 16),
                 ("flags".into(), 28),
+            ],
+        )
+    );
+}
+
+#[test]
+fn transvoxel_transition_gpu_layouts_match_wgsl_exactly() {
+    let module = wgsl::parse_str(TRANSVOXEL_TRANSITION_GPU_WGSL)
+        .expect("Transvoxel transition GPU WGSL parses");
+    Validator::new(ValidationFlags::all(), Capabilities::all())
+        .validate(&module)
+        .expect("Transvoxel transition GPU WGSL validates");
+
+    assert_eq!(align_of::<GpuTransvoxelTransitionDispatch>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelTransitionDispatch>(), 32);
+    assert_eq!(
+        wgsl_struct_in(
+            TRANSVOXEL_TRANSITION_GPU_WGSL,
+            "GpuTransvoxelTransitionDispatch"
+        ),
+        (
+            32,
+            vec![
+                ("transition_mask".into(), 0),
+                ("generation_low".into(), 4),
+                ("generation_high".into(), 8),
+                ("cell_count".into(), 12),
+                ("max_vertices".into(), 16),
+                ("max_indices".into(), 20),
+                ("scan_block_count".into(), 24),
+                ("_pad".into(), 28),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelTransitionCell>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelTransitionCell>(), 16);
+    assert_eq!(
+        wgsl_struct_in(
+            TRANSVOXEL_TRANSITION_GPU_WGSL,
+            "GpuTransvoxelTransitionCell"
+        ),
+        (
+            16,
+            vec![
+                ("packed_case_class_counts".into(), 0),
+                ("generation_low".into(), 4),
+                ("generation_high".into(), 8),
+                ("_pad".into(), 12),
+            ],
+        )
+    );
+
+    assert_eq!(align_of::<GpuTransvoxelTransitionCounters>(), 16);
+    assert_eq!(size_of::<GpuTransvoxelTransitionCounters>(), 48);
+    assert_eq!(
+        wgsl_struct_in(
+            TRANSVOXEL_TRANSITION_GPU_WGSL,
+            "GpuTransvoxelTransitionCounters"
+        ),
+        (
+            48,
+            vec![
+                ("active_cells".into(), 0),
+                ("active_faces".into(), 4),
+                ("required_vertices".into(), 8),
+                ("required_indices".into(), 12),
+                ("emitted_vertices".into(), 16),
+                ("emitted_indices".into(), 20),
+                ("vertex_overflow".into(), 24),
+                ("index_overflow".into(), 28),
+                ("completed".into(), 32),
+                ("_pad".into(), 36),
             ],
         )
     );


### PR DESCRIPTION
## Scope

Adds the bounded GPU Transvoxel transition-cell classifier, two-level prefix allocator, and deterministic emitter for planetary voxel page faces.

- consumes six fixed 67 x 67 x 3 face-local scalar slabs (`CellWord`), not CPU-produced geometry
- classifies at most 6 x 32 x 32 = 6,144 transition cells
- derives central-difference normals from scalar samples on GPU
- applies the one-quarter coarse-cell tangent-projected secondary position and Helio winding convention
- publishes all geometry or none on capacity overflow
- generation-stamps metadata and invalidates disabled faces, including same-generation transition-mask changes
- keeps allocations independent of the window size

Fixed default allocation: 9 buffers, 3,799,224 bytes, with worst-case capacity for 73,728 vertices and 221,184 indices.

This is the extraction-kernel contract. Building these slabs directly from resident planetary pages and drawing the result are later integration steps; this PR does not claim issue #96 is complete.

## Validation

- `cargo test -p helio-planet-voxel-core` (20 unit + 3 WGSL layout tests)
- `cargo test -p helio-pass-planetary-voxel` (44 unit, residency GPU, regular classify GPU, regular emission GPU, transition emission GPU, 10 WGSL/layout tests)
- exhaustive CPU/GPU classification parity across all 512 transition cases
- all six face orientations, CPU/GPU geometry parity, repeat bitwise determinism, overflow, stale generation, and same-generation mask invalidation
- GPU adapter: NVIDIA GeForce RTX 3060, Vulkan, DiscreteGpu
- `cargo clippy -p helio-pass-planetary-voxel --all-targets -- -D warnings`
- `cargo check -p helio --lib`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch`
- `git diff --check`

Progresses #96 and #60.