### PR TITLE
Cherry-pick Pulsar PRs #430 and #401 onto main

### DIFF
--- a/crates/helio-core/src/graph/execution.rs
+++ b/crates/helio-core/src/graph/execution.rs
@@ -332,7 +332,7 @@ impl RenderGraph {
         scene: &GpuScene,
         target: &wgpu::TextureView,
         depth: &wgpu::TextureView,
-    ) -> Result<()> {
+    ) -> Result<wgpu::SubmissionIndex> {
         let frame_resources = libhelio::FrameResources::empty();
         self.execute_with_frame_resources(scene, target, depth, &frame_resources)
     }
@@ -343,7 +343,7 @@ impl RenderGraph {
         target: &wgpu::TextureView,
         depth: &wgpu::TextureView,
         frame_resources: &libhelio::FrameResources<'_>,
-    ) -> Result<()> {
+    ) -> Result<wgpu::SubmissionIndex> {
         assert!(self.locked, "RenderGraph::execute() requires lock() to be called first");
 
         self.profiler.clear_cpu_timings();
@@ -604,7 +604,7 @@ impl RenderGraph {
         }
 
         self.profiler.resolve_gpu_queries(&mut compute_encoder);
-        scene.queue.submit([compute_encoder.finish(), encoder.finish()]);
+        let submission_index = scene.queue.submit([compute_encoder.finish(), encoder.finish()]);
         crate::upload::finish_frame();
 
         if self.owns_device {
@@ -615,7 +615,7 @@ impl RenderGraph {
 
         self.frame_count += 1;
 
-        Ok(())
+        Ok(submission_index)
     }
 
     /// Finalize the graph after all passes have been added.

--- a/crates/helio-pass-hlfs/shaders/hlfs_toroidal_shift.wgsl
+++ b/crates/helio-pass-hlfs/shaders/hlfs_toroidal_shift.wgsl
@@ -1,0 +1,31 @@
+//! HLFS Toroidal Ring-Buffer Shift (stub)
+//!
+//! Phase 1: no-op dispatch placeholder. Phase 2 will implement the actual
+//! wrap-region copy that shifts the clip-stack origin and recycles voxels
+//! that remain in the new frustum.
+
+struct ShiftParams {
+    origin_delta: vec3<i32>,
+    inv_voxel_size: f32,
+}
+
+@group(0) @binding(0) var<uniform> params: ShiftParams;
+@group(0) @binding(1) var read_tex: texture_3d<f32>;
+@group(0) @binding(2) var write_tex: texture_storage_3d<rgba16float, write>;
+
+const VOXEL_RESOLUTION: u32 = 128u;
+
+@compute @workgroup_size(8, 8, 8)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {
+    if (all(global_id < vec3<u32>(VOXEL_RESOLUTION))) {
+        let write_coord = vec3<i32>(global_id);
+        let src_coord = write_coord - params.origin_delta;
+        var clamped = src_coord;
+        if (any(src_coord < vec3<i32>(0)) || any(src_coord >= vec3<i32>(VOXEL_RESOLUTION))) {
+            let half = i32(VOXEL_RESOLUTION) / 2;
+            clamped = vec3<i32>(half, half, half);
+        }
+        let sample = textureLoad(read_tex, clamped, 0);
+        textureStore(write_tex, write_coord, sample);
+    }
+}

--- a/crates/helio-pass-hlfs/src/clip_stack.rs
+++ b/crates/helio-pass-hlfs/src/clip_stack.rs
@@ -1,0 +1,112 @@
+use wgpu;
+
+pub const HLFS_LEVELS: u32 = 4;
+pub const HLFS_RES: u32 = 128;
+pub const HLFS_NEAR_FIELD: f32 = 50.0;
+pub const HLFS_CASCADE_SCALE: f32 = 2.0;
+
+/// Per-level clip-stack state
+pub struct ClipStackLevel {
+    /// 3D texture for this level (RGBA16F, 128³)
+    pub texture: wgpu::Texture,
+    pub texture_view: wgpu::TextureView,
+    /// Toroidal origin in voxel-space
+    pub origin: [i32; 3],
+    pub half_extent: f32,
+    pub voxel_size: f32,
+}
+
+pub struct ClipStack {
+    pub levels: [ClipStackLevel; 4],
+    /// Double-buffered: read (accumulated from prev frames) and write (current injection target)
+    pub read: Vec<wgpu::TextureView>,
+    pub write: Vec<wgpu::TextureView>,
+    /// Secondary textures backing the read views
+    _read_textures: Vec<wgpu::Texture>,
+}
+
+impl ClipStack {
+    pub fn new(device: &wgpu::Device, format: wgpu::TextureFormat) -> Self {
+        let per_level = |label: String| {
+            let texture = device.create_texture(&wgpu::TextureDescriptor {
+                label: Some(&label),
+                size: wgpu::Extent3d {
+                    width: HLFS_RES,
+                    height: HLFS_RES,
+                    depth_or_array_layers: HLFS_RES,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D3,
+                format,
+                usage: wgpu::TextureUsages::STORAGE_BINDING
+                    | wgpu::TextureUsages::TEXTURE_BINDING
+                    | wgpu::TextureUsages::COPY_DST
+                    | wgpu::TextureUsages::COPY_SRC,
+                view_formats: &[],
+            });
+            let texture_view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+            (texture, texture_view)
+        };
+
+        // Write set: injected into this frame (owned by levels)
+        let mut levels: [std::mem::MaybeUninit<ClipStackLevel>; 4] =
+            unsafe { std::mem::MaybeUninit::uninit().assume_init() };
+        let mut write = Vec::with_capacity(4);
+
+        for i in 0..4 {
+            let label = format!("HLFS Clip-Stack Write Level {}", i);
+            let half_extent = HLFS_NEAR_FIELD * HLFS_CASCADE_SCALE.powi(i as i32);
+            let voxel_size = 2.0 * half_extent / HLFS_RES as f32;
+            let (texture, texture_view) = per_level(label);
+            write.push(texture_view.clone());
+            levels[i] = std::mem::MaybeUninit::new(ClipStackLevel {
+                texture,
+                texture_view,
+                origin: [0; 3],
+                half_extent,
+                voxel_size,
+            });
+        }
+        let levels = unsafe { std::mem::transmute::<_, [ClipStackLevel; 4]>(levels) };
+
+        // Read set: accumulated from previous frames
+        let mut read_textures = Vec::with_capacity(4);
+        let mut read = Vec::with_capacity(4);
+        for i in 0..4 {
+            let label = format!("HLFS Clip-Stack Read Level {}", i);
+            let (tex, view) = per_level(label);
+            read_textures.push(tex);
+            read.push(view);
+        }
+
+        ClipStack {
+            levels,
+            read,
+            write,
+            _read_textures: read_textures,
+        }
+    }
+
+    /// Toroidal ring-buffer shift placeholder.
+    ///
+    /// When the camera moves beyond a voxel-sized threshold, this shifts the
+    /// clip-stack origins and issues copy commands to wrap around the 3D
+    /// texture toroidally, reusing existing data instead of discarding it.
+    #[allow(unused)]
+    pub fn toroidal_shift(
+        &mut self,
+        _device: &wgpu::Device,
+        _encoder: &mut wgpu::CommandEncoder,
+        _camera_pos: [f32; 3],
+    ) {
+        // Phase 1: no-op — origins remain at zero.
+        // Phase 2 will implement the actual compute-based copy.
+    }
+
+    /// Swaps read/write roles so that this frame's accumulation becomes
+    /// next frame's history.
+    pub fn swap_buffers(&mut self) {
+        std::mem::swap(&mut self.read, &mut self.write);
+    }
+}

--- a/crates/helio-pass-hlfs/src/globals.rs
+++ b/crates/helio-pass-hlfs/src/globals.rs
@@ -1,0 +1,27 @@
+use bytemuck::{Pod, Zeroable};
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct HlfsGlobals {
+    pub clip_origins: [[i32; 4]; 4],
+    pub voxel_sizes: [f32; 4],
+    pub frame_time: f32,
+    pub temporal_decay: [f32; 4],
+    pub near_field_size: f32,
+    pub cascade_scale: f32,
+    pub screen_size: [u32; 2],
+    pub sample_count: u32,
+    pub light_count: u32,
+    pub dissipation_mode: u32,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Pod, Zeroable)]
+pub struct HlfsLevelState {
+    pub origin: [i32; 3],
+    pub origin_world: [f32; 3],
+    pub half_extent: f32,
+    pub voxel_size: f32,
+    pub active_min: [i32; 3],
+    pub active_max: [i32; 3],
+}

--- a/crates/helio-pass-hlfs/src/lib.rs
+++ b/crates/helio-pass-hlfs/src/lib.rs
@@ -14,21 +14,26 @@ use bytemuck::{Pod, Zeroable};
 use helio_core::graph::{ResourceBuilder, ResourceSize};
 use helio_core::{PassContext, PrepareContext, RenderPass, Result as HelioResult};
 
-const CLIP_STACK_LEVELS: usize = 4;
-const VOXEL_RESOLUTION: u32 = 128; // 128^3 per level
+mod clip_stack;
+mod globals;
+use clip_stack::{ClipStack, HLFS_LEVELS, HLFS_RES, HLFS_NEAR_FIELD, HLFS_CASCADE_SCALE};
+use globals::HlfsGlobals;
+
+const CLIP_STACK_LEVELS: usize = HLFS_LEVELS as usize;
+const VOXEL_RESOLUTION: u32 = HLFS_RES; // 128^3 per level
 const SAMPLES_PER_PIXEL: u32 = 8; // K samples for importance sampling
 
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
-struct HlfsGlobals {
+struct LegacyGlobals {
     frame: u32,
     sample_count: u32,
     light_count: u32,
     screen_width: u32,
     screen_height: u32,
-    near_field_size: f32, // Level 0 world-space size (meters)
-    cascade_scale: f32,   // Scale multiplier per level (e.g., 2.0)
-    temporal_blend: f32,  // Temporal accumulation weight
+    near_field_size: f32,
+    cascade_scale: f32,
+    temporal_blend: f32,
     camera_position: [f32; 3],
     _pad0: u32,
     camera_forward: [f32; 3],
@@ -48,8 +53,11 @@ pub struct HlfsPass {
     fallback_shadow_sampler: wgpu::Sampler,
 
     // Clip-stack: 4 levels of 3D textures (128^3 RGBA16F each)
-    clip_stack_views: Vec<wgpu::TextureView>,
+    clip_stack: ClipStack,
     clip_stack_sampler: wgpu::Sampler,
+
+    // HLFS-specific globals uniform (new layout with clip_origins, voxel_sizes, etc.)
+    hlfs_globals_buf: wgpu::Buffer,
 
     // Intermediate buffers
     sample_buffer: wgpu::Buffer, // Stores K samples per pixel
@@ -117,29 +125,16 @@ impl HlfsPass {
             mapped_at_creation: false,
         });
 
-        // Create clip-stack textures (4 levels of 128^3 RGBA16F)
-        let mut clip_stack_textures = Vec::new();
-        let mut clip_stack_views = Vec::new();
+        // Create clip-stack (double-buffered, 4 levels of 128^3 RGBA16F 3D textures)
+        let clip_stack = ClipStack::new(device, wgpu::TextureFormat::Rgba16Float);
 
-        for level in 0..CLIP_STACK_LEVELS {
-            let texture = device.create_texture(&wgpu::TextureDescriptor {
-                label: Some(&format!("HLFS Clip-Stack Level {}", level)),
-                size: wgpu::Extent3d {
-                    width: VOXEL_RESOLUTION,
-                    height: VOXEL_RESOLUTION,
-                    depth_or_array_layers: VOXEL_RESOLUTION,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: wgpu::TextureDimension::D3,
-                format: wgpu::TextureFormat::Rgba16Float,
-                usage: wgpu::TextureUsages::STORAGE_BINDING | wgpu::TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            });
-            let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
-            clip_stack_textures.push(texture);
-            clip_stack_views.push(view);
-        }
+        // HLFS-specific globals uniform buffer (new layout with clip_origins, voxel_sizes, etc.)
+        let hlfs_globals_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("HLFS Globals (New)"),
+            size: std::mem::size_of::<HlfsGlobals>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
 
         // Sample buffer: stores K samples per pixel (position, direction, radiance)
         let sample_count = (width * height * SAMPLES_PER_PIXEL) as u64;
@@ -957,8 +952,9 @@ impl HlfsPass {
             hierarchical_propagate_pipeline,
             final_shade_pipeline,
             globals_buf,
+            hlfs_globals_buf,
             fallback_shadow_sampler,
-            clip_stack_views,
+            clip_stack,
             clip_stack_sampler,
             sample_buffer,
             bgl_compute_importance,
@@ -1031,10 +1027,21 @@ impl RenderPass for HlfsPass {
     fn publish<'a>(&'a self, frame: &mut libhelio::FrameResources<'a>) {
         // Publish output as pre_aa for downstream passes (always overwrite)
         frame.pre_aa.write(&self.output_view, "HLFS");
+
+        // Publish clip-stack read views so the shade pass can sample the accumulated field
+        frame.hlfs_clip_stack = Some([
+            &self.clip_stack.read[0],
+            &self.clip_stack.read[1],
+            &self.clip_stack.read[2],
+            &self.clip_stack.read[3],
+        ]);
+
+        // Publish HLFS globals buffer for downstream passes
+        frame.hlfs_globals = Some(&self.hlfs_globals_buf);
     }
 
     fn writes(&self) -> &'static [&'static str] {
-        &["pre_aa"]
+        &["pre_aa", "hlfs_clip_stack", "hlfs_globals"]
     }
 
     fn declare_resources(&self, builder: &mut ResourceBuilder) {
@@ -1043,24 +1050,49 @@ impl RenderPass for HlfsPass {
 
     fn prepare(&mut self, ctx: &PrepareContext) -> HelioResult<()> {
         let camera_pos = ctx.scene.camera.position();
-        let cam_forward = [0.0_f32, 0.0_f32, -1.0_f32];
 
-        let globals = HlfsGlobals {
+        // Write legacy globals for existing shaders
+        let legacy = LegacyGlobals {
             frame: ctx.frame_num as u32,
             sample_count: SAMPLES_PER_PIXEL,
-            light_count: ctx.scene.movable_light_count, // Only movable lights (static/stationary are baked)
+            light_count: ctx.scene.movable_light_count,
             screen_width: self.width,
             screen_height: self.height,
-            near_field_size: 50.0, // 50m near field
-            cascade_scale: 2.0,    // Double size per level
-            temporal_blend: 0.95,  // 95% history, 5% new
+            near_field_size: 50.0,
+            cascade_scale: 2.0,
+            temporal_blend: 0.95,
             camera_position: camera_pos,
             _pad0: 0,
-            camera_forward: cam_forward,
+            camera_forward: [0.0_f32, 0.0_f32, -1.0_f32],
             _pad1: 0,
             csm_splits: libhelio::CSM_SPLITS,
         };
-        ctx.write_buffer(&self.globals_buf, 0, bytemuck::bytes_of(&globals));
+        ctx.write_buffer(&self.globals_buf, 0, bytemuck::bytes_of(&legacy));
+
+        // Write new HLFS globals with clip-stack state
+        let hlfs = HlfsGlobals {
+            clip_origins: [
+                [self.clip_stack.levels[0].origin[0], self.clip_stack.levels[0].origin[1], self.clip_stack.levels[0].origin[2], 0],
+                [self.clip_stack.levels[1].origin[0], self.clip_stack.levels[1].origin[1], self.clip_stack.levels[1].origin[2], 0],
+                [self.clip_stack.levels[2].origin[0], self.clip_stack.levels[2].origin[1], self.clip_stack.levels[2].origin[2], 0],
+                [self.clip_stack.levels[3].origin[0], self.clip_stack.levels[3].origin[1], self.clip_stack.levels[3].origin[2], 0],
+            ],
+            voxel_sizes: [
+                self.clip_stack.levels[0].voxel_size,
+                self.clip_stack.levels[1].voxel_size,
+                self.clip_stack.levels[2].voxel_size,
+                self.clip_stack.levels[3].voxel_size,
+            ],
+            frame_time: ctx.delta_time,
+            temporal_decay: [0.95; 4],
+            near_field_size: HLFS_NEAR_FIELD,
+            cascade_scale: HLFS_CASCADE_SCALE,
+            screen_size: [self.width, self.height],
+            sample_count: SAMPLES_PER_PIXEL,
+            light_count: ctx.scene.movable_light_count,
+            dissipation_mode: 0,
+        };
+        ctx.write_buffer(&self.hlfs_globals_buf, 0, bytemuck::bytes_of(&hlfs));
 
         let shadow_config = libhelio::ShadowConfig::from_quality(self.shadow_quality);
         ctx.write_buffer(
@@ -1104,19 +1136,19 @@ impl RenderPass for HlfsPass {
                     entries: &[
                         wgpu::BindGroupEntry {
                             binding: 0,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[0]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[0]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 1,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[1]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[1]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 2,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[2]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[2]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 3,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[3]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[3]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 4,
@@ -1184,19 +1216,19 @@ impl RenderPass for HlfsPass {
                             entries: &[
                                 wgpu::BindGroupEntry {
                                     binding: 0,
-                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[0]),
+                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[0]),
                                 },
                                 wgpu::BindGroupEntry {
                                     binding: 1,
-                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[1]),
+                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[1]),
                                 },
                                 wgpu::BindGroupEntry {
                                     binding: 2,
-                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[2]),
+                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[2]),
                                 },
                                 wgpu::BindGroupEntry {
                                     binding: 3,
-                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[3]),
+                                    resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[3]),
                                 },
                                 wgpu::BindGroupEntry {
                                     binding: 4,
@@ -1324,7 +1356,7 @@ impl RenderPass for HlfsPass {
                         },
                         wgpu::BindGroupEntry {
                             binding: 4,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[0]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[0]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 5,
@@ -1362,19 +1394,19 @@ impl RenderPass for HlfsPass {
                         },
                         wgpu::BindGroupEntry {
                             binding: 8,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[0]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[0]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 9,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[1]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[1]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 10,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[2]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[2]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 11,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[3]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[3]),
                         },
                     ],
                 }));
@@ -1392,25 +1424,35 @@ impl RenderPass for HlfsPass {
                         },
                         wgpu::BindGroupEntry {
                             binding: 4,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[0]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.read[0]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 8,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[1]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[1]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 9,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[2]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[2]),
                         },
                         wgpu::BindGroupEntry {
                             binding: 10,
-                            resource: wgpu::BindingResource::TextureView(&self.clip_stack_views[3]),
+                            resource: wgpu::BindingResource::TextureView(&self.clip_stack.write[3]),
                         },
                     ],
                 }));
         }
 
-        // Step 1: Importance sampling (compute)
+        // Step 1: Toroidal shift — update clip-stack origins and recycle voxels
+        {
+            let mut pass =
+                unsafe { &mut *ctx.encoder_ptr }.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("HLFS Toroidal Shift"),
+                    timestamp_writes: None,
+                });
+            // Phase 1: no-op dispatch (placeholder for compute-based ring-buffer update)
+        }
+
+        // Step 2: Importance sampling (compute)
         let workgroups_x = self.width.div_ceil(8);
         let workgroups_y = self.height.div_ceil(8);
 
@@ -1488,6 +1530,15 @@ impl RenderPass for HlfsPass {
             pass.set_bind_group(1, self.bind_group_shade1.as_ref().unwrap(), &[]);
             pass.draw(0..3, 0..1);
         }
+
+        // Step 5: Swap clip-stack read/write buffers for next frame
+        self.clip_stack.swap_buffers();
+
+        // Invalidate compute bind groups after buffer swap (they hold references to
+        // clip-stack read/write views that become stale).
+        self.bind_group_compute_importance = None;
+        self.bind_group_compute_inject = None;
+        self.bind_group_compute_propagate = None;
 
         Ok(())
     }

--- a/crates/helio/src/renderer/debug.rs
+++ b/crates/helio/src/renderer/debug.rs
@@ -18,6 +18,9 @@ pub struct DebugDrawState {
     /// Bumped whenever `editor_volume_lines` changes, so the pass can keep
     /// caching its uploads instead of re-sending the set every frame.
     pub editor_volume_generation: u64,
+    /// Color-blind mode for axis/gizmo colors:
+    /// 0=None, 1=Protanopia, 2=Deuteranopia, 3=Tritanopia, 4=Achromatopsia
+    pub color_blind_mode: u8,
 }
 
 impl Default for DebugDrawState {
@@ -31,6 +34,7 @@ impl Default for DebugDrawState {
             user_tris_generation: 0,
             editor_volume_lines: Vec::new(),
             editor_volume_generation: 0,
+            color_blind_mode: 0,
         }
     }
 }
@@ -586,13 +590,33 @@ impl DebugDrawPass {
         self.pass.set_depth_test(enabled);
     }
 
-    fn rebuild_editor_grid_cache(&mut self, center_x: f32, center_z: f32, grid_step: f32) {
+    fn rebuild_editor_grid_cache(&mut self, center_x: f32, center_z: f32, grid_step: f32, color_blind_mode: u8) {
         self.editor_grid_cache.clear();
 
         let minor_color: [f32; 4] = [0.25, 0.25, 0.25, 1.0];
         let major_color: [f32; 4] = [0.5, 0.5, 0.5, 1.0];
-        let axis_color_x: [f32; 4] = [1.0, 0.2, 0.2, 1.0];
-        let axis_color_z: [f32; 4] = [0.2, 1.0, 0.2, 1.0];
+        let (axis_color_x, axis_color_z, origin_color) = match color_blind_mode {
+            1 | 2 => (
+                [1.0, 0.6, 0.0, 1.0],
+                [0.0, 0.5, 1.0, 1.0],
+                [1.0, 1.0, 0.0, 1.0],
+            ),
+            3 => (
+                [1.0, 0.2, 0.2, 1.0],
+                [0.0, 0.7, 0.3, 1.0],
+                [1.0, 0.5, 0.0, 1.0],
+            ),
+            4 => (
+                [0.0, 0.0, 0.0, 1.0],
+                [0.5, 0.5, 0.5, 1.0],
+                [1.0, 1.0, 1.0, 1.0],
+            ),
+            _ => (
+                [1.0, 0.2, 0.2, 1.0],
+                [0.2, 1.0, 0.2, 1.0],
+                [1.0, 1.0, 0.0, 1.0],
+            ),
+        };
 
         let range: f32 = 40.0;
         let count = (range / grid_step).ceil() as i32;
@@ -649,7 +673,6 @@ impl DebugDrawPass {
             });
         }
 
-        let origin_color = [1.0, 1.0, 0.0, 1.0];
         self.editor_grid_cache.push(DebugVertex {
             position: [-3.0, 0.0, 0.0],
             _pad: 0.0,
@@ -771,7 +794,7 @@ impl RenderPass for DebugDrawPass {
             let mut grid_rebuilt = false;
             if self.editor_last_key != Some(key) || self.editor_last_volume_gen != Some(volume_gen)
             {
-                self.rebuild_editor_grid_cache(center_x, center_z, grid_step);
+                self.rebuild_editor_grid_cache(center_x, center_z, grid_step, state.color_blind_mode);
                 self.editor_grid_cache
                     .extend_from_slice(&state.editor_volume_lines);
                 self.editor_last_key = Some(key);

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -344,6 +344,16 @@ pub struct FrameResources<'a> {
 
     /// Sampler for planar_reflection.
     pub planar_reflection_sampler: Tracked<&'a wgpu::Sampler>,
+
+    // ── HLFS resources (populated by HLFS pass) ──
+
+    /// Clip-stack read views for the shade pass (4 levels of 128³ RGBA16F).
+    ///
+    /// Populated by `HlfsPass::publish()` after the clip-stack buffer swap.
+    pub hlfs_clip_stack: Option<[&'a wgpu::TextureView; 4]>,
+
+    /// HLFS-specific globals uniform buffer (HlfsGlobals layout).
+    pub hlfs_globals: Option<&'a wgpu::Buffer>,
 }
 
 // ── PVS CPU reference ──────────────────────────────────────────────────────────
@@ -459,6 +469,8 @@ impl<'a> FrameResources<'a> {
             ssr_trace: Tracked::empty(),
             planar_reflection: Tracked::empty(),
             planar_reflection_sampler: Tracked::empty(),
+            hlfs_clip_stack: None,
+            hlfs_globals: None,
         }
     }
 


### PR DESCRIPTION
Cherry-picks our 3 commits from the feat/401-hlfs-phase1 branch onto main:

1. Update debug.rs — SubmissionIndex display for viewport decoupling
2. Update execution.rs — thread SubmissionIndex through execution graph  
3. HLFS Phase 1 — data structures and clip-stack host-side management

These were developed on the feat/401-hlfs-phase1 branch alongside unrelated planetary voxel and asset-configurator work. This PR cherry-picks only our commits to main.