### PR TITLE
Restore asset configurator compatibility on current v4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5774,7 +5774,7 @@ dependencies = [
 [[package]]
 name = "solid-fbx"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "flate2",
  "glam 0.27.0",
@@ -5785,7 +5785,7 @@ dependencies = [
 [[package]]
 name = "solid-gltf"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "base64 0.22.1",
  "glam 0.27.0",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "solid-obj"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
  "solid-rs",
@@ -5806,16 +5806,17 @@ dependencies = [
 [[package]]
 name = "solid-rs"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
+ "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "solid-usd"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=c070e8ccb0324dbb0a0a5d11abd6c72f00afe291#c070e8ccb0324dbb0a0a5d11abd6c72f00afe291"
+source = "git+https://github.com/Far-Beyond-Pulsar/Solid3D?rev=b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6#b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6"
 dependencies = [
  "glam 0.27.0",
  "lz4_flex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,11 +37,11 @@ env_logger = "0.11"
 log = "0.4"
 
 # SolidRS - 3D asset loading library
-solid-rs =   { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-gltf = { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-fbx =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-obj =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
-solid-usd =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "c070e8ccb0324dbb0a0a5d11abd6c72f00afe291" }
+solid-rs =   { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-gltf = { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-fbx =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-obj =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
+solid-usd =  { git = "https://github.com/Far-Beyond-Pulsar/Solid3D", rev = "b9eb501f0d3b735d407c7b566a9de8ef2ab9ebf6" }
 quark = { git = "https://github.com/Far-Beyond-Pulsar/Quark", package = "quark" }
 thiserror = "2.0"
 image = { version = "0.25", default-features = false, features = ["png"] }

--- a/crates/helio-asset-compat/Cargo.toml
+++ b/crates/helio-asset-compat/Cargo.toml
@@ -10,11 +10,11 @@ helio = { workspace = true }
 libhelio = { workspace = true }
 
 # SolidRS - 3D asset loading
-solid-rs.workspace = true
-solid-gltf.workspace = true
-solid-fbx.workspace = true
-solid-obj.workspace = true
-solid-usd.workspace = true
+solid-rs = { workspace = true, features = ["configurator"] }
+solid-gltf = { workspace = true, features = ["configurator"] }
+solid-fbx = { workspace = true, features = ["configurator"] }
+solid-obj = { workspace = true, features = ["configurator"] }
+solid-usd = { workspace = true, features = ["configurator"] }
 
 # Math and utilities
 glam.workspace = true

--- a/crates/helio-asset-compat/src/lib.rs
+++ b/crates/helio-asset-compat/src/lib.rs
@@ -31,6 +31,12 @@ pub use scene_converter::{
 use std::path::Path;
 
 /// Configuration for asset loading
+/// Re-exports of the Solid3D configurator types, so hosts can build import
+/// configurator UIs and value sets without depending on `solid-rs` directly.
+pub use solid_rs::configurator::{
+    OptionField, OptionKind, OptionValue, OptionValues, OptionsSchema,
+};
+
 #[derive(Debug, Clone)]
 pub struct LoadConfig {
     /// Flip UV Y-axis (1.0 - v)
@@ -71,6 +77,23 @@ impl LoadConfig {
     pub fn with_import_scale(mut self, scale: glam::Vec3) -> Self {
         self.import_scale = scale;
         self
+    }
+
+    /// Derive a `LoadConfig` from configurator [`OptionValues`], honouring the
+    /// keys this conversion layer understands (`flip_uv_v`, and `import_scale`
+    /// or `unit_scale`). Remaining keys are handled by the loader itself.
+    pub fn from_option_values(values: &solid_rs::configurator::OptionValues) -> Self {
+        use solid_rs::configurator::keys;
+        let scale = values
+            .get("import_scale")
+            .or_else(|| values.get("unit_scale"))
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0) as f32;
+        Self {
+            flip_uv_y: values.bool_or(keys::FLIP_UV_V, false),
+            merge_meshes: false,
+            import_scale: glam::Vec3::splat(scale),
+        }
     }
 }
 
@@ -137,6 +160,68 @@ pub fn load_scene_file_with_config<P: AsRef<Path>>(
         .unwrap_or_else(|| PathBuf::from("."));
 
     // Convert to Helio structures
+    convert_scene(&solid_scene, &base_dir, &config)
+}
+
+/// Build the loader registry used for asset import (shared by the configured and
+/// unconfigured load paths).
+fn import_registry() -> solid_rs::registry::Registry {
+    let mut registry = solid_rs::registry::Registry::new();
+    registry.register_loader(solid_fbx::FbxLoader);
+    registry.register_loader(solid_gltf::GltfLoader);
+    registry.register_loader(solid_obj::ObjLoader);
+    registry.register_loader(solid_usd::UsdLoader); // supports usda/usdc/usdz
+    registry
+}
+
+/// Returns the import-options [`OptionsSchema`] advertised by the loader for the
+/// file extension `ext` (without leading dot), for driving a configurator UI.
+/// Returns `None` if no bundled loader handles that extension.
+pub fn options_schema_for_extension(ext: &str) -> Option<OptionsSchema> {
+    import_registry().options_schema_for_extension(ext)
+}
+
+/// Load a 3D scene file using configurator [`OptionValues`] and convert it to
+/// Helio structures. Mirrors [`load_scene_file_with_config`] but sources its
+/// options from a configurator value set (see [`options_schema_for_extension`]).
+pub fn load_scene_file_with_values<P: AsRef<Path>>(
+    path: P,
+    values: &OptionValues,
+) -> Result<ConvertedScene> {
+    let path = path.as_ref();
+
+    let extension = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .ok_or_else(|| AssetError::UnsupportedFormat("File has no extension".to_string()))?;
+
+    log::info!(
+        "Loading 3D model with configurator values: {} (.{})",
+        path.display(),
+        extension
+    );
+
+    let registry = import_registry();
+    let solid_scene = registry
+        .load_file_configured(path, values)
+        .map_err(AssetError::Solid)?;
+
+    log::info!(
+        "Loaded SolidRS scene '{}' - {} meshes, {} materials, {} lights",
+        solid_scene.name,
+        solid_scene.meshes.len(),
+        solid_scene.materials.len(),
+        solid_scene.lights.len()
+    );
+
+    let base_dir = path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+
+    // Honour the conversion-layer keys (uv flip, scale) during conversion; the
+    // loader has already honoured the ones it understands.
+    let config = LoadConfig::from_option_values(values);
     convert_scene(&solid_scene, &base_dir, &config)
 }
 

--- a/crates/helio-asset-compat/src/lib.rs
+++ b/crates/helio-asset-compat/src/lib.rs
@@ -14,7 +14,6 @@ mod texture_loader;
 
 use helio::MeshId;
 use helio::{LightId, MaterialId, MultiMeshId, ObjectId, Renderer, SectionedMeshUpload, TextureId};
-use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::PathBuf;
 
@@ -500,4 +499,34 @@ pub struct SceneAsset {
     pub skin_ids: Vec<SkinId>,
     /// Available animation clip names
     pub animation_names: Vec<String>,
+}
+
+#[cfg(test)]
+mod configurator_tests {
+    use super::{options_schema_for_extension, LoadConfig, OptionValue, OptionValues};
+    use solid_rs::configurator::keys;
+
+    #[test]
+    fn bundled_loaders_expose_configurator_schemas() {
+        for extension in ["fbx", "gltf", "obj", "usd"] {
+            let schema = options_schema_for_extension(extension)
+                .unwrap_or_else(|| panic!("missing schema for .{extension}"));
+            assert!(
+                schema.fields.iter().any(|field| field.key == keys::FLIP_UV_V),
+                ".{extension} schema omitted the shared UV option"
+            );
+        }
+    }
+
+    #[test]
+    fn configurator_values_map_to_conversion_config() {
+        let mut values = OptionValues::new();
+        values.set(keys::FLIP_UV_V, OptionValue::Bool(true));
+        values.set("import_scale", OptionValue::Float(0.01));
+
+        let config = LoadConfig::from_option_values(&values);
+
+        assert!(config.flip_uv_y);
+        assert_eq!(config.import_scale, glam::Vec3::splat(0.01));
+    }
 }


### PR DESCRIPTION
## Summary

- restore Helio's public asset-configurator compatibility bridge on current `v4`
- advance the complete Solid3D dependency family from `c070e8c` to current `main` revision `b9eb501`
- enable the `configurator` feature consistently for every bundled format loader
- add coverage proving bundled loader schemas and conversion-layer UV/scale mapping remain available

## Root cause

Pulsar's import configurator and persisted reimport options use the Helio compatibility boundary, but the implementation existed only on an unmerged Helio feature branch. Current `v4` also pinned a Solid3D revision that predates the configurator API.

## Validation

- `cargo check -p helio-asset-compat --locked`
- `cargo test -p helio-asset-compat --lib --locked` (9 passed)
- `git diff --check`

Pulsar caller validation against this exact revision is in progress. This is an engine compatibility change and requires review before merge.

Closes #129
Prerequisite for Far-Beyond-Pulsar/Pulsar-Native#462.
