### PR TITLE
deps: bump Solid3D to b9eb501 + enable configurator feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5768,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "solid-fbx"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "flate2",
  "glam 0.27.0",
@@ -5779,7 +5779,7 @@ dependencies = [
 [[package]]
 name = "solid-gltf"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "base64 0.22.1",
  "glam 0.27.0",
@@ -5791,7 +5791,7 @@ dependencies = [
 [[package]]
 name = "solid-obj"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
  "solid-rs",
@@ -5800,16 +5800,17 @@ dependencies = [
 [[package]]
 name = "solid-rs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
+ "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "solid-usd"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ env_logger = "0.11"
 log = "0.4"
 
 # SolidRS - 3D asset loading library
-solid-rs =   { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-gltf = { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-fbx =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-obj =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-usd =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
+solid-rs =   { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-gltf = { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-fbx =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-obj =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-usd =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
 quark = { git = "https://github.com/Far-Beyond-Pulsar/Quark", package = "quark" }
 thiserror = "2.0"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/helio-asset-compat/Cargo.toml
+++ b/crates/helio-asset-compat/Cargo.toml
@@ -10,11 +10,11 @@ helio = { workspace = true }
 libhelio = { workspace = true }
 
 # SolidRS - 3D asset loading
-solid-rs.workspace = true
-solid-gltf.workspace = true
-solid-fbx.workspace = true
-solid-obj.workspace = true
-solid-usd.workspace = true
+solid-rs = { workspace = true, features = ["configurator"] }
+solid-gltf = { workspace = true, features = ["configurator"] }
+solid-fbx = { workspace = true, features = ["configurator"] }
+solid-obj = { workspace = true, features = ["configurator"] }
+solid-usd = { workspace = true, features = ["configurator"] }
 
 # Math and utilities
 glam.workspace = true


### PR DESCRIPTION
Pins the five solid-* deps to the configurator-enabled Solid3D rev and turns on the `configurator` feature in helio-asset-compat so loaders expose their per-format import-options schema at runtime.