### PR TITLE
Preserve full source generations in planetary residency

### DIFF
--- a/crates/helio-pass-planetary-voxel/src/gpu.rs
+++ b/crates/helio-pass-planetary-voxel/src/gpu.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 use helio_planet_voxel_core::{
     AddressError, CellWord, ContractError, EvictOutcome, GpuPageMeta, GpuPageMetaError, PageEvict,
-    PageUpload, PlanetFrameUniform, PlanetId, PlanetPageKey, ResidentPageCache, UploadOutcome,
-    VisibilityOutcome, VisiblePageSet, PAGE_CELL_BYTES, PAGE_CELL_COUNT,
+    PageUpload, PlanetFrameUniform, PlanetId, PlanetPageKey, ResidentPageCache, SourceGeneration,
+    UploadOutcome, VisibilityOutcome, VisiblePageSet, PAGE_CELL_BYTES, PAGE_CELL_COUNT,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -35,7 +35,7 @@ pub struct PlanetaryVoxelResidency {
     plan: GpuAllocationPlan,
     cache: ResidentPageCache,
     frames: BTreeMap<PlanetId, PlanetFrameUniform>,
-    visible: BTreeMap<PlanetPageKey, (u64, u8)>,
+    visible: BTreeMap<PlanetPageKey, (SourceGeneration, u8)>,
     table: PageTable,
     published_table: Vec<GpuPageTableEntry>,
     published_metadata: Vec<GpuPageMeta>,
@@ -203,7 +203,9 @@ impl PlanetaryVoxelResidency {
         for (upload, lookup_key) in uploads.into_iter().zip(lookup_keys) {
             let page_key = upload.key;
             let mut candidate_table = self.table.clone();
-            let placeholder = GpuPageTableEntry::occupied(lookup_key, 0, upload.generation);
+            // Capacity probing does not publish this placeholder. The real
+            // entry below receives the cache-assigned renderer-local token.
+            let placeholder = GpuPageTableEntry::occupied(lookup_key, 0, 0);
             if candidate_table.insert(placeholder).is_err() {
                 candidate_table.compact()?;
                 if candidate_table.insert(placeholder).is_err() {
@@ -228,7 +230,7 @@ impl PlanetaryVoxelResidency {
                         *slot,
                         self.cache
                             .resident(page_key)
-                            .map(|page| page.generation)
+                            .map(|page| page.publication_generation)
                             .ok_or(GpuResidencyError::ResidentPageMissing)?,
                     ))?;
                     dirty_slots.insert(*slot);
@@ -237,13 +239,16 @@ impl PlanetaryVoxelResidency {
                         self.counters.uploads_published.saturating_add(1);
                 }
                 UploadOutcome::Replaced { slot, .. } => {
-                    let generation = self
+                    let publication_generation = self
                         .cache
                         .resident(page_key)
-                        .map(|page| page.generation)
+                        .map(|page| page.publication_generation)
                         .ok_or(GpuResidencyError::ResidentPageMissing)?;
-                    candidate_table
-                        .insert(GpuPageTableEntry::occupied(lookup_key, *slot, generation))?;
+                    candidate_table.insert(GpuPageTableEntry::occupied(
+                        lookup_key,
+                        *slot,
+                        publication_generation,
+                    ))?;
                     dirty_slots.insert(*slot);
                     self.table = candidate_table;
                     self.counters.uploads_published =
@@ -351,7 +356,7 @@ impl PlanetaryVoxelResidency {
     pub fn retire_eviction_watermark(
         &mut self,
         key: PlanetPageKey,
-        through_generation: u64,
+        through_generation: SourceGeneration,
     ) -> bool {
         self.cache
             .retire_eviction_watermark(key, through_generation)
@@ -427,7 +432,7 @@ impl PlanetaryVoxelResidency {
             table.insert(GpuPageTableEntry::occupied(
                 lookup,
                 page.slot,
-                page.generation,
+                page.publication_generation,
             ))?;
         }
         Ok(table)
@@ -451,7 +456,7 @@ impl PlanetaryVoxelResidency {
                 key.page,
                 frame.frame_origin_lod0_cell(),
                 page.slot,
-                page.generation,
+                page.publication_generation,
                 transition_mask,
             )?;
         }

--- a/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
+++ b/crates/helio-pass-planetary-voxel/tests/gpu_residency.rs
@@ -6,8 +6,8 @@ use helio_pass_planetary_voxel::{
 };
 use helio_planet_voxel_core::{
     CellWord, EvictOutcome, GpuPageMeta, PageEvict, PageKey, PageUpload, PlanetFrameUniform,
-    PlanetId, PlanetPageKey, PlanetPosition, UploadOutcome, VisiblePage, VisiblePageSet,
-    PAGE_CELL_BYTES, PAGE_CELL_COUNT,
+    PlanetId, PlanetPageKey, PlanetPosition, SourceGeneration, UploadOutcome, VisiblePage,
+    VisiblePageSet, PAGE_CELL_BYTES, PAGE_CELL_COUNT,
 };
 use std::sync::mpsc;
 use wgpu::util::DeviceExt;
@@ -97,8 +97,8 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
                 .unwrap()
                 .as_slice(),
             [GpuUploadOutcome::Residency(UploadOutcome::Stale {
-                newest_generation: 9
-            })]
+                newest_generation
+            })] if *newest_generation == source(9)
         ));
         assert_eq!(
             residency
@@ -107,13 +107,16 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
                     &queue,
                     vec![PageEvict {
                         key: key_a,
-                        generation: 8,
+                        generation: source(8),
                     }],
                 )
                 .unwrap(),
             vec![EvictOutcome::Recorded { removed: None }]
         );
-        assert_eq!(residency.cache().resident(key_a).unwrap().generation, 9);
+        assert_eq!(
+            residency.cache().resident(key_a).unwrap().generation,
+            source(9)
+        );
 
         assert!(matches!(
             residency.apply_upload_batch(
@@ -179,7 +182,7 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
                     frame_index: 3,
                     pages: vec![VisiblePage {
                         key: key_a,
-                        generation: 9,
+                        generation: source(9),
                         transition_mask: 0b10_0101,
                     }],
                 },
@@ -202,10 +205,10 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
         let results = dispatch_lookup(&device, &queue, &residency, &queries);
         assert!(results[0].found());
         assert_eq!(results[0].slot, 0);
-        assert_eq!(results[0].generation(), 9);
+        assert_eq!(results[0].generation(), 1);
         assert!(results[1].found());
         assert_eq!(results[1].slot, 1);
-        assert_eq!(results[1].generation(), 11);
+        assert_eq!(results[1].generation(), 2);
         assert!(!results[2].found());
 
         let first_cell: Vec<CellWord> = read_buffer_range(
@@ -224,7 +227,7 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
             size_of::<GpuPageMeta>() as u64,
         );
         assert_eq!(metadata[0].slot, 0);
-        assert_eq!(metadata[0].generation(), 9);
+        assert_eq!(metadata[0].generation(), 1);
         assert_eq!(metadata[0].relative_lod0_cell_min, [-96, 32, -96]);
         assert_eq!(metadata[0].transition_mask, 0b10_0101);
         let counters: Vec<GpuResidencyCounters> = read_buffer_range(
@@ -264,7 +267,7 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
                     &queue,
                     vec![PageEvict {
                         key: key_a,
-                        generation: 9,
+                        generation: source(9),
                     }],
                 )
                 .unwrap()
@@ -289,8 +292,8 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
                 .unwrap()
                 .as_slice(),
             [GpuUploadOutcome::Residency(UploadOutcome::Stale {
-                newest_generation: 9
-            })]
+                newest_generation
+            })] if *newest_generation == source(9)
         ));
         assert!(matches!(
             residency
@@ -313,7 +316,7 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
         ));
         let replacement_result = dispatch_lookup(&device, &queue, &residency, &queries[..1]);
         assert!(replacement_result[0].found());
-        assert_eq!(replacement_result[0].generation(), 10);
+        assert_eq!(replacement_result[0].generation(), 3);
         let replacement_cell: Vec<CellWord> = read_buffer_range(
             &device,
             &queue,
@@ -322,6 +325,53 @@ fn headless_residency_round_trips_cells_metadata_lookup_and_rebuild() {
             size_of::<CellWord>() as u64,
         );
         assert_eq!(replacement_cell, vec![replacement]);
+
+        let replacement_planet_cell = CellWord::new(-900, 44, 6);
+        assert!(matches!(
+            residency
+                .apply_upload_batch(
+                    &device,
+                    &queue,
+                    vec![PageUpload::new(
+                        key_a,
+                        SourceGeneration::new(2, 0),
+                        vec![replacement_planet_cell; PAGE_CELL_COUNT],
+                    )
+                    .unwrap()],
+                )
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(UploadOutcome::Replaced { .. })]
+        ));
+        assert!(matches!(
+            residency
+                .apply_upload_batch(
+                    &device,
+                    &queue,
+                    vec![PageUpload::new(
+                        key_a,
+                        SourceGeneration::new(1, u64::MAX),
+                        vec![CellWord::AIR; PAGE_CELL_COUNT],
+                    )
+                    .unwrap()],
+                )
+                .unwrap()
+                .as_slice(),
+            [GpuUploadOutcome::Residency(UploadOutcome::Stale {
+                newest_generation
+            })] if *newest_generation == SourceGeneration::new(2, 0)
+        ));
+        let replacement_planet_result = dispatch_lookup(&device, &queue, &residency, &queries[..1]);
+        assert!(replacement_planet_result[0].found());
+        assert_eq!(replacement_planet_result[0].generation(), 4);
+        let replacement_planet_readback: Vec<CellWord> = read_buffer_range(
+            &device,
+            &queue,
+            residency.atlas_buffers().next().unwrap(),
+            0,
+            size_of::<CellWord>() as u64,
+        );
+        assert_eq!(replacement_planet_readback, vec![replacement_planet_cell]);
 
         validate_table_probe_backpressure(&device, &queue, planet_a);
     });
@@ -383,7 +433,11 @@ async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter
 }
 
 fn upload(key: PlanetPageKey, generation: u64, cell: CellWord) -> PageUpload {
-    PageUpload::new(key, generation, vec![cell; PAGE_CELL_COUNT]).unwrap()
+    PageUpload::new(key, source(generation), vec![cell; PAGE_CELL_COUNT]).unwrap()
+}
+
+const fn source(page: u64) -> SourceGeneration {
+    SourceGeneration::new(1, page)
 }
 
 fn dispatch_lookup(

--- a/crates/helio-planet-voxel-core/src/cache.rs
+++ b/crates/helio-planet-voxel-core/src/cache.rs
@@ -1,5 +1,6 @@
 use crate::{
-    CellWord, ContractError, PageEvict, PageUpload, PlanetPageKey, VisiblePageSet, PAGE_CELL_BYTES,
+    CellWord, ContractError, PageEvict, PageUpload, PlanetPageKey, SourceGeneration,
+    VisiblePageSet, PAGE_CELL_BYTES,
 };
 use std::collections::BTreeMap;
 
@@ -51,7 +52,10 @@ pub enum ResidencyConfigError {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResidentPage {
     pub slot: u32,
-    pub generation: u64,
+    pub generation: SourceGeneration,
+    /// Monotonic token local to this cache lifetime. GPU work uses this token
+    /// instead of attempting to pack the two authoritative source generations.
+    pub publication_generation: u64,
     pub cells: Box<[CellWord]>,
     last_access: u64,
 }
@@ -60,7 +64,8 @@ pub struct ResidentPage {
 pub struct EvictedPage {
     pub key: PlanetPageKey,
     pub slot: u32,
-    pub generation: u64,
+    pub generation: SourceGeneration,
+    pub publication_generation: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -71,13 +76,13 @@ pub enum UploadOutcome {
     },
     Replaced {
         slot: u32,
-        previous_generation: u64,
+        previous_generation: SourceGeneration,
     },
     Duplicate {
         slot: u32,
     },
     Stale {
-        newest_generation: u64,
+        newest_generation: SourceGeneration,
     },
     GenerationConflict {
         slot: u32,
@@ -95,7 +100,7 @@ pub enum BackpressureReason {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum EvictOutcome {
     Recorded { removed: Option<EvictedPage> },
-    Stale { newest_generation: u64 },
+    Stale { newest_generation: SourceGeneration },
     Backpressure(BackpressureReason),
 }
 
@@ -135,10 +140,11 @@ pub struct ResidentPageCache {
     config: ResidencyConfig,
     occupied_slots: BTreeMap<u32, PlanetPageKey>,
     pages: BTreeMap<PlanetPageKey, ResidentPage>,
-    eviction_watermarks: BTreeMap<PlanetPageKey, u64>,
-    visible: BTreeMap<PlanetPageKey, (u64, u8)>,
+    eviction_watermarks: BTreeMap<PlanetPageKey, SourceGeneration>,
+    visible: BTreeMap<PlanetPageKey, (SourceGeneration, u8)>,
     last_visible_frame: Option<u64>,
     access_clock: u64,
+    publication_clock: u64,
     counters: ResidencyCounters,
 }
 
@@ -152,6 +158,7 @@ impl ResidentPageCache {
             visible: BTreeMap::new(),
             last_visible_frame: None,
             access_clock: 0,
+            publication_clock: 0,
             counters: ResidencyCounters::default(),
         }
     }
@@ -174,7 +181,7 @@ impl ResidentPageCache {
         self.pages.iter().map(|(key, page)| (*key, page))
     }
 
-    pub fn eviction_watermark(&self, key: PlanetPageKey) -> Option<u64> {
+    pub fn eviction_watermark(&self, key: PlanetPageKey) -> Option<SourceGeneration> {
         self.eviction_watermarks.get(&key).copied()
     }
 
@@ -210,6 +217,7 @@ impl ResidentPageCache {
                 return Ok(UploadOutcome::GenerationConflict { slot });
             }
 
+            let publication_generation = self.next_publication_generation()?;
             let access = self.next_access();
             let existing = self
                 .pages
@@ -218,6 +226,7 @@ impl ResidentPageCache {
             let previous_generation = existing.generation;
             let slot = existing.slot;
             existing.generation = upload.generation;
+            existing.publication_generation = publication_generation;
             existing.cells = upload.cells;
             existing.last_access = access;
             self.counters.uploads_replaced += 1;
@@ -262,6 +271,7 @@ impl ResidentPageCache {
             ));
         }
 
+        let publication_generation = self.next_publication_generation()?;
         let mut evicted = Vec::with_capacity(eviction_count);
         for (_, key) in candidates.into_iter().take(eviction_count) {
             evicted.push(self.remove_resident(key));
@@ -278,6 +288,7 @@ impl ResidentPageCache {
             ResidentPage {
                 slot,
                 generation: upload.generation,
+                publication_generation,
                 cells: upload.cells,
                 last_access: access,
             },
@@ -324,7 +335,7 @@ impl ResidentPageCache {
     pub fn retire_eviction_watermark(
         &mut self,
         key: PlanetPageKey,
-        through_generation: u64,
+        through_generation: SourceGeneration,
     ) -> bool {
         let can_retire = self
             .eviction_watermarks
@@ -387,7 +398,7 @@ impl ResidentPageCache {
         })
     }
 
-    fn is_visible(&self, key: PlanetPageKey, generation: u64) -> bool {
+    fn is_visible(&self, key: PlanetPageKey, generation: SourceGeneration) -> bool {
         self.visible
             .get(&key)
             .is_some_and(|(visible_generation, _)| *visible_generation == generation)
@@ -396,6 +407,14 @@ impl ResidentPageCache {
     fn next_access(&mut self) -> u64 {
         self.access_clock = self.access_clock.saturating_add(1);
         self.access_clock
+    }
+
+    fn next_publication_generation(&mut self) -> Result<u64, ContractError> {
+        self.publication_clock = self
+            .publication_clock
+            .checked_add(1)
+            .ok_or(ContractError::PublicationGenerationOverflow)?;
+        Ok(self.publication_clock)
     }
 
     fn remove_resident(&mut self, key: PlanetPageKey) -> EvictedPage {
@@ -409,6 +428,7 @@ impl ResidentPageCache {
             key,
             slot: page.slot,
             generation: page.generation,
+            publication_generation: page.publication_generation,
         }
     }
 
@@ -436,8 +456,17 @@ mod tests {
         PlanetPageKey::new(PlanetId([1; 16]), PageKey::new(0, [index, 0, 0]))
     }
 
+    const fn generation(page: u64) -> SourceGeneration {
+        SourceGeneration::new(1, page)
+    }
+
     fn upload(index: i64, generation: u64, cell: CellWord) -> PageUpload {
-        PageUpload::new(key(index), generation, vec![cell; crate::PAGE_CELL_COUNT]).unwrap()
+        PageUpload::new(
+            key(index),
+            self::generation(generation),
+            vec![cell; crate::PAGE_CELL_COUNT],
+        )
+        .unwrap()
     }
 
     fn cache(pages: usize, byte_pages: usize, watermarks: usize) -> ResidentPageCache {
@@ -478,7 +507,8 @@ mod tests {
                 evicted: vec![EvictedPage {
                     key: key(1),
                     slot: 0,
-                    generation: 1,
+                    generation: generation(1),
+                    publication_generation: 1,
                 }],
             }
         );
@@ -495,7 +525,7 @@ mod tests {
                 frame_index: 1,
                 pages: vec![VisiblePage {
                     key: key(1),
-                    generation: 4,
+                    generation: generation(4),
                     transition_mask: 0,
                 }],
             })
@@ -516,7 +546,7 @@ mod tests {
                     frame_index: 1,
                     pages: vec![VisiblePage {
                         key: key(1),
-                        generation: 4,
+                        generation: generation(4),
                         transition_mask: 0,
                     }],
                 })
@@ -559,13 +589,97 @@ mod tests {
     }
 
     #[test]
+    fn replacement_planet_generation_dominates_retired_page_counters() {
+        let mut cache = cache(1, 1, 2);
+        cache
+            .apply_upload(
+                PageUpload::new(
+                    key(0),
+                    SourceGeneration::new(1, u64::MAX),
+                    vec![CellWord::AIR; crate::PAGE_CELL_COUNT],
+                )
+                .unwrap(),
+            )
+            .unwrap();
+        assert_eq!(cache.resident(key(0)).unwrap().publication_generation, 1);
+
+        assert!(matches!(
+            cache
+                .apply_upload(
+                    PageUpload::new(
+                        key(0),
+                        SourceGeneration::new(2, 0),
+                        vec![CellWord::new(-1, 7, 0); crate::PAGE_CELL_COUNT],
+                    )
+                    .unwrap()
+                )
+                .unwrap(),
+            UploadOutcome::Replaced { .. }
+        ));
+        let replacement = cache.resident(key(0)).unwrap();
+        assert_eq!(replacement.generation, SourceGeneration::new(2, 0));
+        assert_eq!(replacement.publication_generation, 2);
+
+        assert_eq!(
+            cache
+                .apply_upload(
+                    PageUpload::new(
+                        key(0),
+                        SourceGeneration::new(1, u64::MAX),
+                        vec![CellWord::AIR; crate::PAGE_CELL_COUNT],
+                    )
+                    .unwrap()
+                )
+                .unwrap(),
+            UploadOutcome::Stale {
+                newest_generation: SourceGeneration::new(2, 0),
+            }
+        );
+        assert_eq!(
+            cache
+                .apply_evict(PageEvict {
+                    key: key(0),
+                    generation: SourceGeneration::new(1, u64::MAX),
+                })
+                .unwrap(),
+            EvictOutcome::Recorded { removed: None }
+        );
+        assert_eq!(
+            cache.resident(key(0)).unwrap().generation,
+            SourceGeneration::new(2, 0)
+        );
+    }
+
+    #[test]
+    fn duplicates_reuse_and_changed_sources_advance_publication_generation() {
+        let mut cache = cache(1, 1, 1);
+        cache.apply_upload(upload(0, 1, CellWord::AIR)).unwrap();
+        let first = cache.resident(key(0)).unwrap().publication_generation;
+        assert!(matches!(
+            cache.apply_upload(upload(0, 1, CellWord::AIR)).unwrap(),
+            UploadOutcome::Duplicate { .. }
+        ));
+        assert_eq!(
+            cache.resident(key(0)).unwrap().publication_generation,
+            first
+        );
+        cache
+            .apply_upload(upload(0, 2, CellWord::new(-1, 1, 0)))
+            .unwrap();
+        assert_eq!(
+            cache.resident(key(0)).unwrap().publication_generation,
+            first + 1
+        );
+    }
+
+    #[test]
     fn eviction_before_upload_blocks_late_generation() {
         let mut cache = cache(1, 1, 1);
         assert_eq!(
             cache
                 .apply_evict(PageEvict {
                     key: key(7),
-                    generation: 9,
+                    generation: generation(9),
                 })
                 .unwrap(),
             EvictOutcome::Recorded { removed: None }
@@ -573,7 +687,7 @@ mod tests {
         assert_eq!(
             cache.apply_upload(upload(7, 9, CellWord::AIR)).unwrap(),
             UploadOutcome::Stale {
-                newest_generation: 9,
+                newest_generation: generation(9),
             }
         );
         assert!(matches!(
@@ -590,22 +704,22 @@ mod tests {
             cache
                 .apply_evict(PageEvict {
                     key: key(1),
-                    generation: 9,
+                    generation: generation(9),
                 })
                 .unwrap(),
             EvictOutcome::Recorded { removed: None }
         );
-        assert_eq!(cache.resident(key(1)).unwrap().generation, 10);
+        assert_eq!(cache.resident(key(1)).unwrap().generation, generation(10));
         assert!(matches!(
             cache
                 .apply_evict(PageEvict {
                     key: key(1),
-                    generation: 10,
+                    generation: generation(10),
                 })
                 .unwrap(),
             EvictOutcome::Recorded {
-                removed: Some(EvictedPage { generation: 10, .. })
-            }
+                removed: Some(EvictedPage { generation: value, .. })
+            } if value == generation(10)
         ));
         assert!(cache.resident(key(1)).is_none());
     }
@@ -628,25 +742,25 @@ mod tests {
         cache
             .apply_evict(PageEvict {
                 key: key(1),
-                generation: 2,
+                generation: generation(2),
             })
             .unwrap();
         assert_eq!(
             cache
                 .apply_evict(PageEvict {
                     key: key(2),
-                    generation: 1,
+                    generation: generation(1),
                 })
                 .unwrap(),
             EvictOutcome::Backpressure(BackpressureReason::EvictionWatermarkCapacity)
         );
-        assert!(!cache.retire_eviction_watermark(key(1), 1));
-        assert!(cache.retire_eviction_watermark(key(1), 2));
+        assert!(!cache.retire_eviction_watermark(key(1), generation(1)));
+        assert!(cache.retire_eviction_watermark(key(1), generation(2)));
         assert!(matches!(
             cache
                 .apply_evict(PageEvict {
                     key: key(2),
-                    generation: 1,
+                    generation: generation(1),
                 })
                 .unwrap(),
             EvictOutcome::Recorded { .. }
@@ -659,7 +773,7 @@ mod tests {
         let mut cache = cache(2, 2, 1);
         let page = VisiblePage {
             key: key(0),
-            generation: 1,
+            generation: generation(1),
             transition_mask: 0,
         };
         let set = VisiblePageSet {

--- a/crates/helio-planet-voxel-core/src/contract.rs
+++ b/crates/helio-planet-voxel-core/src/contract.rs
@@ -3,17 +3,35 @@ use crate::{
 };
 use std::collections::BTreeSet;
 
+/// Authoritative source generation for one planetary page.
+///
+/// Planet generations order complete replacements that reuse a stable
+/// [`PlanetId`]. Page generations order rebuilds within that planet instance.
+/// Keeping both values prevents a late page from a retired instance from
+/// colliding with a replacement whose page counter restarted.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SourceGeneration {
+    pub planet: u64,
+    pub page: u64,
+}
+
+impl SourceGeneration {
+    pub const fn new(planet: u64, page: u64) -> Self {
+        Self { planet, page }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PageUpload {
     pub key: PlanetPageKey,
-    pub generation: u64,
+    pub generation: SourceGeneration,
     pub cells: Box<[CellWord]>,
 }
 
 impl PageUpload {
     pub fn new(
         key: PlanetPageKey,
-        generation: u64,
+        generation: SourceGeneration,
         cells: Vec<CellWord>,
     ) -> Result<Self, ContractError> {
         let upload = Self {
@@ -37,7 +55,7 @@ impl PageUpload {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct PageEvict {
     pub key: PlanetPageKey,
-    pub generation: u64,
+    pub generation: SourceGeneration,
 }
 
 impl PageEvict {
@@ -50,7 +68,7 @@ impl PageEvict {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct VisiblePage {
     pub key: PlanetPageKey,
-    pub generation: u64,
+    pub generation: SourceGeneration,
     pub transition_mask: u8,
 }
 
@@ -134,6 +152,8 @@ pub enum ContractError {
     PaletteRange,
     #[error("material palette delta contains a non-finite value")]
     NonFiniteMaterial,
+    #[error("planetary renderer-local publication generation overflowed")]
+    PublicationGenerationOverflow,
 }
 
 #[cfg(test)]
@@ -148,7 +168,7 @@ mod tests {
     #[test]
     fn page_upload_requires_one_complete_page() {
         assert_eq!(
-            PageUpload::new(key(0), 0, vec![CellWord::AIR; 3]),
+            PageUpload::new(key(0), SourceGeneration::new(1, 0), vec![CellWord::AIR; 3],),
             Err(ContractError::CellCount(3))
         );
     }
@@ -157,7 +177,7 @@ mod tests {
     fn visible_sets_reject_duplicate_keys_and_invalid_face_bits() {
         let page = VisiblePage {
             key: key(0),
-            generation: 1,
+            generation: SourceGeneration::new(1, 1),
             transition_mask: 0,
         };
         assert_eq!(


### PR DESCRIPTION
## Summary
- preserve the authoritative `(planet_generation, page_generation)` pair in planetary uploads, evictions, visibility, residents, and watermarks
- compare the full pair lexicographically so replacement planets dominate all retired page counters
- assign a separate monotonic cache-local publication generation to changed pages for compact GPU metadata and extraction jobs
- retain publication tokens for exact duplicates and advance them only for accepted changed source state

## Why
Pulsar can replace a planet while keeping its stable `PlanetId`, resetting per-page generations. A single source `u64` cannot represent both counters without truncation or collision. The renderer-local token keeps GPU work compact without losing source identity on the CPU boundary.

## Validation
- `cargo test -p helio-planet-voxel-core -p helio-pass-planetary-voxel --no-fail-fast`
- `cargo clippy -p helio-planet-voxel-core -p helio-pass-planetary-voxel --all-targets --no-deps -- -D warnings`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch`
- `cargo metadata --locked --no-deps`
- `git diff --check`

The CPU and headless GPU suites include an adversarial replacement from `(planet 1, page u64::MAX)` to `(planet 2, page 0)`, followed by a late old-instance upload.

Closes #115