### PR TITLE
Expose non-blocking render graph timings

### DIFF
--- a/crates/helio-core/src/graph/execution.rs
+++ b/crates/helio-core/src/graph/execution.rs
@@ -346,6 +346,12 @@ impl RenderGraph {
     ) -> Result<()> {
         assert!(self.locked, "RenderGraph::execute() requires lock() to be called first");
 
+        // External device owners drive wgpu polling. Consume callbacks from
+        // that host cadence before reserving a bounded readback slot for this
+        // frame; this never polls or waits.
+        if !self.owns_device {
+            self.profiler.read_gpu_timestamps_deferred();
+        }
         self.profiler.clear_cpu_timings();
 
         let mut encoder = scene
@@ -603,7 +609,8 @@ impl RenderGraph {
             pass.publish(&mut visible_frame_resources);
         }
 
-        self.profiler.resolve_gpu_queries(&mut compute_encoder);
+        self.profiler
+            .resolve_gpu_queries(&mut compute_encoder, self.frame_count);
         scene.queue.submit([compute_encoder.finish(), encoder.finish()]);
         crate::upload::finish_frame();
 
@@ -612,6 +619,10 @@ impl RenderGraph {
         } else {
             self.profiler.read_gpu_timestamps_deferred();
         }
+        self.profiler.update_snapshot(
+            self.frame_count,
+            self.passes.iter().map(|pass| pass.name()),
+        );
 
         self.frame_count += 1;
 

--- a/crates/helio-core/src/lib.rs
+++ b/crates/helio-core/src/lib.rs
@@ -400,6 +400,6 @@ pub use context::{PassContext, PrepareContext};
 pub use entity::Entity;
 pub use error::{Error, Result};
 pub use graph::{DebugPassInfo, DebugResourceInfo, FrameDebugData, RenderGraph};
-pub use profiling::Profiler;
+pub use profiling::{GpuTimingAvailability, Profiler, RenderPassTiming, RenderTimingSnapshot};
 pub use scene::{GpuScene, SceneResources};
 pub use traits::{AsAny, DebugViewDescriptor, MaybeSend, MaybeSync, RenderPass};

--- a/crates/helio-core/src/profiling/gpu.rs
+++ b/crates/helio-core/src/profiling/gpu.rs
@@ -71,15 +71,39 @@
 /// // GPU commands...
 /// profiler.end_pass(&mut encoder, "ShadowPass");
 /// ```
-use std::collections::VecDeque;
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Mutex},
+};
+
+const QUERY_CAPACITY: u32 = 256;
+const READBACK_SLOT_COUNT: usize = 3;
+
+type QueryRange = (&'static str, u32, u32);
+
+enum ReadbackState {
+    Idle,
+    CopySubmitted,
+    Mapping(Arc<Mutex<Option<Result<(), wgpu::BufferAsyncError>>>>),
+}
+
+struct ReadbackSlot {
+    buffer: wgpu::Buffer,
+    state: ReadbackState,
+    queries: Vec<QueryRange>,
+    frame_index: u64,
+}
 
 pub struct GpuProfiler {
     query_set: Option<wgpu::QuerySet>,
     query_buffer: Option<wgpu::Buffer>,
-    resolve_buffer: Option<wgpu::Buffer>,
-    pending_queries: VecDeque<(&'static str, u32, u32)>, // (name, start_index, end_index)
+    readback_slots: Vec<ReadbackSlot>,
+    pending_queries: VecDeque<QueryRange>,
     next_index: u32,
     last_timings: Vec<GpuTimestamp>,
+    last_completed_frame: Option<u64>,
+    dropped_readbacks: u64,
+    query_overflows: u64,
     timestamp_period: f32, // Nanoseconds per timestamp tick
 }
 
@@ -108,13 +132,15 @@ impl GpuProfiler {
         // TIMESTAMP_QUERY_INSIDE_ENCODERS.  WebGPU browsers typically support neither;
         // guard both so we never call write_timestamp on an unsupported backend.
         let has_timestamps = device.features().contains(wgpu::Features::TIMESTAMP_QUERY)
-            && device.features().contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS);
+            && device
+                .features()
+                .contains(wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS);
 
         let query_set = if has_timestamps {
             Some(device.create_query_set(&wgpu::QuerySetDescriptor {
                 label: Some("GPU Profiler QuerySet"),
                 ty: wgpu::QueryType::Timestamp,
-                count: 256, // 128 passes * 2 timestamps per pass
+                count: QUERY_CAPACITY, // 128 passes * 2 timestamps per pass
             }))
         } else {
             None
@@ -123,7 +149,7 @@ impl GpuProfiler {
         let query_buffer = if has_timestamps {
             Some(device.create_buffer(&wgpu::BufferDescriptor {
                 label: Some("GPU Profiler Query Buffer"),
-                size: 256 * 8, // 256 timestamps * 8 bytes each
+                size: u64::from(QUERY_CAPACITY) * 8,
                 usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
                 mapped_at_creation: false,
             }))
@@ -131,15 +157,22 @@ impl GpuProfiler {
             None
         };
 
-        let resolve_buffer = if has_timestamps {
-            Some(device.create_buffer(&wgpu::BufferDescriptor {
-                label: Some("GPU Profiler Resolve Buffer"),
-                size: 256 * 8,
-                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
-                mapped_at_creation: false,
-            }))
+        let readback_slots = if has_timestamps {
+            (0..READBACK_SLOT_COUNT)
+                .map(|index| ReadbackSlot {
+                    buffer: device.create_buffer(&wgpu::BufferDescriptor {
+                        label: Some(&format!("GPU Profiler Readback Slot {index}")),
+                        size: u64::from(QUERY_CAPACITY) * 8,
+                        usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                        mapped_at_creation: false,
+                    }),
+                    state: ReadbackState::Idle,
+                    queries: Vec::with_capacity((QUERY_CAPACITY / 2) as usize),
+                    frame_index: 0,
+                })
+                .collect()
         } else {
-            None
+            Vec::new()
         };
 
         // Get timestamp period for converting ticks to nanoseconds
@@ -148,10 +181,13 @@ impl GpuProfiler {
         Self {
             query_set,
             query_buffer,
-            resolve_buffer,
+            readback_slots,
             pending_queries: VecDeque::new(),
             next_index: 0,
             last_timings: Vec::new(),
+            last_completed_frame: None,
+            dropped_readbacks: 0,
+            query_overflows: 0,
             timestamp_period,
         }
     }
@@ -180,6 +216,10 @@ impl GpuProfiler {
     /// ```
     pub fn begin_pass(&mut self, encoder: &mut wgpu::CommandEncoder, name: &'static str) {
         if let Some(ref query_set) = self.query_set {
+            if self.next_index + 1 >= QUERY_CAPACITY {
+                self.query_overflows = self.query_overflows.saturating_add(1);
+                return;
+            }
             let start_index = self.next_index;
             self.next_index += 1;
             encoder.write_timestamp(query_set, start_index);
@@ -212,6 +252,12 @@ impl GpuProfiler {
     /// ```
     pub fn end_pass(&mut self, encoder: &mut wgpu::CommandEncoder, _name: &'static str) {
         if let Some(ref query_set) = self.query_set {
+            let Some((_, _, end_index)) = self.pending_queries.back() else {
+                return;
+            };
+            if *end_index != 0 || self.next_index >= QUERY_CAPACITY {
+                return;
+            }
             let end_index = self.next_index;
             self.next_index += 1;
             encoder.write_timestamp(query_set, end_index);
@@ -223,22 +269,44 @@ impl GpuProfiler {
         }
     }
 
-    /// Resolve query set to buffer (call after frame submit)
-    pub fn resolve_queries(&mut self, encoder: &mut wgpu::CommandEncoder) {
-        if let (Some(ref query_set), Some(ref query_buffer)) = (&self.query_set, &self.query_buffer) {
-            if self.next_index > 0 {
-                encoder.resolve_query_set(query_set, 0..self.next_index, query_buffer, 0);
-            }
+    /// Resolves this frame into an idle readback slot without waiting for the
+    /// GPU. If all slots are still in flight, the sample is explicitly
+    /// dropped rather than stalling or reusing a mapped buffer.
+    pub fn resolve_queries(&mut self, encoder: &mut wgpu::CommandEncoder, frame_index: u64) {
+        if self.next_index == 0 {
+            self.pending_queries.clear();
+            return;
         }
-    }
+        let (Some(query_set), Some(query_buffer)) = (&self.query_set, &self.query_buffer) else {
+            self.pending_queries.clear();
+            self.next_index = 0;
+            return;
+        };
 
-    /// Copy resolved queries to CPU-readable buffer
-    pub fn copy_to_resolve_buffer(&mut self, encoder: &mut wgpu::CommandEncoder) {
-        if let (Some(ref query_buffer), Some(ref resolve_buffer)) = (&self.query_buffer, &self.resolve_buffer) {
-            if self.next_index > 0 {
-                encoder.copy_buffer_to_buffer(query_buffer, 0, resolve_buffer, 0, (self.next_index as u64) * 8);
-            }
-        }
+        encoder.resolve_query_set(query_set, 0..self.next_index, query_buffer, 0);
+        let Some(slot) = self
+            .readback_slots
+            .iter_mut()
+            .find(|slot| matches!(slot.state, ReadbackState::Idle))
+        else {
+            self.dropped_readbacks = self.dropped_readbacks.saturating_add(1);
+            self.pending_queries.clear();
+            self.next_index = 0;
+            return;
+        };
+
+        encoder.copy_buffer_to_buffer(
+            query_buffer,
+            0,
+            &slot.buffer,
+            0,
+            u64::from(self.next_index) * 8,
+        );
+        slot.queries.clear();
+        slot.queries.extend(self.pending_queries.drain(..));
+        slot.frame_index = frame_index;
+        slot.state = ReadbackState::CopySubmitted;
+        self.next_index = 0;
     }
 
     /// Read back GPU timestamps (blocking, call after frame completion).
@@ -248,56 +316,9 @@ impl GpuProfiler {
     /// When sharing an external device (e.g., GPUI) use
     /// `read_timestamps_deferred` instead.
     pub fn read_timestamps_blocking(&mut self, device: &wgpu::Device) -> &[GpuTimestamp] {
-        self.last_timings.clear();
-
-        if let Some(ref resolve_buffer) = self.resolve_buffer {
-            if !self.pending_queries.is_empty() {
-                // Map the buffer for reading
-                let buffer_slice = resolve_buffer.slice(..);
-
-                // Create a channel to wait for the mapping
-                let (tx, rx) = std::sync::mpsc::channel();
-                buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
-                    let _ = tx.send(result);
-                });
-
-                // Poll the device until mapping completes
-                let _ = device.poll(wgpu::PollType::wait_indefinitely());
-
-                // Wait for the mapping to complete
-                if let Ok(Ok(())) = rx.recv() {
-                    // Read the timestamp data
-                    let data = buffer_slice
-                        .get_mapped_range()
-                        .expect("timestamp buffer should be mapped");
-                    let timestamps: &[u64] = bytemuck::cast_slice(&data);
-
-                    // Calculate deltas for each pass
-                    for (name, start_idx, end_idx) in &self.pending_queries {
-                        if (*end_idx as usize) < timestamps.len() && (*start_idx as usize) < timestamps.len() {
-                            let start = timestamps[*start_idx as usize];
-                            let end = timestamps[*end_idx as usize];
-                            let duration_ticks = end.saturating_sub(start);
-                            let duration_ns = (duration_ticks as f32 * self.timestamp_period) as u64;
-
-                            self.last_timings.push(GpuTimestamp {
-                                name: name.to_string(),
-                                duration_ns,
-                            });
-                        }
-                    }
-
-                    // Unmap the buffer
-                    drop(data);
-                    resolve_buffer.unmap();
-                }
-            }
-        }
-
-        // Reset for next frame
-        self.pending_queries.clear();
-        self.next_index = 0;
-
+        self.start_submitted_mappings();
+        let _ = device.poll(wgpu::PollType::wait_indefinitely());
+        self.consume_completed_mappings();
         &self.last_timings
     }
 
@@ -313,18 +334,115 @@ impl GpuProfiler {
     /// Even a single `PollType::Poll` call from a non-owning thread causes
     /// "Parent device is lost" panics on DX12/Vulkan.
     pub fn read_timestamps_deferred(&mut self) -> &[GpuTimestamp] {
-        // Do NOT attempt to map the buffer or call device.poll().
-        // Without a poll the map_async callback never fires, so the only safe
-        // option is to skip readback entirely and return stale data.
-        // Just reset query-slot tracking so next frame can write fresh data.
-        self.pending_queries.clear();
-        self.next_index = 0;
+        self.consume_completed_mappings();
+        self.start_submitted_mappings();
         &self.last_timings
+    }
+
+    fn start_submitted_mappings(&mut self) {
+        for slot in &mut self.readback_slots {
+            if !matches!(slot.state, ReadbackState::CopySubmitted) {
+                continue;
+            }
+            let completion = Arc::new(Mutex::new(None));
+            let callback_completion = Arc::clone(&completion);
+            slot.buffer
+                .slice(..)
+                .map_async(wgpu::MapMode::Read, move |result| {
+                    if let Ok(mut completion) = callback_completion.lock() {
+                        *completion = Some(result);
+                    }
+                });
+            slot.state = ReadbackState::Mapping(completion);
+        }
+    }
+
+    fn consume_completed_mappings(&mut self) {
+        loop {
+            let next_index = self
+                .readback_slots
+                .iter()
+                .enumerate()
+                .filter(|(_, slot)| {
+                    let ReadbackState::Mapping(completion) = &slot.state else {
+                        return false;
+                    };
+                    completion
+                        .lock()
+                        .is_ok_and(|completion| completion.is_some())
+                })
+                .min_by_key(|(_, slot)| slot.frame_index)
+                .map(|(index, _)| index);
+            let Some(index) = next_index else {
+                break;
+            };
+            let frame_index = self.readback_slots[index].frame_index;
+            let result = match &self.readback_slots[index].state {
+                ReadbackState::Mapping(completion) => completion
+                    .lock()
+                    .expect("GPU timestamp completion mutex is not poisoned")
+                    .take()
+                    .expect("completed GPU timestamp mapping has a result"),
+                _ => unreachable!("selected GPU timestamp slot must be mapping"),
+            };
+            let slot = &mut self.readback_slots[index];
+            if result.is_ok() {
+                let data = slot
+                    .buffer
+                    .slice(..)
+                    .get_mapped_range()
+                    .expect("completed GPU timestamp mapping must be readable");
+                let timestamps: &[u64] = bytemuck::cast_slice(&data);
+                self.last_timings.clear();
+                for &(name, start_index, end_index) in &slot.queries {
+                    if (end_index as usize) < timestamps.len()
+                        && (start_index as usize) < timestamps.len()
+                    {
+                        let duration_ticks = timestamps[end_index as usize]
+                            .saturating_sub(timestamps[start_index as usize]);
+                        self.last_timings.push(GpuTimestamp {
+                            name,
+                            duration_ns: (duration_ticks as f32 * self.timestamp_period) as u64,
+                        });
+                    }
+                }
+                self.last_completed_frame = Some(frame_index);
+                drop(data);
+            } else {
+                self.dropped_readbacks = self.dropped_readbacks.saturating_add(1);
+            }
+            slot.buffer.unmap();
+            slot.queries.clear();
+            slot.state = ReadbackState::Idle;
+        }
     }
 
     /// Get last recorded timings (non-blocking)
     pub fn get_last_timings(&self) -> &[GpuTimestamp] {
         &self.last_timings
+    }
+
+    pub const fn supported(&self) -> bool {
+        self.query_set.is_some()
+    }
+
+    pub const fn last_completed_frame(&self) -> Option<u64> {
+        self.last_completed_frame
+    }
+
+    pub fn pending_readbacks(&self) -> usize {
+        self.readback_slots
+            .iter()
+            .filter(|slot| !matches!(slot.state, ReadbackState::Idle))
+            .count()
+    }
+
+    pub const fn dropped_readbacks(&self) -> u64 {
+        self.dropped_readbacks
+    }
+
+    pub const fn query_overflows(&self) -> u64 {
+        self.query_overflows
     }
 }
 
@@ -346,9 +464,10 @@ impl GpuProfiler {
 ///     println!("{}: {:.2}ms", ts.name, ts.duration_ns as f64 / 1_000_000.0);
 /// }
 /// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct GpuTimestamp {
     /// Pass name (e.g., "ShadowPass").
-    pub name: String,
+    pub name: &'static str,
 
     /// GPU time in nanoseconds.
     ///

--- a/crates/helio-core/src/profiling/gpu.rs
+++ b/crates/helio-core/src/profiling/gpu.rs
@@ -73,23 +73,30 @@
 /// ```
 use std::{
     collections::VecDeque,
-    sync::{Arc, Mutex},
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
 };
 
 const QUERY_CAPACITY: u32 = 256;
 const READBACK_SLOT_COUNT: usize = 3;
+const MAP_PENDING: u8 = 0;
+const MAP_SUCCEEDED: u8 = 1;
+const MAP_FAILED: u8 = 2;
 
 type QueryRange = (&'static str, u32, u32);
 
 enum ReadbackState {
     Idle,
     CopySubmitted,
-    Mapping(Arc<Mutex<Option<Result<(), wgpu::BufferAsyncError>>>>),
+    Mapping,
 }
 
 struct ReadbackSlot {
     buffer: wgpu::Buffer,
     state: ReadbackState,
+    map_completion: Arc<AtomicU8>,
     queries: Vec<QueryRange>,
     frame_index: u64,
 }
@@ -167,6 +174,7 @@ impl GpuProfiler {
                         mapped_at_creation: false,
                     }),
                     state: ReadbackState::Idle,
+                    map_completion: Arc::new(AtomicU8::new(MAP_PENDING)),
                     queries: Vec::with_capacity((QUERY_CAPACITY / 2) as usize),
                     frame_index: 0,
                 })
@@ -344,16 +352,19 @@ impl GpuProfiler {
             if !matches!(slot.state, ReadbackState::CopySubmitted) {
                 continue;
             }
-            let completion = Arc::new(Mutex::new(None));
-            let callback_completion = Arc::clone(&completion);
+            slot.map_completion.store(MAP_PENDING, Ordering::Relaxed);
+            let callback_completion = Arc::clone(&slot.map_completion);
             slot.buffer
                 .slice(..)
                 .map_async(wgpu::MapMode::Read, move |result| {
-                    if let Ok(mut completion) = callback_completion.lock() {
-                        *completion = Some(result);
-                    }
+                    let completion = if result.is_ok() {
+                        MAP_SUCCEEDED
+                    } else {
+                        MAP_FAILED
+                    };
+                    callback_completion.store(completion, Ordering::Release);
                 });
-            slot.state = ReadbackState::Mapping(completion);
+            slot.state = ReadbackState::Mapping;
         }
     }
 
@@ -364,12 +375,10 @@ impl GpuProfiler {
                 .iter()
                 .enumerate()
                 .filter(|(_, slot)| {
-                    let ReadbackState::Mapping(completion) = &slot.state else {
+                    if !matches!(slot.state, ReadbackState::Mapping) {
                         return false;
-                    };
-                    completion
-                        .lock()
-                        .is_ok_and(|completion| completion.is_some())
+                    }
+                    slot.map_completion.load(Ordering::Acquire) != MAP_PENDING
                 })
                 .min_by_key(|(_, slot)| slot.frame_index)
                 .map(|(index, _)| index);
@@ -377,16 +386,11 @@ impl GpuProfiler {
                 break;
             };
             let frame_index = self.readback_slots[index].frame_index;
-            let result = match &self.readback_slots[index].state {
-                ReadbackState::Mapping(completion) => completion
-                    .lock()
-                    .expect("GPU timestamp completion mutex is not poisoned")
-                    .take()
-                    .expect("completed GPU timestamp mapping has a result"),
-                _ => unreachable!("selected GPU timestamp slot must be mapping"),
-            };
+            let completion = self.readback_slots[index]
+                .map_completion
+                .load(Ordering::Acquire);
             let slot = &mut self.readback_slots[index];
-            if result.is_ok() {
+            if completion == MAP_SUCCEEDED {
                 let data = slot
                     .buffer
                     .slice(..)
@@ -409,6 +413,7 @@ impl GpuProfiler {
                 self.last_completed_frame = Some(frame_index);
                 drop(data);
             } else {
+                debug_assert_eq!(completion, MAP_FAILED);
                 self.dropped_readbacks = self.dropped_readbacks.saturating_add(1);
             }
             slot.buffer.unmap();

--- a/crates/helio-core/src/profiling/mod.rs
+++ b/crates/helio-core/src/profiling/mod.rs
@@ -140,6 +140,7 @@ pub struct Profiler {
     cpu: CpuProfiler,
     gpu: GpuProfiler,
     enabled: bool,
+    snapshot: RenderTimingSnapshot,
 }
 
 impl Profiler {
@@ -160,6 +161,7 @@ impl Profiler {
             cpu: CpuProfiler::new(),
             gpu: GpuProfiler::new(device, queue),
             enabled: cfg!(feature = "profiling"),
+            snapshot: RenderTimingSnapshot::default(),
         }
     }
 
@@ -228,10 +230,9 @@ impl Profiler {
     }
 
     /// Resolve GPU timestamp queries to buffer (call after submitting command buffer)
-    pub fn resolve_gpu_queries(&mut self, encoder: &mut wgpu::CommandEncoder) {
+    pub fn resolve_gpu_queries(&mut self, encoder: &mut wgpu::CommandEncoder, frame_index: u64) {
         if self.enabled {
-            self.gpu.resolve_queries(encoder);
-            self.gpu.copy_to_resolve_buffer(encoder);
+            self.gpu.resolve_queries(encoder, frame_index);
         }
     }
 
@@ -273,6 +274,71 @@ impl Profiler {
     /// Clear CPU timings for new frame
     pub fn clear_cpu_timings(&mut self) {
         self.cpu.clear();
+    }
+
+    /// Updates the reusable host-facing snapshot after a frame has submitted.
+    pub fn update_snapshot(
+        &mut self,
+        cpu_frame_index: u64,
+        pass_names: impl Iterator<Item = &'static str>,
+    ) {
+        self.snapshot.generation = self.snapshot.generation.saturating_add(1);
+        self.snapshot.cpu_frame_index = cpu_frame_index;
+        self.snapshot.gpu_frame_index = self.gpu.last_completed_frame();
+        self.snapshot.gpu_lag_frames = self
+            .snapshot
+            .gpu_frame_index
+            .map(|gpu_frame| cpu_frame_index.saturating_sub(gpu_frame));
+        self.snapshot.readback_drops = self.gpu.dropped_readbacks();
+        self.snapshot.query_overflows = self.gpu.query_overflows();
+        self.snapshot.gpu_availability = if !self.enabled {
+            GpuTimingAvailability::Disabled
+        } else if !self.gpu.supported() {
+            GpuTimingAvailability::Unsupported
+        } else if self.snapshot.gpu_frame_index.is_some() {
+            GpuTimingAvailability::Available
+        } else if self.snapshot.readback_drops != 0 {
+            GpuTimingAvailability::Backpressured
+        } else {
+            GpuTimingAvailability::Pending
+        };
+
+        self.snapshot.passes.clear();
+        let mut total_cpu_ms = 0.0_f32;
+        let mut has_cpu = false;
+        let mut total_gpu_ms = 0.0_f32;
+        let mut has_gpu = false;
+        for name in pass_names {
+            let cpu_ms = self.cpu.get_timings().get(name).map(|duration| {
+                has_cpu = true;
+                let milliseconds = duration.as_secs_f64() as f32 * 1_000.0;
+                total_cpu_ms += milliseconds;
+                milliseconds
+            });
+            let gpu_ms = self
+                .gpu
+                .get_last_timings()
+                .iter()
+                .find(|timing| timing.name == name)
+                .map(|timing| {
+                    has_gpu = true;
+                    let milliseconds = timing.duration_ns as f32 / 1_000_000.0;
+                    total_gpu_ms += milliseconds;
+                    milliseconds
+                });
+            self.snapshot.passes.push(RenderPassTiming {
+                name,
+                cpu_ms,
+                gpu_ms,
+            });
+        }
+        self.snapshot.total_cpu_ms = has_cpu.then_some(total_cpu_ms);
+        self.snapshot.total_gpu_ms = has_gpu.then_some(total_gpu_ms);
+    }
+
+    /// Returns the latest snapshot without allocation or synchronization.
+    pub const fn timing_snapshot(&self) -> &RenderTimingSnapshot {
+        &self.snapshot
     }
 
     /// Print profiling results to console (blocking - use for debugging only!)
@@ -354,7 +420,7 @@ impl Profiler {
         let mut gpu_map = std::collections::HashMap::new();
         for ts in self.gpu.get_last_timings() {
             let ms = ts.duration_ns as f64 / 1_000_000.0;
-            gpu_map.insert(ts.name.as_str(), ms as f32);
+            gpu_map.insert(ts.name, ms as f32);
             total_gpu_ms += ms as f32;
         }
 
@@ -377,7 +443,7 @@ impl Profiler {
             if !pass_timings.iter().any(|pt| pt.name == ts.name) {
                 let ms = ts.duration_ns as f64 / 1_000_000.0;
                 pass_timings.push(PassTiming {
-                    name: ts.name.clone(),
+                    name: ts.name.to_string(),
                     cpu_ms: 0.0,
                     gpu_ms: ms as f32,
                 });
@@ -394,4 +460,47 @@ pub struct PassTiming {
     pub name: String,
     pub cpu_ms: f32,
     pub gpu_ms: f32,
+}
+
+/// State of non-blocking GPU timing readback for the current snapshot.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum GpuTimingAvailability {
+    /// The `profiling` feature is disabled.
+    Disabled,
+    /// The adapter does not expose the required timestamp-query features.
+    Unsupported,
+    /// Timestamp data has been submitted but no host-driven poll has completed it yet.
+    #[default]
+    Pending,
+    /// At least one completed GPU frame is available.
+    Available,
+    /// All bounded readback slots were occupied before the first result completed.
+    Backpressured,
+}
+
+/// One pass in a host-facing timing snapshot.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct RenderPassTiming {
+    pub name: &'static str,
+    pub cpu_ms: Option<f32>,
+    pub gpu_ms: Option<f32>,
+}
+
+/// Reusable read-only timing state exposed by `Renderer`.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct RenderTimingSnapshot {
+    /// Monotonic snapshot revision, incremented after every submitted frame.
+    pub generation: u64,
+    /// Frame whose CPU pass timings are represented.
+    pub cpu_frame_index: u64,
+    /// Most recent GPU frame whose asynchronous readback completed.
+    pub gpu_frame_index: Option<u64>,
+    /// Difference between `cpu_frame_index` and `gpu_frame_index`.
+    pub gpu_lag_frames: Option<u64>,
+    pub gpu_availability: GpuTimingAvailability,
+    pub total_cpu_ms: Option<f32>,
+    pub total_gpu_ms: Option<f32>,
+    pub readback_drops: u64,
+    pub query_overflows: u64,
+    pub passes: Vec<RenderPassTiming>,
 }

--- a/crates/helio-core/src/profiling/mod.rs
+++ b/crates/helio-core/src/profiling/mod.rs
@@ -308,6 +308,8 @@ impl Profiler {
         let mut has_cpu = false;
         let mut total_gpu_ms = 0.0_f32;
         let mut has_gpu = false;
+        let gpu_timings = self.gpu.get_last_timings();
+        let mut gpu_cursor = 0;
         for name in pass_names {
             let cpu_ms = self.cpu.get_timings().get(name).map(|duration| {
                 has_cpu = true;
@@ -315,17 +317,26 @@ impl Profiler {
                 total_cpu_ms += milliseconds;
                 milliseconds
             });
-            let gpu_ms = self
-                .gpu
-                .get_last_timings()
-                .iter()
-                .find(|timing| timing.name == name)
-                .map(|timing| {
-                    has_gpu = true;
-                    let milliseconds = timing.duration_ns as f32 / 1_000_000.0;
-                    total_gpu_ms += milliseconds;
-                    milliseconds
-                });
+            let gpu_timing = match gpu_timings.get(gpu_cursor) {
+                Some(timing) if timing.name == name => {
+                    gpu_cursor += 1;
+                    Some(timing)
+                }
+                _ => gpu_timings
+                    .iter()
+                    .enumerate()
+                    .find(|(_, timing)| timing.name == name)
+                    .map(|(index, timing)| {
+                        gpu_cursor = gpu_cursor.max(index + 1);
+                        timing
+                    }),
+            };
+            let gpu_ms = gpu_timing.map(|timing| {
+                has_gpu = true;
+                let milliseconds = timing.duration_ns as f32 / 1_000_000.0;
+                total_gpu_ms += milliseconds;
+                milliseconds
+            });
             self.snapshot.passes.push(RenderPassTiming {
                 name,
                 cpu_ms,

--- a/crates/helio-core/tests/render_timing_snapshot.rs
+++ b/crates/helio-core/tests/render_timing_snapshot.rs
@@ -1,0 +1,136 @@
+use helio_core::{profiling::GpuProfiler, GpuTimingAvailability, Profiler, RenderTimingSnapshot};
+
+#[test]
+fn empty_snapshot_is_explicitly_pending_and_allocation_free_to_read() {
+    let snapshot = RenderTimingSnapshot::default();
+    assert_eq!(snapshot.generation, 0);
+    assert_eq!(snapshot.gpu_availability, GpuTimingAvailability::Pending);
+    assert!(snapshot.passes.is_empty());
+    assert_eq!(snapshot.total_cpu_ms, None);
+    assert_eq!(snapshot.total_gpu_ms, None);
+    assert_eq!(snapshot.gpu_frame_index, None);
+    assert_eq!(snapshot.gpu_lag_frames, None);
+}
+
+#[test]
+fn unsupported_gpu_state_and_pass_order_are_stable() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: timing snapshot");
+            return;
+        };
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Timing Snapshot Unsupported Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a timing snapshot device");
+        let mut profiler = Profiler::new(&device, &queue);
+        {
+            let _scope = profiler.scope("SecondPass");
+        }
+        {
+            let _scope = profiler.scope("FirstPass");
+        }
+        profiler.update_snapshot(9, ["FirstPass", "SecondPass"].into_iter());
+
+        let snapshot = profiler.timing_snapshot();
+        assert_eq!(snapshot.generation, 1);
+        assert_eq!(snapshot.cpu_frame_index, 9);
+        assert_eq!(
+            snapshot.gpu_availability,
+            GpuTimingAvailability::Unsupported
+        );
+        assert_eq!(
+            snapshot
+                .passes
+                .iter()
+                .map(|pass| pass.name)
+                .collect::<Vec<_>>(),
+            ["FirstPass", "SecondPass"]
+        );
+        assert!(snapshot.passes.iter().all(|pass| pass.cpu_ms.is_some()));
+        assert!(snapshot.passes.iter().all(|pass| pass.gpu_ms.is_none()));
+    });
+}
+
+#[test]
+fn deferred_readback_attributes_work_after_an_external_poll() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: deferred timing readback");
+            return;
+        };
+        let required =
+            wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+        if !adapter.features().contains(required) {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_TIMESTAMPS");
+            return;
+        }
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Deferred Timing Readback Device"),
+                required_features: required,
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("timestamp-capable adapter must create a timing device");
+        device.on_uncaptured_error(std::sync::Arc::new(|error| {
+            panic!("deferred timing GPU validation error: {error:?}");
+        }));
+
+        let mut profiler = GpuProfiler::new(&device, &queue);
+        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Forced Slow Pass Timing Encoder"),
+        });
+        profiler.begin_pass(&mut encoder, "ForcedSlowPass");
+        {
+            let _pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                label: Some("Forced Slow Pass"),
+                timestamp_writes: None,
+            });
+        }
+        profiler.end_pass(&mut encoder, "ForcedSlowPass");
+        profiler.resolve_queries(&mut encoder, 17);
+        queue.submit([encoder.finish()]);
+
+        // The Helio-owned method only queues map_async. It returns before any
+        // host poll and therefore cannot introduce a wait into the frame.
+        assert!(profiler.read_timestamps_deferred().is_empty());
+        assert_eq!(profiler.pending_readbacks(), 1);
+
+        // This poll represents GPUI/winit's owner-driven event-loop cadence,
+        // not a call made by Helio's external-device render path.
+        let _ = device.poll(wgpu::PollType::wait_indefinitely());
+        let timings = profiler.read_timestamps_deferred();
+        let timing_count = timings.len();
+        let timing_name = timings.first().map(|timing| timing.name);
+        assert_eq!(profiler.last_completed_frame(), Some(17));
+        assert_eq!(timing_count, 1);
+        assert_eq!(timing_name, Some("ForcedSlowPass"));
+        assert_eq!(profiler.pending_readbacks(), 0);
+    });
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}

--- a/crates/helio/src/lib.rs
+++ b/crates/helio/src/lib.rs
@@ -61,7 +61,8 @@ pub use helio_bake::{
 pub use helio_core::{
     Actor, Component, ComponentRegistry, ComponentSlot, ComponentVec, DebugViewDescriptor,
     DrawIndexedIndirectArgs, Entity, Error, GpuCameraUniforms, GpuDrawCall, GpuInstanceAabb,
-    GpuInstanceData, GpuLight, GpuMaterial, GpuScene, RenderGraph, RenderPass, Result,
+    GpuInstanceData, GpuLight, GpuMaterial, GpuScene, GpuTimingAvailability, RenderGraph,
+    RenderPass, RenderPassTiming, RenderTimingSnapshot, Result,
 };
 pub use libhelio::{LightType, Movability, ShadowQuality, SkyActor, VolumetricClouds};
 

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -394,6 +394,12 @@ impl Renderer {
         self.scene.gpu_scene().camera.buffer()
     }
 
+    /// Latest frame timing state. Reading it performs no GPU polling,
+    /// synchronization, or allocation.
+    pub fn timing_snapshot(&self) -> &helio_core::RenderTimingSnapshot {
+        self.graph.profiler().timing_snapshot()
+    }
+
     pub fn mesh_buffers(&self) -> MeshBuffers<'_> {
         self.scene.mesh_buffers()
     }


### PR DESCRIPTION
## Summary

- expose a borrowed, reusable `Renderer::timing_snapshot()` with stable per-pass CPU/GPU timings and totals
- identify the CPU frame, asynchronously completed GPU frame, snapshot generation, and readback lag
- report disabled, unsupported, pending, available, and bounded-backpressure states explicitly
- replace the external-device timestamp stub with a three-slot `map_async` readback ring that never polls or waits inside Helio
- bound query capacity and expose readback drops/query overflow instead of silently reporting zero

## Root cause

The render graph recorded timestamp queries, but the external-device path cleared every pending query without ever mapping the resolve buffer. Pulsar therefore had only whole-submit wall time and no pass attribution. Reusing one staging buffer would also conflict with in-flight mapping, so the fix uses bounded staging slots and consumes callbacks only on the external owner's poll cadence.

## Host impact

Reading the snapshot performs no allocation, GPU polling, locking, or synchronization. CPU timings refer to the submitted frame; GPU timings retain their own completed frame identity and explicit lag.

## Validation

- `cargo test -p helio-core --lib` (15 passed)
- `cargo test -p helio-core --test render_timing_snapshot -- --nocapture` (3 passed on NVIDIA GeForce RTX 3060)
- `cargo test -p helio --lib` (19 passed)
- `cargo check -p helio-core -p helio --lib`
- `git diff --check`

The adapter-backed test proves deferred readback returns before host polling, then attributes the named GPU pass after an external owner poll. Pulsar viewport wiring and configurable runtime spike attribution are validated in Far-Beyond-Pulsar/Pulsar-Native#462.

Closes #122
