### PR TITLE
Add Earth-radius camera-local planet coordinates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,6 +3240,7 @@ name = "helio-planet-voxel-core"
 version = "0.1.0"
 dependencies = [
  "bytemuck",
+ "pollster 0.4.0",
  "thiserror 2.0.18",
  "wgpu 30.0.0",
 ]

--- a/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
@@ -6,8 +6,8 @@ use helio_pass_planetary_voxel::{
 };
 use helio_planet_voxel_core::{
     CellWord, EvictOutcome, GpuPageMeta, PageEvict, PageKey, PageUpload, PlanetFrameUniform,
-    PlanetId, PlanetPageKey, UploadOutcome, VisiblePage, VisiblePageSet, PAGE_CELL_BYTES,
-    PAGE_CELL_COUNT,
+    PlanetId, PlanetPageKey, PlanetPosition, UploadOutcome, VisiblePage, VisiblePageSet,
+    PAGE_CELL_BYTES, PAGE_CELL_COUNT,
 };
 use std::sync::mpsc;
 use wgpu::util::DeviceExt;
@@ -15,9 +15,7 @@ use wgpu::util::DeviceExt;
 #[test]
 fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
     pollster::block_on(async {
-        let instance = wgpu::Instance::new(
-            wgpu::InstanceDescriptor::new_without_display_handle(),
-        );
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
         let adapter = request_test_adapter(&instance).await;
         let Some(adapter) = adapter else {
             eprintln!(
@@ -58,13 +56,21 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
         residency
             .set_planet_frame(
                 &queue,
-                PlanetFrameUniform::new(planet_a, [0; 3], [0.25, -1.0, 2.0], 1).unwrap(),
+                PlanetFrameUniform::from_camera(
+                    planet_a,
+                    PlanetPosition::from_meters([0.25, 1.0, 2.0]).unwrap(),
+                    1,
+                ),
             )
             .unwrap();
         residency
             .set_planet_frame(
                 &queue,
-                PlanetFrameUniform::new(planet_b, [0; 3], [-2.0, 3.0, 1.0], 1).unwrap(),
+                PlanetFrameUniform::from_camera(
+                    planet_b,
+                    PlanetPosition::from_meters([2.0, 3.0, 1.0]).unwrap(),
+                    1,
+                ),
             )
             .unwrap();
 
@@ -133,7 +139,11 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
         assert!(matches!(
             residency.set_planet_frame(
                 &queue,
-                PlanetFrameUniform::new(planet_a, [0; 3], [9.0, 0.0, 0.0], 1).unwrap(),
+                PlanetFrameUniform::from_camera(
+                    planet_a,
+                    PlanetPosition::from_meters([9.0, 0.0, 0.0]).unwrap(),
+                    1,
+                ),
             ),
             Ok(FrameUpdateOutcome::FrameConflict)
         ));
@@ -141,14 +151,22 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
         assert!(matches!(
             residency.set_planet_frame(
                 &queue,
-                PlanetFrameUniform::new(planet_a, outside_origin, [0.0; 3], 2).unwrap(),
+                PlanetFrameUniform::from_camera(
+                    planet_a,
+                    PlanetPosition::from_lod0_cell(outside_origin),
+                    2,
+                ),
             ),
             Err(GpuResidencyError::Address(_))
         ));
         assert!(matches!(
             residency.set_planet_frame(
                 &queue,
-                PlanetFrameUniform::new(planet_a, [32, 0, 0], [0.0; 3], 2).unwrap(),
+                PlanetFrameUniform::from_camera(
+                    planet_a,
+                    PlanetPosition::from_lod0_cell([32, 0, 0]),
+                    2,
+                ),
             ),
             Ok(FrameUpdateOutcome::Applied {
                 previous_frame: Some(1)
@@ -319,7 +337,7 @@ fn validate_table_probe_backpressure(device: &wgpu::Device, queue: &wgpu::Queue,
     residency
         .set_planet_frame(
             queue,
-            PlanetFrameUniform::new(planet, [0; 3], [0.0; 3], 1).unwrap(),
+            PlanetFrameUniform::from_camera(planet, PlanetPosition::from_lod0_cell([0; 3]), 1),
         )
         .unwrap();
     let mut collisions = Vec::new();

--- a/crates/helio-planet-voxel-core/Cargo.toml
+++ b/crates/helio-planet-voxel-core/Cargo.toml
@@ -9,4 +9,5 @@ bytemuck = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+pollster = { workspace = true }
 wgpu = { workspace = true }

--- a/crates/helio-planet-voxel-core/src/gpu.rs
+++ b/crates/helio-planet-voxel-core/src/gpu.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AddressError, PageKey, PlanetId, LOD0_CELL_SIZE_METERS, PAGE_EDGE_CELLS, TRANSITION_FACE_MASK,
+    AddressError, PageKey, PlanetId, PlanetPosition, PlanetRenderFrame, LOD0_CELL_SIZE_METERS,
+    TRANSITION_FACE_MASK,
 };
 use bytemuck::{Pod, Zeroable};
 
@@ -21,33 +22,24 @@ pub struct PlanetFrameUniform {
 }
 
 impl PlanetFrameUniform {
-    pub fn new(
-        planet: PlanetId,
-        frame_origin_lod0_cell: [i64; 3],
-        camera_relative_m: [f32; 3],
-        frame_index: u64,
-    ) -> Result<Self, FrameError> {
-        if frame_origin_lod0_cell
-            .iter()
-            .any(|axis| axis.rem_euclid(PAGE_EDGE_CELLS) != 0)
-        {
-            return Err(FrameError::UnsnappedOrigin);
-        }
-        if camera_relative_m.iter().any(|value| !value.is_finite()) {
-            return Err(FrameError::NonFiniteCameraOffset);
-        }
-
-        Ok(Self {
-            planet_id: planet_words(planet),
+    pub fn from_render_frame(frame: PlanetRenderFrame) -> Self {
+        let frame_origin_lod0_cell = frame.origin_lod0_cell();
+        let camera_relative_m = frame.camera_relative_m().map(|value| value as f32);
+        Self {
+            planet_id: planet_words(frame.planet()),
             origin_x: split_i64(frame_origin_lod0_cell[0]),
             origin_y: split_i64(frame_origin_lod0_cell[1]),
             origin_z: split_i64(frame_origin_lod0_cell[2]),
-            frame_index: split_u64(frame_index),
+            frame_index: split_u64(frame.frame_index()),
             camera_relative_m,
             lod0_cell_size_m: LOD0_CELL_SIZE_METERS as f32,
-            page_edge_cells: PAGE_EDGE_CELLS as u32,
+            page_edge_cells: crate::PAGE_EDGE_CELLS as u32,
             _pad: [0; 3],
-        })
+        }
+    }
+
+    pub fn from_camera(planet: PlanetId, camera: PlanetPosition, frame_index: u64) -> Self {
+        Self::from_render_frame(PlanetRenderFrame::new(planet, camera, frame_index))
     }
 
     pub fn frame_origin_lod0_cell(self) -> [i64; 3] {
@@ -109,6 +101,22 @@ impl GpuPageMeta {
     pub const fn generation(self) -> u64 {
         (self.generation_low as u64) | ((self.generation_high as u64) << 32)
     }
+
+    /// CPU mirror of `planet_camera_local_position_m` in the shared WGSL.
+    pub fn camera_local_position_m(
+        self,
+        frame: PlanetFrameUniform,
+        local_lod0_cell: [f32; 3],
+    ) -> [f32; 3] {
+        [
+            (self.relative_lod0_cell_min[0] as f32 + local_lod0_cell[0]) * frame.lod0_cell_size_m
+                - frame.camera_relative_m[0],
+            (self.relative_lod0_cell_min[1] as f32 + local_lod0_cell[1]) * frame.lod0_cell_size_m
+                - frame.camera_relative_m[1],
+            (self.relative_lod0_cell_min[2] as f32 + local_lod0_cell[2]) * frame.lod0_cell_size_m
+                - frame.camera_relative_m[2],
+        ]
+    }
 }
 
 #[repr(C, align(16))]
@@ -116,14 +124,6 @@ impl GpuPageMeta {
 pub struct GpuVoxelMaterial {
     pub base_color_roughness: [f32; 4],
     pub emissive_metalness: [f32; 4],
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
-pub enum FrameError {
-    #[error("planet frame origin must be snapped to an LOD0 page boundary")]
-    UnsnappedOrigin,
-    #[error("planet frame camera offset must contain only finite values")]
-    NonFiniteCameraOffset,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
@@ -160,23 +160,41 @@ mod tests {
 
     #[test]
     fn frame_round_trips_signed_canonical_origin() {
+        let camera =
+            PlanetPosition::new([-63_i64, 34, i64::from(i32::MAX) * 32 + 3], [0.0; 3]).unwrap();
+        let uniform = PlanetFrameUniform::from_camera(PlanetId([7; 16]), camera, 9);
         let origin = [-64_i64, 32, i64::from(i32::MAX) * 32];
-        let uniform =
-            PlanetFrameUniform::new(PlanetId([7; 16]), origin, [1.0, 2.0, 3.0], 9).unwrap();
         assert_eq!(uniform.frame_origin_lod0_cell(), origin);
         assert_eq!(uniform.frame_index, [9, 0]);
         assert_eq!(uniform.page_edge_cells, 32);
+        assert_eq!(uniform.camera_relative_m, [0.1, 0.2, 0.3]);
     }
 
     #[test]
-    fn frame_rejects_unsnapped_and_non_finite_values() {
+    fn page_boundary_reconstruction_is_identical_from_both_pages() {
+        let camera =
+            PlanetPosition::new([63_710_017, -63_710_017, 0], [0.025, 0.075, 0.0]).unwrap();
+        let frame = PlanetRenderFrame::new(PlanetId([9; 16]), camera, 4);
+        let uniform = PlanetFrameUniform::from_render_frame(frame);
+        let left = GpuPageMeta::new(
+            PageKey::new(0, [1_990_938, -1_990_940, 0]),
+            frame.origin_lod0_cell(),
+            0,
+            1,
+            0,
+        )
+        .unwrap();
+        let right = GpuPageMeta::new(
+            PageKey::new(0, [1_990_939, -1_990_940, 0]),
+            frame.origin_lod0_cell(),
+            1,
+            1,
+            0,
+        )
+        .unwrap();
         assert_eq!(
-            PlanetFrameUniform::new(PlanetId::default(), [1, 0, 0], [0.0; 3], 0),
-            Err(FrameError::UnsnappedOrigin)
-        );
-        assert_eq!(
-            PlanetFrameUniform::new(PlanetId::default(), [0; 3], [f32::INFINITY, 0.0, 0.0], 0,),
-            Err(FrameError::NonFiniteCameraOffset)
+            left.camera_local_position_m(uniform, [32.0, 7.5, 3.25]),
+            right.camera_local_position_m(uniform, [0.0, 7.5, 3.25])
         );
     }
 }

--- a/crates/helio-planet-voxel-core/src/planet_voxel_layout.wgsl
+++ b/crates/helio-planet-voxel-core/src/planet_voxel_layout.wgsl
@@ -40,3 +40,16 @@ fn cell_material(cell: CellWord) -> u32 {
 fn cell_flags(cell: CellWord) -> u32 {
     return cell >> 24u;
 }
+
+// Reconstruct a bounded camera-local position. Absolute planet coordinates
+// remain split integers on the CPU; shaders only convert the checked i32 page
+// delta and page-local coordinate to f32.
+fn planet_camera_local_position_m(
+    frame: PlanetFrameUniform,
+    page: GpuPageMeta,
+    local_lod0_cell: vec3<f32>,
+) -> vec3<f32> {
+    return (vec3<f32>(page.relative_lod0_cell_min) + local_lod0_cell)
+        * frame.lod0_cell_size_m
+        - frame.camera_relative_m;
+}

--- a/crates/helio-planet-voxel-core/src/types.rs
+++ b/crates/helio-planet-voxel-core/src/types.rs
@@ -4,6 +4,10 @@ pub type MaterialId = u8;
 
 pub const LOD0_CELL_SIZE_METERS: f64 = 0.1;
 pub const PAGE_EDGE_CELLS: i64 = 32;
+/// Largest camera-local distance at which an `f32` unit in the last place is
+/// no larger than one millimeter. Canonical positions never use this bound;
+/// it applies only to the bounded render/interaction bubble.
+pub const MILLIMETER_INTERACTION_RADIUS_METERS: f64 = 8_192.0;
 pub const PAGE_EDGE: usize = PAGE_EDGE_CELLS as usize;
 pub const PAGE_CELL_COUNT: usize = PAGE_EDGE * PAGE_EDGE * PAGE_EDGE;
 pub const PAGE_CELL_BYTES: usize = PAGE_CELL_COUNT * core::mem::size_of::<CellWord>();
@@ -69,6 +73,160 @@ impl TransitionFace {
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Pod, Zeroable)]
 pub struct PlanetId(pub [u8; 16]);
+
+/// Canonical planet-space position.
+///
+/// The integer cell address is authoritative. The sub-cell remainder is
+/// normalized to `[0, LOD0_CELL_SIZE_METERS)` on every axis, including for
+/// negative positions. Absolute world positions therefore never depend on a
+/// large `f32` coordinate.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlanetPosition {
+    lod0_cell: [i64; 3],
+    subcell_m: [f64; 3],
+}
+
+impl PlanetPosition {
+    pub fn new(lod0_cell: [i64; 3], mut subcell_m: [f64; 3]) -> Result<Self, PositionError> {
+        for value in &mut subcell_m {
+            if !value.is_finite() {
+                return Err(PositionError::NonFinite);
+            }
+            if !(0.0..LOD0_CELL_SIZE_METERS).contains(value) {
+                return Err(PositionError::SubcellOutOfRange);
+            }
+            if *value == -0.0 {
+                *value = 0.0;
+            }
+        }
+        Ok(Self {
+            lod0_cell,
+            subcell_m,
+        })
+    }
+
+    pub const fn from_lod0_cell(lod0_cell: [i64; 3]) -> Self {
+        Self {
+            lod0_cell,
+            subcell_m: [0.0; 3],
+        }
+    }
+
+    /// Convenience conversion for camera/input values. Persistent terrain
+    /// addresses should already arrive as integer cells plus a remainder.
+    pub fn from_meters(meters: [f64; 3]) -> Result<Self, PositionError> {
+        let mut cells = [0_i64; 3];
+        let mut subcell_m = [0.0_f64; 3];
+        for axis in 0..3 {
+            let value = meters[axis];
+            if !value.is_finite() {
+                return Err(PositionError::NonFinite);
+            }
+            let cell = (value / LOD0_CELL_SIZE_METERS).floor();
+            if cell < i64::MIN as f64 || cell >= -(i64::MIN as f64) {
+                return Err(PositionError::CoordinateOverflow);
+            }
+            cells[axis] = cell as i64;
+            let mut remainder = value - cell * LOD0_CELL_SIZE_METERS;
+            // Floating-point division can leave a value one rounding step
+            // outside the canonical interval at an exact cell boundary.
+            if remainder < 0.0 {
+                cells[axis] = cells[axis]
+                    .checked_sub(1)
+                    .ok_or(PositionError::CoordinateOverflow)?;
+                remainder += LOD0_CELL_SIZE_METERS;
+            } else if remainder >= LOD0_CELL_SIZE_METERS {
+                cells[axis] = cells[axis]
+                    .checked_add(1)
+                    .ok_or(PositionError::CoordinateOverflow)?;
+                remainder -= LOD0_CELL_SIZE_METERS;
+            }
+            if remainder == -0.0 {
+                remainder = 0.0;
+            }
+            subcell_m[axis] = remainder;
+        }
+        Self::new(cells, subcell_m)
+    }
+
+    pub const fn lod0_cell(self) -> [i64; 3] {
+        self.lod0_cell
+    }
+
+    pub const fn subcell_m(self) -> [f64; 3] {
+        self.subcell_m
+    }
+
+    /// Computes `self - origin` without first constructing a large absolute
+    /// floating-point coordinate.
+    pub fn relative_meters(self, origin: Self) -> Result<[f64; 3], PositionError> {
+        let mut relative = [0.0_f64; 3];
+        for (axis, output) in relative.iter_mut().enumerate() {
+            let cells = self.lod0_cell[axis]
+                .checked_sub(origin.lod0_cell[axis])
+                .ok_or(PositionError::CoordinateOverflow)?;
+            *output = cells as f64 * LOD0_CELL_SIZE_METERS
+                + (self.subcell_m[axis] - origin.subcell_m[axis]);
+        }
+        Ok(relative)
+    }
+
+    pub fn relative_to_lod0_cell(
+        self,
+        origin_lod0_cell: [i64; 3],
+    ) -> Result<[f64; 3], PositionError> {
+        self.relative_meters(Self::from_lod0_cell(origin_lod0_cell))
+    }
+}
+
+/// Page-snapped camera frame used to derive all bounded GPU coordinates.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct PlanetRenderFrame {
+    planet: PlanetId,
+    camera: PlanetPosition,
+    origin_lod0_cell: [i64; 3],
+    frame_index: u64,
+}
+
+impl PlanetRenderFrame {
+    pub fn new(planet: PlanetId, camera: PlanetPosition, frame_index: u64) -> Self {
+        let origin_lod0_cell = camera
+            .lod0_cell
+            .map(|axis| axis.div_euclid(PAGE_EDGE_CELLS) * PAGE_EDGE_CELLS);
+        Self {
+            planet,
+            camera,
+            origin_lod0_cell,
+            frame_index,
+        }
+    }
+
+    pub const fn planet(self) -> PlanetId {
+        self.planet
+    }
+
+    pub const fn camera(self) -> PlanetPosition {
+        self.camera
+    }
+
+    pub const fn origin_lod0_cell(self) -> [i64; 3] {
+        self.origin_lod0_cell
+    }
+
+    pub const fn frame_index(self) -> u64 {
+        self.frame_index
+    }
+
+    pub fn camera_relative_m(self) -> [f64; 3] {
+        self.camera
+            .relative_to_lod0_cell(self.origin_lod0_cell)
+            .expect("a page-snapped camera origin cannot overflow")
+    }
+
+    pub fn camera_local_meters(self, position: PlanetPosition) -> Result<[f64; 3], PositionError> {
+        position.relative_meters(self.camera)
+    }
+}
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PageKey {
@@ -205,6 +363,16 @@ pub enum AddressError {
     OutsideRenderFrame,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum PositionError {
+    #[error("planet position contains a non-finite value")]
+    NonFinite,
+    #[error("planet position sub-cell remainder must be in [0, 0.1) meters")]
+    SubcellOutOfRange,
+    #[error("planet position coordinate arithmetic overflowed")]
+    CoordinateOverflow,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -264,5 +432,69 @@ mod tests {
             PageKey::new(0, [i64::from(i32::MAX), 0, 0]).relative_lod0_cell_min([0; 3]),
             Err(AddressError::OutsideRenderFrame)
         );
+    }
+
+    #[test]
+    fn canonical_positions_normalize_negative_meter_coordinates() {
+        let position = PlanetPosition::from_meters([-0.001, -0.1, -3.201]).unwrap();
+        assert_eq!(position.lod0_cell(), [-1, -1, -33]);
+        let expected = [0.099, 0.0, 0.099];
+        for (actual, expected) in position.subcell_m().into_iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-12);
+        }
+    }
+
+    #[test]
+    fn canonical_positions_reject_invalid_remainders_and_remove_negative_zero() {
+        assert_eq!(
+            PlanetPosition::new([0; 3], [0.1, 0.0, 0.0]),
+            Err(PositionError::SubcellOutOfRange)
+        );
+        assert_eq!(
+            PlanetPosition::new([0; 3], [f64::NAN, 0.0, 0.0]),
+            Err(PositionError::NonFinite)
+        );
+        let zero = PlanetPosition::new([0; 3], [-0.0, 0.0, 0.0]).unwrap();
+        assert_eq!(zero.subcell_m()[0].to_bits(), 0.0_f64.to_bits());
+    }
+
+    #[test]
+    fn render_frames_are_page_snapped_on_both_sides_of_zero() {
+        let positive = PlanetRenderFrame::new(
+            PlanetId::default(),
+            PlanetPosition::new([63_710_017, 5, 0], [0.025, 0.0, 0.0]).unwrap(),
+            7,
+        );
+        assert_eq!(positive.origin_lod0_cell(), [63_710_016, 0, 0]);
+        assert_eq!(positive.camera_relative_m(), [0.125, 0.5, 0.0]);
+
+        let negative = PlanetRenderFrame::new(
+            PlanetId::default(),
+            PlanetPosition::new([-63_710_017, -1, 0], [0.025, 0.05, 0.0]).unwrap(),
+            8,
+        );
+        assert_eq!(negative.origin_lod0_cell(), [-63_710_048, -32, 0]);
+        assert_eq!(negative.camera_relative_m(), [3.125, 3.15, 0.0]);
+    }
+
+    #[test]
+    fn earth_radius_and_orbit_offsets_do_not_use_absolute_f32() {
+        let ground =
+            PlanetPosition::new([63_710_000, -63_710_000, 0], [0.001, 0.099, 0.05]).unwrap();
+        let orbit =
+            PlanetPosition::new([67_710_000, -63_710_000, 0], [0.001, 0.099, 0.05]).unwrap();
+        assert_eq!(
+            orbit.relative_meters(ground).unwrap(),
+            [400_000.0, 0.0, 0.0]
+        );
+
+        let frame = PlanetRenderFrame::new(PlanetId([3; 16]), ground, 42);
+        let nearby =
+            PlanetPosition::new([63_710_007, -63_710_004, 0], [0.0015, 0.0985, 0.0505]).unwrap();
+        let local = frame.camera_local_meters(nearby).unwrap();
+        let expected = [0.7005, -0.4005, 0.0005];
+        for (actual, expected) in local.into_iter().zip(expected) {
+            assert!((actual - expected).abs() < 1.0e-12);
+        }
     }
 }

--- a/crates/helio-planet-voxel-core/tests/gpu_planet_frame.rs
+++ b/crates/helio-planet-voxel-core/tests/gpu_planet_frame.rs
@@ -1,0 +1,330 @@
+use bytemuck::{Pod, Zeroable};
+use helio_planet_voxel_core::{
+    GpuPageMeta, PageKey, PlanetFrameUniform, PlanetId, PlanetPosition, PlanetRenderFrame,
+    LOD0_CELL_SIZE_METERS, MILLIMETER_INTERACTION_RADIUS_METERS, PLANET_VOXEL_LAYOUT_WGSL,
+};
+use std::sync::mpsc;
+use wgpu::util::DeviceExt;
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct GpuParityInput {
+    frame: PlanetFrameUniform,
+    page: GpuPageMeta,
+    local_lod0_cell: [f32; 4],
+}
+
+#[repr(C, align(16))]
+#[derive(Clone, Copy, Debug, Pod, Zeroable)]
+struct GpuParityOutput {
+    origin_x: [u32; 2],
+    origin_y: [u32; 2],
+    origin_z: [u32; 2],
+    frame_index: [u32; 2],
+    camera_local_m: [f32; 4],
+}
+
+#[derive(Clone, Copy)]
+struct Case {
+    camera: PlanetPosition,
+    point: PlanetPosition,
+}
+
+#[test]
+fn gpu_matches_canonical_frames_at_planet_scale_and_across_rebases() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!(
+                "GPU_VALIDATION_SKIPPED_NO_ADAPTER: no primary or fallback adapter available"
+            );
+            return;
+        };
+        let info = adapter.get_info();
+        eprintln!(
+            "GPU_PLANET_FRAME_ADAPTER: name={:?} backend={:?} device_type={:?}",
+            info.name, info.backend, info.device_type
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planet Frame Parity Test Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a validation device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("planet frame GPU validation error: {error:?}");
+        }));
+
+        let earth_cells = 63_710_000_i64;
+        let orbit_cells = 67_710_000_i64;
+        let cases = [
+            // Ground, low orbit, antipode, and mixed-sign coordinates.
+            case([earth_cells, 0, 0], [11, -7, 3]),
+            case([orbit_cells, 120, -80], [-13, 9, 5]),
+            case([-earth_cells, 0, 0], [17, 4, -6]),
+            case([-earth_cells, earth_cells, -earth_cells], [-19, 21, 8]),
+            // The same local relationship on either side of a page-origin rebase.
+            case([earth_cells + 31, -1, 7], [5, -3, 2]),
+            case([earth_cells + 32, 0, 8], [5, -3, 2]),
+            // The documented millimeter-precision interaction bound.
+            case(
+                [earth_cells, 0, 0],
+                [
+                    (MILLIMETER_INTERACTION_RADIUS_METERS / LOD0_CELL_SIZE_METERS) as i64 - 1,
+                    0,
+                    0,
+                ],
+            ),
+        ];
+
+        let planet = PlanetId([0x5a; 16]);
+        let mut inputs = Vec::with_capacity(cases.len());
+        let mut expected = Vec::with_capacity(cases.len());
+        for (index, case) in cases.into_iter().enumerate() {
+            let frame = PlanetRenderFrame::new(planet, case.camera, index as u64 + 1);
+            let uniform = PlanetFrameUniform::from_render_frame(frame);
+            let (page, local) = PageKey::address_lod0_cell(0, case.point.lod0_cell()).unwrap();
+            let page =
+                GpuPageMeta::new(page, frame.origin_lod0_cell(), index as u32, 1, 0).unwrap();
+            let subcell = case.point.subcell_m();
+            let local_lod0_cell = [
+                f32::from(local[0]) + (subcell[0] / LOD0_CELL_SIZE_METERS) as f32,
+                f32::from(local[1]) + (subcell[1] / LOD0_CELL_SIZE_METERS) as f32,
+                f32::from(local[2]) + (subcell[2] / LOD0_CELL_SIZE_METERS) as f32,
+                0.0,
+            ];
+            inputs.push(GpuParityInput {
+                frame: uniform,
+                page,
+                local_lod0_cell,
+            });
+            expected.push((uniform, frame.camera_local_meters(case.point).unwrap()));
+        }
+
+        let outputs = dispatch(&device, &queue, &inputs);
+        assert_eq!(outputs.len(), expected.len());
+        let mut max_error_m = 0.0_f64;
+        for (index, (output, (uniform, expected_m))) in
+            outputs.into_iter().zip(expected).enumerate()
+        {
+            assert_eq!(output.origin_x, uniform.origin_x, "case {index} origin x");
+            assert_eq!(output.origin_y, uniform.origin_y, "case {index} origin y");
+            assert_eq!(output.origin_z, uniform.origin_z, "case {index} origin z");
+            assert_eq!(
+                output.frame_index, uniform.frame_index,
+                "case {index} frame index"
+            );
+            for (axis, expected_axis_m) in expected_m.into_iter().enumerate() {
+                let error = (f64::from(output.camera_local_m[axis]) - expected_axis_m).abs();
+                max_error_m = max_error_m.max(error);
+                assert!(
+                    error <= 0.001,
+                    "case {index} axis {axis} exceeded 1 mm: gpu={} cpu={} error={error}",
+                    output.camera_local_m[axis],
+                    expected_axis_m
+                );
+            }
+        }
+        eprintln!("GPU_PLANET_FRAME_MAX_ERROR_METERS: {max_error_m:.9}");
+
+        let camera =
+            PlanetPosition::new([earth_cells + 17, -earth_cells - 5, 11], [0.03; 3]).unwrap();
+        let frame = PlanetRenderFrame::new(planet, camera, 99);
+        let uniform = PlanetFrameUniform::from_render_frame(frame);
+        let left_page = PageKey::address_lod0_cell(0, frame.origin_lod0_cell())
+            .unwrap()
+            .0;
+        let right_page = PageKey::new(
+            0,
+            [
+                left_page.page_xyz[0] + 1,
+                left_page.page_xyz[1],
+                left_page.page_xyz[2],
+            ],
+        );
+        let boundary_inputs = [
+            GpuParityInput {
+                frame: uniform,
+                page: GpuPageMeta::new(left_page, frame.origin_lod0_cell(), 0, 1, 0).unwrap(),
+                local_lod0_cell: [32.0, 13.25, 6.75, 0.0],
+            },
+            GpuParityInput {
+                frame: uniform,
+                page: GpuPageMeta::new(right_page, frame.origin_lod0_cell(), 1, 1, 0).unwrap(),
+                local_lod0_cell: [0.0, 13.25, 6.75, 0.0],
+            },
+        ];
+        let boundary_outputs = dispatch(&device, &queue, &boundary_inputs);
+        assert_eq!(
+            boundary_outputs[0].camera_local_m, boundary_outputs[1].camera_local_m,
+            "adjacent pages must reconstruct their shared boundary bit-identically"
+        );
+    });
+}
+
+fn case(camera_cell: [i64; 3], point_delta_cell: [i64; 3]) -> Case {
+    let camera = PlanetPosition::new(camera_cell, [0.037, 0.081, 0.019]).unwrap();
+    let point_cell = [
+        camera_cell[0] + point_delta_cell[0],
+        camera_cell[1] + point_delta_cell[1],
+        camera_cell[2] + point_delta_cell[2],
+    ];
+    let point = PlanetPosition::new(point_cell, [0.092, 0.006, 0.071]).unwrap();
+    Case { camera, point }
+}
+
+fn dispatch(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    inputs: &[GpuParityInput],
+) -> Vec<GpuParityOutput> {
+    let shader_source = format!(
+        "{PLANET_VOXEL_LAYOUT_WGSL}\n{}",
+        r#"
+struct GpuParityInput {
+    frame: PlanetFrameUniform,
+    page: GpuPageMeta,
+    local_lod0_cell: vec4<f32>,
+}
+
+struct GpuParityOutput {
+    origin_x: vec2<u32>,
+    origin_y: vec2<u32>,
+    origin_z: vec2<u32>,
+    frame_index: vec2<u32>,
+    camera_local_m: vec4<f32>,
+}
+
+@group(0) @binding(0) var<storage, read> inputs: array<GpuParityInput>;
+@group(0) @binding(1) var<storage, read_write> outputs: array<GpuParityOutput>;
+
+@compute @workgroup_size(64)
+fn validate_planet_frame(@builtin(global_invocation_id) id: vec3<u32>) {
+    let index = id.x;
+    if (index >= arrayLength(&inputs)) {
+        return;
+    }
+    let input = inputs[index];
+    let local_m = planet_camera_local_position_m(
+        input.frame,
+        input.page,
+        input.local_lod0_cell.xyz,
+    );
+    outputs[index] = GpuParityOutput(
+        input.frame.origin_x,
+        input.frame.origin_y,
+        input.frame.origin_z,
+        input.frame.frame_index,
+        vec4<f32>(local_m, 0.0),
+    );
+}
+"#
+    );
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Planet Frame Parity Shader"),
+        source: wgpu::ShaderSource::Wgsl(shader_source.into()),
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("Planet Frame Parity Pipeline"),
+        layout: None,
+        module: &shader,
+        entry_point: Some("validate_planet_frame"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let input_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: Some("Planet Frame Parity Inputs"),
+        contents: bytemuck::cast_slice(inputs),
+        usage: wgpu::BufferUsages::STORAGE,
+    });
+    let output_size = (inputs.len() * core::mem::size_of::<GpuParityOutput>()) as u64;
+    let output_buffer = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planet Frame Parity Outputs"),
+        size: output_size,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Planet Frame Parity Bind Group"),
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: input_buffer.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: output_buffer.as_entire_binding(),
+            },
+        ],
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planet Frame Parity Encoder"),
+    });
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("Planet Frame Parity Dispatch"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.dispatch_workgroups((inputs.len() as u32).div_ceil(64), 1, 1);
+    }
+    queue.submit([encoder.finish()]);
+    read_buffer(device, queue, &output_buffer, output_size)
+}
+
+fn read_buffer<T: Pod + Copy>(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    source: &wgpu::Buffer,
+    size: u64,
+) -> Vec<T> {
+    let readback = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Planet Frame Parity Readback"),
+        size,
+        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+        mapped_at_creation: false,
+    });
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("Planet Frame Readback Encoder"),
+    });
+    encoder.copy_buffer_to_buffer(source, 0, &readback, 0, size);
+    queue.submit([encoder.finish()]);
+    let slice = readback.slice(..);
+    let (tx, rx) = mpsc::channel();
+    slice.map_async(wgpu::MapMode::Read, move |result| {
+        let _ = tx.send(result);
+    });
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    rx.recv()
+        .expect("GPU readback callback must run")
+        .expect("GPU readback mapping must succeed");
+    let mapped = slice
+        .get_mapped_range()
+        .expect("GPU readback range must be available");
+    let values = bytemuck::cast_slice::<u8, T>(&mapped).to_vec();
+    drop(mapped);
+    readback.unmap();
+    values
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}

--- a/docs/planetary_voxel_progress.md
+++ b/docs/planetary_voxel_progress.md
@@ -34,7 +34,7 @@ and `helio-voxel-core` remain unchanged regression baselines.
 
 - [x] Pulsar terrain component/subsystem and asynchronous work queues ([Pulsar-Native#327](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/327))
 - [x] Helio bounded GPU page atlas, hash table, upload, eviction, and device-loss recovery ([Helio#65](https://github.com/Far-Beyond-Pulsar/Helio/pull/65))
-- [ ] Earth-radius camera-local coordinates and precision validation ([issue #108](https://github.com/Far-Beyond-Pulsar/Helio/issues/108))
+- [x] Earth-radius camera-local coordinates and precision validation ([Helio#109](https://github.com/Far-Beyond-Pulsar/Helio/pull/109))
 - [ ] View-driven page demand, streaming, and strict CPU/GPU/VRAM budgets
 - [x] GPU Transvoxel versus manifold dual-contouring extraction bake-off ([Helio#107](https://github.com/Far-Beyond-Pulsar/Helio/pull/107))
 - [ ] Generation-safe bounded meshlet publication and indirect drawing

--- a/docs/planetary_voxel_progress.md
+++ b/docs/planetary_voxel_progress.md
@@ -1,6 +1,6 @@
 # Production planetary voxel terrain progress
 
-Status: active umbrella tracker, 2026-07-16
+Status: active umbrella tracker, 2026-07-19
 
 This document tracks the cross-repository implementation of the architecture in
 [`planetary_voxel_renderer_plan.md`](planetary_voxel_renderer_plan.md) and
@@ -23,18 +23,20 @@ and `helio-voxel-core` remain unchanged regression baselines.
 - [x] Helio bounded renderer-facing residency contract: [Helio#62](https://github.com/Far-Beyond-Pulsar/Helio/pull/62)
 - [x] Helio bounded GPU residency atlas and page table: [Helio#65](https://github.com/Far-Beyond-Pulsar/Helio/pull/65)
 - [x] Pulsar bounded terrain runtime subsystem and component: [Pulsar-Native#327](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/327)
+- [x] Helio bounded GPU manifold candidate and parity oracle: [Helio#106](https://github.com/Far-Beyond-Pulsar/Helio/pull/106)
+- [x] Matched extraction bake-off and GPU Transvoxel promotion: [Helio#107](https://github.com/Far-Beyond-Pulsar/Helio/pull/107)
 
 ## Active milestones
 
-- [ ] GPU Transvoxel versus manifold dual-contouring extraction bake-off: [issue #96](https://github.com/Far-Beyond-Pulsar/Helio/issues/96)
+- [ ] Earth-radius camera-local coordinates and precision validation: [issue #108](https://github.com/Far-Beyond-Pulsar/Helio/issues/108)
 
 ## Implementation milestones
 
 - [x] Pulsar terrain component/subsystem and asynchronous work queues ([Pulsar-Native#327](https://github.com/Far-Beyond-Pulsar/Pulsar-Native/pull/327))
 - [x] Helio bounded GPU page atlas, hash table, upload, eviction, and device-loss recovery ([Helio#65](https://github.com/Far-Beyond-Pulsar/Helio/pull/65))
-- [ ] Earth-radius camera-local coordinates and precision validation
+- [ ] Earth-radius camera-local coordinates and precision validation ([issue #108](https://github.com/Far-Beyond-Pulsar/Helio/issues/108))
 - [ ] View-driven page demand, streaming, and strict CPU/GPU/VRAM budgets
-- [ ] GPU Transvoxel versus manifold dual-contouring extraction bake-off ([issue #96](https://github.com/Far-Beyond-Pulsar/Helio/issues/96))
+- [x] GPU Transvoxel versus manifold dual-contouring extraction bake-off ([Helio#107](https://github.com/Far-Beyond-Pulsar/Helio/pull/107))
 - [ ] Generation-safe bounded meshlet publication and indirect drawing
 - [ ] Crack-free LOD selection, transition topology, and horizon-scale coverage
 - [ ] Exact hierarchical destruction, compaction, snapshots, and recovery


### PR DESCRIPTION
## Summary
- add canonical signed LOD0-cell plus normalized sub-cell planet positions
- derive page-snapped render origins and GPU frame uniforms from the canonical camera
- reconstruct only checked camera-local coordinates in WGSL and remove arbitrary origin/offset pairing
- add CPU/GPU precision, negative-coordinate, rebase, interaction-radius, and adjacent-boundary validation
- refresh the planetary progress tracker after the extraction promotion

## Validation
- `cargo test -p helio-planet-voxel-core`
- `cargo test -p helio-pass-planetary-voxel`
- `cargo clippy -p helio-planet-voxel-core -p helio-pass-planetary-voxel --all-targets -- -D warnings`
- `cargo test -p helio-default-graphs`
- `cargo check -p helio --lib`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch`
- RTX 3060 Vulkan GPU parity: maximum measured error `0.000078125 m` (0.078125 mm), including the 8.192 km interaction bound
- adjacent pages reconstruct their shared boundary bit-identically on CPU and GPU

Planet-only implementation targeting the planetary umbrella branch. No shared Helio camera, transform, graph, or retained voxel-demo code changed.

Tracks #108.