### PR TITLE
Publish authoritative SceneDB resources to Helio render graphs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1504,6 +1504,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1895,6 +1909,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2260,6 +2288,18 @@ dependencies = [
  "wgpu 30.0.0",
  "winit",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -2738,6 +2778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,6 +2812,7 @@ dependencies = [
  "helio-bake",
  "helio-core",
  "helio-pass-postprocess",
+ "helio-scenedb",
  "helio-voxel-core",
  "image",
  "libhelio",
@@ -3301,6 +3351,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "helio-scenedb"
+version = "0.1.0"
+dependencies = [
+ "bytemuck",
+ "libhelio",
+ "naga 30.0.0",
+ "pollster 0.4.0",
+ "pulsar_scenedb",
+ "wgpu 30.0.0",
+]
+
+[[package]]
 name = "helio-snapshot"
 version = "0.1.0"
 dependencies = [
@@ -3407,6 +3469,30 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core 0.58.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_collections"
@@ -3581,6 +3667,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -3790,6 +3885,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.9.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4738,6 +4844,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5001,6 +5113,19 @@ dependencies = [
 
 [[package]]
 name = "profiling"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Profiling?rev=12424a5f75166332f9f1d2741281f6fc4847b44d#12424a5f75166332f9f1d2741281f6fc4847b44d"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "once_cell",
+ "parking_lot",
+ "rusqlite",
+ "serde",
+]
+
+[[package]]
+name = "profiling"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
@@ -5016,6 +5141,46 @@ checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
  "syn",
+]
+
+[[package]]
+name = "pulsar_reflection"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=cf37ed000fedb9a01424c7e575d1d6ee30db7281#cf37ed000fedb9a01424c7e575d1d6ee30db7281"
+dependencies = [
+ "dashmap",
+ "glam 0.33.2",
+ "inventory",
+ "once_cell",
+ "pulsar_reflection_derive",
+ "serde",
+ "serde_json",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "pulsar_reflection_derive"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=cf37ed000fedb9a01424c7e575d1d6ee30db7281#cf37ed000fedb9a01424c7e575d1d6ee30db7281"
+dependencies = [
+ "owo-colors",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pulsar_scenedb"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=43921b0d432e99654161e1de65799fb65fa629f0#43921b0d432e99654161e1de65799fb65fa629f0"
+dependencies = [
+ "ahash",
+ "profiling 0.1.0",
+ "pulsar_reflection",
+ "serde_json",
+ "tracing",
+ "wgpu 30.0.0",
 ]
 
 [[package]]
@@ -5184,7 +5349,7 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "parry3d 0.19.0",
- "profiling",
+ "profiling 1.0.18",
  "rustc-hash 2.1.3",
  "serde",
  "simba 0.9.1",
@@ -5210,7 +5375,7 @@ dependencies = [
  "crossbeam",
  "md5",
  "nalgebra 0.33.3",
- "profiling",
+ "profiling 1.0.18",
  "rand",
  "rand_pcg",
  "rapier3d 0.24.0",
@@ -5394,6 +5559,20 @@ checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
 dependencies = [
  "heapless",
  "num-traits",
+ "smallvec",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
  "smallvec",
 ]
 
@@ -6424,6 +6603,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6679,7 +6864,7 @@ dependencies = [
  "log",
  "naga 23.1.0",
  "parking_lot",
- "profiling",
+ "profiling 1.0.18",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
@@ -6709,7 +6894,7 @@ dependencies = [
  "naga 30.0.0",
  "parking_lot",
  "portable-atomic",
- "profiling",
+ "profiling 1.0.18",
  "raw-window-handle",
  "smallvec",
  "static_assertions",
@@ -6737,7 +6922,7 @@ dependencies = [
  "naga 23.1.0",
  "once_cell",
  "parking_lot",
- "profiling",
+ "profiling 1.0.18",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
@@ -6767,7 +6952,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "portable-atomic",
- "profiling",
+ "profiling 1.0.18",
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
@@ -6838,7 +7023,7 @@ dependencies = [
  "objc",
  "once_cell",
  "parking_lot",
- "profiling",
+ "profiling 1.0.18",
  "range-alloc",
  "raw-window-handle",
  "renderdoc-sys",
@@ -6890,7 +7075,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "portable-atomic-util",
- "profiling",
+ "profiling 1.0.18",
  "range-alloc",
  "raw-window-handle",
  "raw-window-metal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,8 @@ helio-pass-decal = { path = "crates/helio-pass-decal" }
 helio-pass-sdf = { path = "crates/helio-pass-sdf" }
 helio-pass-voxel-mesh = { path = "crates/helio-pass-voxel-mesh" }
 helio-pass-fxaa = { path = "crates/helio-pass-fxaa" }
+helio-scenedb = { path = "crates/helio-scenedb" }
+pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "43921b0d432e99654161e1de65799fb65fa629f0", features = ["gpu"] }
 
 [dependencies]
 tiny_http = "0.12"

--- a/crates/helio-scenedb/Cargo.toml
+++ b/crates/helio-scenedb/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "helio-scenedb"
+version = "0.1.0"
+edition = "2021"
+description = "Helio <-> SceneDB binding seam: SceneDbBinding binds SceneDB-owned GPU buffers into Helio's bind-group model (M3-a T9, design Rev 2 S5)"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# This is the only Helio crate allowed to name SceneDB. The exact workspace
+# revision is shared with Pulsar so a caller can pass SceneDB-owned GPU state
+# across this boundary without Cargo creating incompatible package identities.
+# The dependency direction remains SceneDB -> nothing renderer-specific and
+# Helio -> SceneDB, preserving the ownership law.
+pulsar_scenedb = { workspace = true }
+# Helio's workspace wgpu = 30 (crates.io) -- MUST resolve to the same major
+# as `pulsar_scenedb`'s own `gpu`-feature wgpu dep (also crates.io 30). Both
+# requirements ("30" here, "30" in pulsar_scenedb/Cargo.toml) unify to ONE
+# Cargo.lock entry (wgpu 30.0.0, crates.io) when this workspace is resolved
+# as a whole -- verified against Pulsar-Native's root Cargo.lock, which
+# carries exactly one crates.io `wgpu 30.0.0` entry (plus an unrelated
+# `wgpu 28.0.0` git-forked entry other Pulsar crates pin, not touched by
+# this seam). Fixed a stale version of this comment (T9 final-review F3)
+# that claimed "two separate Cargo.lock entries" -- not how Cargo.lock
+# unification works for compatible semver requirements in one resolution.
+# What genuinely has no dependency-graph enforcement is the two requirements
+# staying compatible over time: nothing pins them together, so they could
+# drift to incompatible majors in a future edit and Cargo would happily
+# resolve two different `wgpu` versions. `tests/seam_smoke.rs` IS that
+# enforcement in practice -- see that file's doc comment.
+wgpu = { workspace = true }
+libhelio = { workspace = true }
+# M3-b T5 (cull.rs): `bytemuck::{Pod, Zeroable}` for the Helio-owned derived
+# structs (`DrawCommand`/`CullRecord`/`CullUniforms`) written to/read from
+# the cull pass's own buffers -- same workspace dep every other Helio pass
+# crate already uses (`helio-pass-occlusion-cull`'s `CullParams`, etc.).
+bytemuck = { workspace = true }
+
+[dev-dependencies]
+pollster = { workspace = true }
+# naga tracks the same major as Helio's workspace wgpu (crates.io 30) — the
+# Test 3 reflection harness (`tests/binding_layout.rs`, M3-a T10) parses
+# `wgsl::SCENE_BINDINGS_WGSL` with naga's WGSL front end and reflects struct
+# layout via `naga::proc::Layouter`, mirroring `pulsar_scenedb/tests/
+# gpu_layout.rs`'s harness exactly (same naga major, same API forms).
+naga = { version = "30", features = ["wgsl-in"] }
+
+# M3-b T9: cull/draw pass timing + the S14.2 readback-latency decision.
+# `harness = false` (matches `pulsar_scenedb/benches/gpu_timing.rs`'s own
+# choice, same task lineage): TIMESTAMP_QUERY brackets make each iteration
+# self-measuring, so this is a plain `main()` doing its own warm-up/sample-
+# size/statistics and printing a table, not a criterion harness.
+[[bench]]
+name = "pass_timing"
+harness = false

--- a/crates/helio-scenedb/benches/pass_timing.rs
+++ b/crates/helio-scenedb/benches/pass_timing.rs
@@ -1,0 +1,1009 @@
+//! M3-β T9: cull/draw pass GPU timing + the §14.2 readback-latency decision.
+//!
+//! This is the measurement task that closes the perf campaign's deferred
+//! GPU-side claims (perf-validation report §2.7, contract #5/#43/#47's
+//! timing sub-claim) now that a real cull pass (T5) and indirect draw
+//! executor (T7) exist to time. Four deliverables, each a section below:
+//!
+//! 1. Cull dispatch GPU time at N ∈ {1k, 10k, 100k} tokens × visible
+//!    fractions {100%, 50%, 10%}.
+//! 2. Indirect draw GPU time for the visible set at the same 9 cells.
+//! 3. THE §14.2 DECISION: readback-then-clamp (what T7/T8 do today) vs
+//!    conservative max-count (dispatch `capacity` draws unconditionally,
+//!    `instance_count=0` on the culled slots, no readback) — measured
+//!    end-to-end (CPU wall time) at N=10,000/10% visible, the scale the
+//!    plan brief itself names as "many culled draws for (b) to waste."
+//! 4. Cull+draw total vs. a no-cull "draw everything" baseline at the same
+//!    3 N-scales — first real evidence for perf-report DEFERRED claim #5
+//!    ("CPU out of the GPU inner loop").
+//!
+//! ## Methodology inherited from T3 (perf-validation report §1.2/§1.3)
+//!
+//! **GPU-timestamp bracket.** [`GpuTimer`] below is copied wholesale from
+//! `pulsar_scenedb/benches/gpu_timing.rs` (that file's own reuse note:
+//! "later tasks can copy it wholesale into their own bench files") — same
+//! two-submit shape (`submit([start])` → `work()` → `submit([end, resolve,
+//! copy])`), same reasoning (`wgpu-core-30.0.0`'s `executions.insert(0, ..)`
+//! always splices the queue's pending-writes belt at position 0 of a
+//! submission, so a single-submit bracket built around `queue.write_buffer`
+//! reads ~0 regardless of payload).
+//!
+//! **One documented deviation from T3's `work()` contract.** T3's doc
+//! comment states `work` "must NOT itself call `queue.submit`" — true for
+//! its own payload (`queue.write_buffer` calls only, which rely on the
+//! pending-writes belt). This file's payload is different: real compute
+//! dispatches / indexed-indirect draws, which cannot be expressed as
+//! pending writes at all — they only exist once recorded into a command
+//! buffer and submitted. This bench's `work()` closures therefore DO call
+//! `queue.submit` on their own encoder. This is still bracket-correct: wgpu
+//! guarantees same-queue submissions execute in submission order (T3's own
+//! file doc cites this exact guarantee for why the two-submit form works),
+//! and that guarantee does not depend on which submission call-site issued
+//! which encoder — only on submission ORDER, which is: [start_ts] →
+//! [work()'s own submit(s)] → [end_ts, resolve, copy]. No `write_buffer`
+//! call happens inside any of this file's timed brackets, so the pending-
+//! writes-splice hazard T3 discovered does not apply here at all; the
+//! two-submit *shape* is kept purely for methodology continuity with T3/T4/
+//! T6, not because this payload has the same failure mode.
+//!
+//! **Amplification.** Cull dispatch recording is O(1) CPU-side regardless
+//! of N (one `dispatch_workgroups` call encodes the whole N-thread launch),
+//! so cull timing uses a FIXED repeat count ([`REPEATS_CULL`]) at every
+//! scale — GPU execution time already scales with N per dispatch, no
+//! CPU-side blow-up risk. Draw timing is different: `DrawExecutor::record`
+//! issues one CPU-side `draw_indexed_indirect` call PER COMMAND (draw.rs's
+//! documented mechanism, not `multi_draw_indexed_indirect`), so repeating a
+//! large command_count many times would blow the "sane wall time" budget —
+//! draw repeat count is therefore ADAPTIVE (`draw_repeats`), targeting a
+//! roughly constant total command count per bracket regardless of scale.
+//!
+//! **Fixed-slack honesty gates**, not noise-derived (T3's dead-bracket
+//! lesson, perf-validation report §1.3(c)): every monotonicity assert below
+//! uses a constant nanosecond slack, and the payload-visibility check
+//! compares the largest-N cull mean against an INDEPENDENTLY measured noise
+//! floor (an empty-`work()` bracket — literally zero GPU commands between
+//! the two timestamp submits), not a floor derived from the same trend
+//! being validated.
+//!
+//! ## Scene fixture shape
+//!
+//! `SpatialCell`/`CellStorage` hard-caps at 1024 rows/cell
+//! (`pulsar_scenedb::MAX_PAGE_CAPACITY`), so N=100,000 tokens needs ~98
+//! independently-registered cells (gpu_timing.rs's T3 precedent for "one
+//! bigger cell is not an option"). Rows are placed at one of two fixed
+//! positions: `x=0` (comfortably inside `support::view_proj_90deg`'s
+//! fovy=90 frustum, matching `cull_pass.rs` row 0's geometry) or `x=1000`
+//! (frustum-culled, matching `cull_pass.rs` row 1's geometry) — the first
+//! `round(N * visible_fraction)` GLOBAL rows (in cell-registration order)
+//! get the visible position, the rest get the culled one. This is verified,
+//! not assumed: every fixture runs one untimed real cull dispatch + counter
+//! readback before any timing loop starts, asserting `stale_drops==0`,
+//! `oob_drops==0`, and `visible_count == round(N*frac)` exactly (house law:
+//! self-verifying fixture guards).
+
+#[path = "../tests/support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullRecord, CullUniforms};
+use helio_scenedb::draw::{DrawExecutor, DrawUniforms};
+use helio_scenedb::repack::{packed_indirect_buffer, RepackPass};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellId, CellSlot, ClusterBuffer, EngineGpuContext, FrameDriver, GeometryArena, HarvestPipeline,
+    HarvestStaging, MaterialRegistry, MeshClass, MeshRegistry, MeshletBuffer, RegionClassConfig,
+    SceneGpuConfig, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, Handle, InstanceInfo, Scratchpad, SpatialCell};
+use std::time::Instant;
+
+use support::{frustum_planes_90deg, mesh, readback, translation, view_proj_90deg};
+
+const MAX_CELL_ROWS: u32 = 1024;
+const NS: [u32; 3] = [1_000, 10_000, 100_000];
+const FRACS: [f32; 3] = [1.0, 0.5, 0.1];
+
+const WARMUP_PASS: usize = 2;
+const ITERS_PASS: usize = 8;
+const REPEATS_CULL: u32 = 32;
+/// Adaptive draw-bracket repeat count: target ~`DRAW_TARGET_TOTAL` recorded
+/// `draw_indexed_indirect` calls per bracket sample regardless of scale
+/// (module doc: CPU-side recording cost scales with command_count, unlike
+/// cull's O(1)-per-dispatch recording).
+const DRAW_TARGET_TOTAL: u32 = 1000;
+const DRAW_REPEATS_CAP: u32 = 32;
+
+const WARMUP_WALL: usize = 5;
+const ITERS_WALL: usize = 30;
+
+const QUAD_VERTICES: [[f32; 3]; 4] =
+    [[-0.5, -0.5, 0.0], [0.5, -0.5, 0.0], [0.5, 0.5, 0.0], [-0.5, 0.5, 0.0]];
+const QUAD_INDICES: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+/// Mirrors `support::test_context_indirect_first_instance` PLUS
+/// `TIMESTAMP_QUERY`/`TIMESTAMP_QUERY_INSIDE_ENCODERS` (T3's requirement for
+/// `CommandEncoder::write_timestamp` outside a pass) — this bench is the
+/// first `helio-scenedb` harness to need BOTH feature sets at once (T7's
+/// indirect-first-instance requirement for nonzero `first_instance`, T3's
+/// timestamp requirement for GPU-side pass timing).
+fn test_context() -> EngineGpuContext {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+        apply_limit_buckets: false,
+    }))
+    .expect("no adapter -- GPU bench needs a local GPU");
+    let required_features = wgpu::Features::INDIRECT_FIRST_INSTANCE
+        | wgpu::Features::TIMESTAMP_QUERY
+        | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+    assert!(
+        adapter.features().contains(required_features),
+        "adapter must support INDIRECT_FIRST_INSTANCE + TIMESTAMP_QUERY(_INSIDE_ENCODERS) -- \
+         verified present on this host's RTX 5080/Vulkan adapter (T3/T7 precedent)"
+    );
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("helio-scenedb-pass-timing-bench"),
+        required_features,
+        required_limits: wgpu::Limits::default(),
+        ..Default::default()
+    }))
+    .expect("device");
+    EngineGpuContext::new(std::sync::Arc::new(device), std::sync::Arc::new(queue))
+}
+
+/// Two-submit GPU timestamp bracket -- copied wholesale from
+/// `pulsar_scenedb/benches/gpu_timing.rs`'s `GpuTimer` (T3's own reuse
+/// note). See this file's module doc for the one documented deviation
+/// (`work()` here calls `queue.submit` itself, since its payload is real
+/// dispatch/draw commands, not `queue.write_buffer` pending writes).
+struct GpuTimer {
+    query_set: wgpu::QuerySet,
+    resolve_buf: wgpu::Buffer,
+    staging_buf: wgpu::Buffer,
+    period_ns: f32,
+}
+
+impl GpuTimer {
+    fn new(ctx: &EngineGpuContext) -> Self {
+        let query_set = ctx.device().create_query_set(&wgpu::QuerySetDescriptor {
+            label: Some("pass-timing-query-set"),
+            ty: wgpu::QueryType::Timestamp,
+            count: 2,
+        });
+        let resolve_buf = ctx.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pass-timing-resolve"),
+            size: 16,
+            usage: wgpu::BufferUsages::QUERY_RESOLVE | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+        let staging_buf = ctx.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("pass-timing-staging"),
+            size: 16,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let period_ns = ctx.queue().get_timestamp_period();
+        Self { query_set, resolve_buf, staging_buf, period_ns }
+    }
+
+    fn measure_ns(&self, ctx: &EngineGpuContext, work: impl FnOnce()) -> u64 {
+        let mut enc_start = ctx.device().create_command_encoder(&Default::default());
+        enc_start.write_timestamp(&self.query_set, 0);
+        ctx.queue().submit([enc_start.finish()]);
+
+        work();
+
+        let mut enc_end = ctx.device().create_command_encoder(&Default::default());
+        enc_end.write_timestamp(&self.query_set, 1);
+        enc_end.resolve_query_set(&self.query_set, 0..2, &self.resolve_buf, 0);
+        enc_end.copy_buffer_to_buffer(&self.resolve_buf, 0, &self.staging_buf, 0, 16);
+        ctx.queue().submit([enc_end.finish()]);
+
+        let slice = self.staging_buf.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |r| r.expect("map"));
+        ctx.device().poll(wgpu::PollType::wait_indefinitely()).expect("poll");
+        let data = slice.get_mapped_range().expect("mapped range");
+        let t0 = u64::from_le_bytes(data[0..8].try_into().unwrap());
+        let t1 = u64::from_le_bytes(data[8..16].try_into().unwrap());
+        drop(data);
+        self.staging_buf.unmap();
+
+        let ticks = t1.wrapping_sub(t0);
+        (ticks as f64 * self.period_ns as f64).round() as u64
+    }
+}
+
+/// mean / p95 (nearest-rank) over a sample set.
+fn stats(mut samples: Vec<f64>) -> (f64, f64) {
+    samples.sort_by(|a, b| a.total_cmp(b));
+    let n = samples.len();
+    let mean = samples.iter().copied().sum::<f64>() / n as f64;
+    let p95_idx = (((n - 1) as f64) * 0.95).round() as usize;
+    (mean, samples[p95_idx])
+}
+
+/// min / mean / p95 -- used for the §14.2 wall-clock series (M3-b T9
+/// review: report a RANGE, not a point). The min/max spread WITHIN one
+/// process run is a floor on the true cross-process variance (T9 review
+/// defect 2 found run-to-run swings this bench's own single-process stats
+/// cannot see at all) -- both are reported, neither substitutes the other.
+fn stats3(mut samples: Vec<f64>) -> (f64, f64, f64) {
+    samples.sort_by(|a, b| a.total_cmp(b));
+    let n = samples.len();
+    let min = samples[0];
+    let mean = samples.iter().copied().sum::<f64>() / n as f64;
+    let p95_idx = (((n - 1) as f64) * 0.95).round() as usize;
+    (min, mean, samples[p95_idx])
+}
+
+fn draw_repeats(command_count: u32) -> u32 {
+    (DRAW_TARGET_TOTAL / command_count.max(1)).clamp(1, DRAW_REPEATS_CAP)
+}
+
+// ======================================================================
+// M3-b T9 review (defect 1) fix: strategy (b') -- the STRONGEST no-
+// readback realization of "conservative max-count" available in wgpu 30
+// without any extra `wgpu::Features`. `RenderPass::multi_draw_indexed_
+// indirect` (`draw.rs`'s `DrawExecutor::record_multi_indirect`) issues
+// `count` GPU-side draws from ONE CPU call, gated only by
+// `DownlevelFlags::INDIRECT_EXECUTION` (universal on desktop backends,
+// verified against `wgpu-30.0.0/src/api/render_pass.rs:346-389` -- NOT
+// `Features::MULTI_DRAW_INDIRECT_COUNT`, which gates only the separate
+// `_count` variant). Its own doc requires a TIGHTLY PACKED 20-byte
+// `DrawIndexedIndirectArgs` array; `CullOutputBuffers`' `CullRecord`
+// stride is 32 bytes (`cull.rs`'s module doc has the group(2) storage-
+// budget reason), so a repack pass bridges that gap -- ONE GPU-side
+// compute dispatch, no CPU readback, no CPU stall: reads each
+// `CullRecord`'s first 20 bytes and writes them densely to a separate
+// buffer.
+//
+// M3-b T9-followup (review defect 2): this repack used to be a bench-local
+// copy (`REPACK_WGSL`/`RepackPass`/`packed_indirect_buffer`, defined right
+// here). It is now `helio_scenedb::repack::{RepackPass, packed_
+// indirect_buffer}` -- a real library capability
+// `DrawExecutor::record_multi_indirect` callers outside this bench can
+// actually use (see `src/repack.rs`'s module doc and `src/wgsl.rs`'s
+// `REPACK_WGSL` doc for the full 32->20 byte field contract). This bench
+// now CALLS the promoted capability rather than keeping its own copy --
+// a duplicated repack is exactly how the two would drift.
+// ======================================================================
+
+/// One fully-built, real (non-synthetic) scene fixture: `n` tokens spread
+/// across `ceil(n/1024)` cells, `round(n*visible_fraction)` of them
+/// (lowest global rows first) placed inside the frustum, the rest outside
+/// it. `output` already holds a VERIFIED real cull result (see module doc)
+/// -- `visible_count` is the measured, asserted-correct value, not the
+/// requested `visible_fraction` rounded blind.
+struct SceneFixture {
+    #[allow(dead_code)]
+    store: SceneGpuStore,
+    view_tokens: ViewTokenBuffers,
+    scene_binding: SceneDbBinding,
+    cull_pass: CullPass,
+    draw_executor: DrawExecutor,
+    output: CullOutputBuffers,
+    output_bind_group: wgpu::BindGroup,
+    draw_output_bind_group: wgpu::BindGroup,
+    n: u32,
+    visible_count: u32,
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_scene(
+    ctx: &EngineGpuContext,
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    meshes: &MeshRegistry,
+    clusters: &ClusterBuffer,
+    meshlets: &MeshletBuffer,
+    materials: &MaterialRegistry,
+    n: u32,
+    visible_fraction: f32,
+) -> SceneFixture {
+    let visible_target = (n as f32 * visible_fraction).round() as u32;
+    let num_cells = n.div_ceil(MAX_CELL_ROWS);
+
+    let cfg = SceneGpuConfig {
+        classes: vec![RegionClassConfig { capacity: MAX_CELL_ROWS, max_resident_cells: num_cells.max(1) }],
+        tombstone_headroom: 8,
+        max_cells_metadata: num_cells.max(1),
+    };
+    let mut store = SceneGpuStore::new(ctx, cfg);
+
+    let mut caps: Vec<u32> = Vec::with_capacity(num_cells as usize);
+    let mut remaining = n;
+    for _ in 0..num_cells {
+        let cap = remaining.min(MAX_CELL_ROWS);
+        caps.push(cap);
+        remaining -= cap;
+    }
+    let mut cells: Vec<SpatialCell> = caps.iter().map(|&c| SpatialCell::with_transform(c).unwrap()).collect();
+    let ids: Vec<CellId> = cells.iter().map(|c| store.register_cell(c.storage(), 0).unwrap()).collect();
+    let bases: Vec<u32> = ids.iter().map(|&id| store.row_region_base(id)).collect();
+
+    // --- Allocate + write every row (untimed setup). ---
+    let mut handles: Vec<Vec<Handle>> = Vec::with_capacity(num_cells as usize);
+    for (&base, (cell, &cap)) in bases.iter().zip(cells.iter_mut().zip(caps.iter())) {
+        let mut hs = Vec::with_capacity(cap as usize);
+        for li in 0..cap {
+            let global_row = base + li;
+            let x = if global_row < visible_target { 0.0 } else { 1000.0 };
+            let h = cell
+                .alloc(Aabb { min: [x - 1.0, -1.0, -11.0], max: [x + 1.0, 1.0, -9.0] })
+                .expect("cell capacity matches the fixed allocation count exactly");
+            hs.push(h);
+        }
+        handles.push(hs);
+    }
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (((cell, &id), &base), hs) in cells.iter_mut().zip(ids.iter()).zip(bases.iter()).zip(handles.iter()) {
+        for (li, &h) in hs.iter().enumerate() {
+            let global_row = base + li as u32;
+            let x = if global_row < visible_target { 0.0 } else { 1000.0 };
+            let xf = translation([x, 0.0, -10.0]);
+            assert!(store.write_transform(id, cell.storage_mut(), h, &xf, &sim));
+            assert!(store.write_instance_info(id, cell.storage_mut(), h, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+        }
+    }
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    // Generous view AABB covering both the visible (x=0) and the culled
+    // (x=1000) synthetic positions -- harvest is a broad-phase CPU query,
+    // independent of the cull SHADER's own precise frustum test (module doc).
+    let view = View::Aabb(Aabb { min: [-2000.0, -2000.0, -2000.0], max: [2000.0, 2000.0, 2000.0] });
+    let mut total_harvested = 0u32;
+    for (cell, &base) in cells.iter().zip(bases.iter()) {
+        total_harvested += pipeline.harvest_cell(cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    }
+    assert_eq!(total_harvested, n, "sanity: harvest must catch every synthetic row");
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots: Vec<CellSlot> = cells.iter_mut().zip(ids.iter()).map(|(cell, &id)| CellSlot { id, cell: cell.storage_mut() }).collect();
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(ctx, "pass-timing-view", 0);
+    view_tokens.upload(ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), n, "sanity: every token uploaded");
+
+    let scene_binding = SceneDbBinding::new(device, &store, meshes, clusters, meshlets, materials);
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let draw_executor = DrawExecutor::new(device, &scene_binding.cull_layout);
+    draw_executor.write_uniforms(queue, &DrawUniforms { view_proj: view_proj_90deg() });
+
+    let output = CullOutputBuffers::new(device, "pass-timing-cull-output", n.max(1));
+    output.clear_counters(queue);
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(queue, &uniforms);
+
+    // --- ONE untimed real cull dispatch: verifies the fixture's visible
+    // fraction is exactly what was asked for (house law: self-verifying
+    // fixture guard), and leaves `output` populated with a REAL cull result
+    // every subsequent draw-timing / baseline measurement reads from. ---
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+        queue.submit([encoder.finish()]);
+    }
+    let hdr = readback(ctx, output.buffer(), CullOutputBuffers::HEADER_BYTES);
+    let visible_count = u32::from_le_bytes(hdr[0..4].try_into().unwrap());
+    let stale_drops = u32::from_le_bytes(hdr[4..8].try_into().unwrap());
+    let oob_drops = u32::from_le_bytes(hdr[8..12].try_into().unwrap());
+    let frustum_drops = u32::from_le_bytes(hdr[12..16].try_into().unwrap());
+    assert_eq!(stale_drops, 0, "fixture has no stale rows");
+    assert_eq!(oob_drops, 0, "fixture has no OOB mesh_index rows");
+    assert_eq!(visible_count, visible_target, "guard: the synthetic visible-fraction fixture must produce EXACTLY the intended visible count");
+    assert_eq!(frustum_drops, n - visible_target, "guard: every non-visible row must be frustum-culled (no other drop category in this fixture)");
+
+    let draw_output_bind_group = draw_executor.build_output_bind_group(device, &output);
+
+    SceneFixture {
+        store,
+        view_tokens,
+        scene_binding,
+        cull_pass,
+        draw_executor,
+        output,
+        output_bind_group,
+        draw_output_bind_group,
+        n,
+        visible_count,
+    }
+}
+
+struct CellResult {
+    n: u32,
+    frac: f32,
+    visible: u32,
+    cull_mean: f64,
+    cull_p95: f64,
+    draw_mean: f64,
+    draw_p95: f64,
+    baseline_draw_mean: Option<f64>,
+    baseline_draw_p95: Option<f64>,
+}
+
+fn main() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue = ctx.queue();
+    let timer = GpuTimer::new(&ctx);
+    println!("timestamp_period_ns_per_tick = {:.4}", timer.period_ns);
+
+    // --- Shared geometry + asset registries (mesh0 reused by every
+    // fixture -- MeshDbBinding is built per-store, but the mesh/cluster/
+    // meshlet/material registries themselves are store-independent, so one
+    // shared set avoids rebuilding identical geometry 9 times). ---
+    let mut arena = GeometryArena::new(&ctx, 4096, 4096);
+    let vbytes: &[u8] = bytemuck::cast_slice(&QUAD_VERTICES);
+    let ibytes: &[u8] = bytemuck::cast_slice(&QUAD_INDICES);
+    let voff = arena.upload_vertices(queue, vbytes).unwrap();
+    let ioff = arena.upload_indices(queue, ibytes).unwrap();
+    let base_vertex = (voff / 12) as i32;
+    let first_index = ioff / 4;
+    let mut meshes = MeshRegistry::new(&ctx, 4);
+    let mesh0 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    assert_eq!(mesh0, 0);
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+
+    // --- Noise floor: an EMPTY bracket (zero GPU commands between the two
+    // timestamp submits) -- the honest floor this file's payload-visibility
+    // gate compares against (T3's dead-bracket lesson: derive the floor
+    // independently of the trend being validated). ---
+    let mut floor_samples = Vec::with_capacity(16);
+    for _ in 0..16 {
+        floor_samples.push(timer.measure_ns(&ctx, || {}) as f64);
+    }
+    let (floor_mean, floor_p95) = stats(floor_samples);
+    println!("noise_floor_ns (empty two-submit bracket, 16 samples) = mean {floor_mean:.1} p95 {floor_p95:.1}");
+
+    // ==================================================================
+    // Deliverables 1, 2, 4: cull GPU time / draw GPU time / no-cull
+    // baseline, at N x visible_fraction.
+    // ==================================================================
+    let mut results: Vec<CellResult> = Vec::new();
+    let mut item3_fixture: Option<SceneFixture> = None;
+
+    for &n in &NS {
+        for &frac in &FRACS {
+            let fixture = build_scene(&ctx, device, queue, &meshes, &clusters, &meshlets, &materials, n, frac);
+
+            // --- (1) Cull dispatch GPU time: REPEATS_CULL dispatches of
+            // the SAME N-thread cull, recorded into one encoder, one
+            // bracket. Correctness of the output past the first dispatch
+            // doesn't matter here (this measures dispatch cost, not a
+            // second verification) -- overflow past `capacity` is silently
+            // guarded by the shader itself (S14.2), never UB. ---
+            let mut cull_samples = Vec::with_capacity(ITERS_PASS);
+            for it in 0..(WARMUP_PASS + ITERS_PASS) {
+                let ns = timer.measure_ns(&ctx, || {
+                    let mut encoder = device.create_command_encoder(&Default::default());
+                    for _ in 0..REPEATS_CULL {
+                        fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &fixture.output_bind_group, fixture.view_tokens.count());
+                    }
+                    queue.submit([encoder.finish()]);
+                });
+                if it >= WARMUP_PASS {
+                    cull_samples.push(ns as f64 / REPEATS_CULL as f64);
+                }
+            }
+            let (cull_mean, cull_p95) = stats(cull_samples);
+
+            // --- (2) Indirect draw GPU time for the ALREADY-VERIFIED
+            // visible set (fixture.output holds a real, checked cull
+            // result from build_scene's setup dispatch). ---
+            let command_count = fixture.visible_count;
+            let draw_reps = draw_repeats(command_count.max(1));
+            // ONE throwaway target, created OUTSIDE every timed bracket and
+            // reused across all repeats/samples -- texture (re)allocation is
+            // not part of "draw pass GPU time" and must not bleed into the
+            // measurement (a per-repeat allocation would have, see the fix
+            // note in this file's history / M3-b T9 review).
+            let target = throwaway_target(device);
+            let mut draw_samples = Vec::with_capacity(ITERS_PASS);
+            for it in 0..(WARMUP_PASS + ITERS_PASS) {
+                let ns = timer.measure_ns(&ctx, || {
+                    let mut encoder = device.create_command_encoder(&Default::default());
+                    for _ in 0..draw_reps {
+                        fixture.draw_executor.record(
+                            &mut encoder,
+                            &target,
+                            &fixture.scene_binding.cull_bind_group,
+                            &fixture.draw_output_bind_group,
+                            &fixture.output,
+                            arena.vertex_buffer(),
+                            arena.index_buffer(),
+                            command_count,
+                        );
+                    }
+                    queue.submit([encoder.finish()]);
+                });
+                if it >= WARMUP_PASS {
+                    draw_samples.push(ns as f64 / draw_reps as f64);
+                }
+            }
+            let (draw_mean, draw_p95) = stats(draw_samples);
+
+            // --- (4) No-cull baseline, only at frac==1.0 (visible_count ==
+            // n there, i.e. fixture.output ALREADY holds a valid command
+            // for every one of the n rows -- "draw everything" needs no
+            // separate buffer). Skips the cull dispatch entirely: times
+            // ONLY the draw pass issuing n commands. ---
+            let (baseline_draw_mean, baseline_draw_p95) = if (frac - 1.0).abs() < 1e-6 {
+                let reps = draw_repeats(n.max(1));
+                let baseline_target = throwaway_target(device);
+                let mut samples = Vec::with_capacity(ITERS_PASS);
+                for it in 0..(WARMUP_PASS + ITERS_PASS) {
+                    let ns = timer.measure_ns(&ctx, || {
+                        let mut encoder = device.create_command_encoder(&Default::default());
+                        for _ in 0..reps {
+                            fixture.draw_executor.record(
+                                &mut encoder,
+                                &baseline_target,
+                                &fixture.scene_binding.cull_bind_group,
+                                &fixture.draw_output_bind_group,
+                                &fixture.output,
+                                arena.vertex_buffer(),
+                                arena.index_buffer(),
+                                n,
+                            );
+                        }
+                        queue.submit([encoder.finish()]);
+                    });
+                    if it >= WARMUP_PASS {
+                        samples.push(ns as f64 / reps as f64);
+                    }
+                }
+                let (m, p) = stats(samples);
+                (Some(m), Some(p))
+            } else {
+                (None, None)
+            };
+
+            println!(
+                "N={n}\tfrac={frac}\tvisible={}\tcull_ns(mean/p95)={cull_mean:.1}/{cull_p95:.1}\tdraw_ns(mean/p95)={draw_mean:.1}/{draw_p95:.1}\tbaseline_draw_ns={baseline_draw_mean:?}/{baseline_draw_p95:?}",
+                fixture.visible_count
+            );
+
+            results.push(CellResult {
+                n,
+                frac,
+                visible: fixture.visible_count,
+                cull_mean,
+                cull_p95,
+                draw_mean,
+                draw_p95,
+                baseline_draw_mean,
+                baseline_draw_p95,
+            });
+
+            // Stash the exact scale the §14.2 comparison (item 3) below
+            // wants (N=10,000 / 10% visible -- "many culled draws for (b)
+            // to waste"), instead of rebuilding it a second time.
+            if n == 10_000 && (frac - 0.1).abs() < 1e-6 {
+                item3_fixture = Some(fixture);
+            }
+        }
+    }
+
+    // ==================================================================
+    // Deliverable 3: THE §14.2 DECISION.
+    // ==================================================================
+    let fixture = item3_fixture.expect("N=10000/frac=0.1 cell must have run in the matrix above");
+    let device2: &wgpu::Device = ctx.device().as_ref();
+
+    // --- Standalone readback-latency measurement (the explicit §9(a)
+    // ask): map_async + poll round trip on the cull pass's atomic counter
+    // buffer, exactly as tests/draw_transform_sweep.rs's frame loop already
+    // pays it every frame. Two variants: header-only (16 B -- the minimum a
+    // real §14.2 clamp implementation needs) and full-buffer (what T7/T8's
+    // existing `readback()` helper actually reads today, header+records). ---
+    let mut header_only_ns = Vec::with_capacity(ITERS_WALL);
+    let mut full_buffer_ns = Vec::with_capacity(ITERS_WALL);
+    for it in 0..(WARMUP_WALL + ITERS_WALL) {
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &fixture.output_bind_group, fixture.view_tokens.count());
+            queue.submit([encoder.finish()]);
+        }
+        let t0 = Instant::now();
+        let _hdr = readback(&ctx, fixture.output.buffer(), CullOutputBuffers::HEADER_BYTES);
+        let t1 = Instant::now();
+        if it >= WARMUP_WALL {
+            header_only_ns.push((t1 - t0).as_nanos() as f64);
+        }
+    }
+    for it in 0..(WARMUP_WALL + ITERS_WALL) {
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &fixture.output_bind_group, fixture.view_tokens.count());
+            queue.submit([encoder.finish()]);
+        }
+        let t0 = Instant::now();
+        let _full = readback(&ctx, fixture.output.buffer(), fixture.output.byte_size());
+        let t1 = Instant::now();
+        if it >= WARMUP_WALL {
+            full_buffer_ns.push((t1 - t0).as_nanos() as f64);
+        }
+    }
+    let (header_mean, header_p95) = stats(header_only_ns);
+    let (full_mean, full_p95) = stats(full_buffer_ns);
+    println!();
+    println!("readback_latency_ns header_only(mean/p95) = {header_mean:.1}/{header_p95:.1}");
+    println!("readback_latency_ns full_buffer(mean/p95, matches T7/T8's existing readback()) = {full_mean:.1}/{full_p95:.1}");
+
+    // --- Strategy (a): readback-then-clamp, exactly what T7/T8 do today.
+    // Wall-clock per frame: cull submit -> map_async+poll STALL -> clamp ->
+    // draw submit (not polled -- matches draw_transform_sweep.rs, which
+    // never waits on the draw's own completion either). ---
+    let a_target = throwaway_target(device2);
+    let mut a_frame_ns = Vec::with_capacity(ITERS_WALL);
+    let mut a_stall_ns = Vec::with_capacity(ITERS_WALL);
+    for it in 0..(WARMUP_WALL + ITERS_WALL) {
+        fixture.output.clear_counters(queue);
+        let t_frame_start = Instant::now();
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &fixture.output_bind_group, fixture.view_tokens.count());
+            queue.submit([encoder.finish()]);
+        }
+        let t_stall_start = Instant::now();
+        let hdr = readback(&ctx, fixture.output.buffer(), CullOutputBuffers::HEADER_BYTES);
+        let t_stall_end = Instant::now();
+        let visible = u32::from_le_bytes(hdr[0..4].try_into().unwrap());
+        let command_count = visible.min(fixture.output.capacity());
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.draw_executor.record(
+                &mut encoder,
+                &a_target,
+                &fixture.scene_binding.cull_bind_group,
+                &fixture.draw_output_bind_group,
+                &fixture.output,
+                arena.vertex_buffer(),
+                arena.index_buffer(),
+                command_count,
+            );
+            queue.submit([encoder.finish()]);
+        }
+        let t_frame_end = Instant::now();
+        if it >= WARMUP_WALL {
+            a_frame_ns.push((t_frame_end - t_frame_start).as_nanos() as f64);
+            a_stall_ns.push((t_stall_end - t_stall_start).as_nanos() as f64);
+        }
+    }
+    let (a_frame_min, a_frame_mean, a_frame_p95) = stats3(a_frame_ns);
+    let (a_stall_min, a_stall_mean, a_stall_p95) = stats3(a_stall_ns);
+
+    // --- Strategy (b): conservative max-count. A SEPARATE output buffer,
+    // capacity == n (10,000), whose tail is pre-filled ONCE (untimed) with
+    // harmless `instance_count=0` records at every slot; the real per-frame
+    // cull dispatch then overwrites slots [0, visible_count) with real
+    // commands every frame -- overwriting the SAME compacted range each
+    // time since this fixture's visible set never changes frame to frame,
+    // so the pre-fill at slots >= visible_count is never touched by the
+    // shader and never needs re-priming. NO readback of the counter at
+    // all; the draw pass unconditionally issues `capacity` (== n) indirect
+    // calls every frame. ---
+    let mesh0_meta = (QUAD_INDICES.len() as u32, first_index, base_vertex);
+    let output_b = CullOutputBuffers::new(device2, "pass-timing-conservative-output", fixture.n);
+    fill_zero_instance_records(queue, &output_b, fixture.n, mesh0_meta);
+    let output_bind_group_b = fixture.cull_pass.build_output_bind_group(device2, &fixture.view_tokens, &output_b);
+    let draw_output_bind_group_b = fixture.draw_executor.build_output_bind_group(device2, &output_b);
+    let uniforms_b = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: fixture.view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output_b.capacity(),
+        reserved: 0,
+    };
+    fixture.cull_pass.write_uniforms(queue, &uniforms_b);
+
+    let b_target = throwaway_target(device2);
+    let mut b_frame_ns = Vec::with_capacity(ITERS_WALL);
+    for it in 0..(WARMUP_WALL + ITERS_WALL) {
+        output_b.clear_counters(queue); // enqueue-only write, no stall
+        let t_frame_start = Instant::now();
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &output_bind_group_b, fixture.view_tokens.count());
+            queue.submit([encoder.finish()]);
+        }
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.draw_executor.record(
+                &mut encoder,
+                &b_target,
+                &fixture.scene_binding.cull_bind_group,
+                &draw_output_bind_group_b,
+                &output_b,
+                arena.vertex_buffer(),
+                arena.index_buffer(),
+                output_b.capacity(), // conservative: ALWAYS capacity draws
+            );
+            queue.submit([encoder.finish()]);
+        }
+        let t_frame_end = Instant::now();
+        if it >= WARMUP_WALL {
+            b_frame_ns.push((t_frame_end - t_frame_start).as_nanos() as f64);
+        }
+    }
+    let (b_frame_min, b_frame_mean, b_frame_p95) = stats3(b_frame_ns);
+
+    // --- Strategy (b'): conservative max-count, STRONGEST no-readback
+    // realization (M3-b T9 review defect 1 fix -- see the RepackPass /
+    // `record_multi_indirect` doc comments for the full mechanism). Reuses
+    // `output_b` verbatim (same pre-fill, same real per-frame cull
+    // dispatch, same no-readback design as (b)) -- the ONLY difference is
+    // the draw-issue mechanism: a GPU-side repack pass turns output_b's
+    // 32-byte `CullRecord`s into a tightly-packed 20-byte indirect-args
+    // buffer, then ONE `multi_draw_indexed_indirect` call issues all
+    // `capacity` draws, instead of (b)'s CPU loop of `capacity` individual
+    // `draw_indexed_indirect` calls. All three passes (cull, repack, draw)
+    // batch into ONE encoder / ONE submit per frame -- matching how a real
+    // engine would build one frame's command buffer, and giving (b') the
+    // fewest possible CPU-side submit calls. ---
+    let repack_pass = RepackPass::new(device2);
+    repack_pass.write_capacity(queue, output_b.capacity());
+    let packed_buf = packed_indirect_buffer(device2, output_b.capacity());
+    let repack_bind_group = repack_pass.build_bind_group(device2, &output_b, &packed_buf);
+
+    // The repack pass's OWN GPU cost, charged honestly (not modeled away):
+    // one real cull dispatch primes output_b with real data (untimed
+    // setup), then the repack pass alone is bracketed with the SAME
+    // GpuTimer/amplification approach used for cull/draw pass timing above.
+    {
+        let mut encoder = device2.create_command_encoder(&Default::default());
+        fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &output_bind_group_b, fixture.view_tokens.count());
+        queue.submit([encoder.finish()]);
+    }
+    let repack_reps = draw_repeats(output_b.capacity().max(1));
+    let mut repack_samples = Vec::with_capacity(ITERS_PASS);
+    for it in 0..(WARMUP_PASS + ITERS_PASS) {
+        let ns = timer.measure_ns(&ctx, || {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            for _ in 0..repack_reps {
+                repack_pass.record(&mut encoder, &repack_bind_group, output_b.capacity());
+            }
+            queue.submit([encoder.finish()]);
+        });
+        if it >= WARMUP_PASS {
+            repack_samples.push(ns as f64 / repack_reps as f64);
+        }
+    }
+    let (repack_mean, repack_p95) = stats(repack_samples);
+    println!();
+    println!("repack_pass_ns (GPU, amortized, mean/p95) = {repack_mean:.1}/{repack_p95:.1} (capacity={} records, charged honestly as (b')'s own GPU cost, not modeled away)", output_b.capacity());
+
+    let bp_target = throwaway_target(device2);
+    let mut bp_frame_ns = Vec::with_capacity(ITERS_WALL);
+    for it in 0..(WARMUP_WALL + ITERS_WALL) {
+        output_b.clear_counters(queue);
+        let t_frame_start = Instant::now();
+        {
+            let mut encoder = device2.create_command_encoder(&Default::default());
+            fixture.cull_pass.record(&mut encoder, &fixture.scene_binding.cull_bind_group, &output_bind_group_b, fixture.view_tokens.count());
+            repack_pass.record(&mut encoder, &repack_bind_group, output_b.capacity());
+            fixture.draw_executor.record_multi_indirect(
+                &mut encoder,
+                &bp_target,
+                &fixture.scene_binding.cull_bind_group,
+                &draw_output_bind_group_b,
+                &packed_buf,
+                0,
+                output_b.capacity(),
+                arena.vertex_buffer(),
+                arena.index_buffer(),
+            );
+            queue.submit([encoder.finish()]);
+        }
+        let t_frame_end = Instant::now();
+        if it >= WARMUP_WALL {
+            bp_frame_ns.push((t_frame_end - t_frame_start).as_nanos() as f64);
+        }
+    }
+    let (bp_frame_min, bp_frame_mean, bp_frame_p95) = stats3(bp_frame_ns);
+
+    println!();
+    println!("=== S14.2 DECISION (N=10000, 10% visible, visible_count={}) -- WITHIN-RUN samples (see report for the ACROSS-RUN range, this process's numbers are one data point) ===", fixture.visible_count);
+    println!("(a)  readback-then-clamp:      frame_ns(min/mean/p95) = {a_frame_min:.1}/{a_frame_mean:.1}/{a_frame_p95:.1}  stall_ns(min/mean/p95) = {a_stall_min:.1}/{a_stall_mean:.1}/{a_stall_p95:.1}");
+    println!("(b)  conservative max-count:    frame_ns(min/mean/p95) = {b_frame_min:.1}/{b_frame_mean:.1}/{b_frame_p95:.1}  wasted_draws = {}  (per-slot draw_indexed_indirect CPU loop)", fixture.n - fixture.visible_count);
+    println!("(b') conservative max-count':   frame_ns(min/mean/p95) = {bp_frame_min:.1}/{bp_frame_mean:.1}/{bp_frame_p95:.1}  wasted_draws = {}  (repack + ONE multi_draw_indexed_indirect call)", fixture.n - fixture.visible_count);
+    let mut ranked = [("(a) readback-then-clamp", a_frame_mean), ("(b) conservative max-count (loop)", b_frame_mean), ("(b') conservative max-count (multi-indirect)", bp_frame_mean)];
+    ranked.sort_by(|x, y| x.1.total_cmp(&y.1));
+    println!("winner at this scale (this run): {} (fastest mean frame_ns = {:.1})", ranked[0].0, ranked[0].1);
+    println!("full ranking (this run): {} < {} < {}", ranked[0].0, ranked[1].0, ranked[2].0);
+
+    // ==================================================================
+    // Report: full matrix.
+    // ==================================================================
+    println!();
+    println!("=== Full matrix (N x visible_fraction) ===");
+    println!("N\tfrac\tvisible\tcull_ns(mean/p95)\tdraw_ns(mean/p95)\tbaseline_draw_ns(mean/p95)");
+    for r in &results {
+        println!(
+            "{}\t{}\t{}\t{:.1}/{:.1}\t{:.1}/{:.1}\t{}",
+            r.n,
+            r.frac,
+            r.visible,
+            r.cull_mean,
+            r.cull_p95,
+            r.draw_mean,
+            r.draw_p95,
+            match (r.baseline_draw_mean, r.baseline_draw_p95) {
+                (Some(m), Some(p)) => format!("{m:.1}/{p:.1}"),
+                _ => "n/a".to_string(),
+            }
+        );
+    }
+
+    // ==================================================================
+    // Honesty gates (house law): fixed slack, provably-failable, payload
+    // clearly above the independently-measured floor.
+    // ==================================================================
+    // 5 microseconds, NOT derived from any measured noise-floor variable in
+    // this file (T3's dead-bracket lesson: a floor-derived slack scales
+    // with the very noise it should be catching) -- chosen from the
+    // ABSOLUTE SCALE of what is being compared instead: amortized cull-
+    // dispatch means on this host land in a 9.5-14 us band across all of
+    // 1k/10k/100k tokens (measured finding, see below), so a slack an order
+    // of magnitude tighter (500 ns) would fail on ordinary GPU-scheduling
+    // jitter alone, and a slack an order of magnitude looser (50 us) would
+    // stop being able to catch a real inversion. 5 us sits between those.
+    const TREND_SLACK_NS: f64 = 5_000.0;
+
+    // Payload visibility: the largest N's cull cost, un-amortized back to a
+    // RAW per-bracket total (`cull_mean * REPEATS_CULL` -- the floor above
+    // is a single un-amplified empty bracket, so comparing it against an
+    // AMORTIZED per-dispatch mean would be an apples-to-oranges unit
+    // mismatch; this is exactly why amplification is needed in the first
+    // place -- a single un-amplified cull dispatch's raw bracket total,
+    // ~floor + payload, would sit only modestly above the ~47-80us noise
+    // floor measured on this host, indistinguishable from noise without
+    // REPEATS_CULL's amortization) must be clearly above the empty-bracket
+    // floor -- a dead/misplaced bracket reads ~flat, this catches it (T3's
+    // exact gate, reused).
+    let cull_100k_100 = results.iter().find(|r| r.n == 100_000 && (r.frac - 1.0).abs() < 1e-6).unwrap();
+    let cull_100k_100_raw = cull_100k_100.cull_mean * REPEATS_CULL as f64;
+    assert!(
+        cull_100k_100_raw > floor_mean * 1.5,
+        "payload invisible: N=100k cull RAW bracket total {cull_100k_100_raw:.1} ns (mean {:.1} ns x {REPEATS_CULL} reps) \
+         not clearly above the empty-bracket floor {floor_mean:.1} ns -- dead or misplaced bracket",
+        cull_100k_100.cull_mean
+    );
+
+    // Cull time vs. N -- REPORT-AND-OBSERVE, NOT an assert (M3-b T9 review
+    // defect 3 fix, same pattern M3-b T6's order probe adopted for a
+    // property the host cannot actually guarantee). An earlier version of
+    // this gate asserted `cull(1k) <= cull(10k) + 5us <= cull(100k) +
+    // 10us`; independent review reproduction (6 separate `cargo bench`
+    // process invocations, same commit/host) tripped it in 3 of 6 runs --
+    // this host's own empty-bracket noise floor swings from ~4us to ~207us
+    // (p95) ACROSS PROCESSES, an order of magnitude wider than the 5us
+    // fixed slack the first version used, and wider than the within-run
+    // floor this file measures for itself. A fixed slack cannot be sized
+    // correctly against a host property that swings by that much between
+    // runs without either (a) being loose enough to stop catching a real
+    // inversion, or (b) firing on ordinary noise roughly half the time, as
+    // it did. Rather than pick an arbitrarily wide constant to make the
+    // assert stop firing (which is exactly what T3's "gate must be provably
+    // capable of failing, not tuned to pass" law warns against from the
+    // other direction), this gate now REPORTS the observed ordering and
+    // deltas without failing the run on them -- the payload-visibility gate
+    // above (which compares the SAME run's own raw N=100k total against the
+    // SAME run's own floor, not against a fixed constant across runs) is
+    // the actual defense against a dead/misplaced cull bracket; N-vs-N
+    // ordering at this token-count range is a genuine, twice-independently-
+    // observed HOST PROPERTY (dispatch-call overhead dominates the real
+    // per-thread cull cost at 1k-100k on this host -- the same shape as the
+    // perf-validation report's T7 "compute/overhead-bound" finding), not
+    // something this harness can promise to always order correctly.
+    let cull_1k_100 = results.iter().find(|r| r.n == 1_000 && (r.frac - 1.0).abs() < 1e-6).unwrap();
+    let cull_10k_100 = results.iter().find(|r| r.n == 10_000 && (r.frac - 1.0).abs() < 1e-6).unwrap();
+    let cull_order_1k_10k = if cull_1k_100.cull_mean <= cull_10k_100.cull_mean { "monotonic" } else { "INVERTED (expected on this host at this scale, see comment above)" };
+    let cull_order_10k_100k = if cull_10k_100.cull_mean <= cull_100k_100.cull_mean { "monotonic" } else { "INVERTED (expected on this host at this scale, see comment above)" };
+    println!(
+        "observed (report-and-observe, not asserted): cull(1k)={:.1} ns cull(10k)={:.1} ns cull(100k)={:.1} ns -- 1k->10k {cull_order_1k_10k}, 10k->100k {cull_order_10k_100k}",
+        cull_1k_100.cull_mean, cull_10k_100.cull_mean, cull_100k_100.cull_mean
+    );
+
+    // Draw time rises with visible (command) count (physics: more indirect
+    // draws issued -> more GPU + recording work). Compare the smallest
+    // visible count in the matrix (1k/10% -> V=100) against the largest
+    // (100k/100% -> V=100000).
+    let smallest_v = results.iter().min_by_key(|r| r.visible).unwrap();
+    let largest_v = results.iter().max_by_key(|r| r.visible).unwrap();
+    assert!(
+        smallest_v.draw_mean <= largest_v.draw_mean + TREND_SLACK_NS,
+        "monotonicity broken: draw(V={}) {:.1} ns > draw(V={}) {:.1} ns + {TREND_SLACK_NS} ns",
+        smallest_v.visible,
+        smallest_v.draw_mean,
+        largest_v.visible,
+        largest_v.draw_mean
+    );
+
+    // The §14.2 stall must be REAL (provably capable of failing: a dead/
+    // no-op readback would read ~0, indistinguishable from a broken gate --
+    // this asserts the measured stall clears the same submission noise
+    // floor used above, i.e. it is doing real driver/kernel work, not
+    // returning instantly).
+    assert!(
+        a_stall_mean > floor_mean * 0.5,
+        "the S14.2 readback stall ({a_stall_mean:.1} ns) is suspiciously close to the empty-bracket \
+         floor ({floor_mean:.1} ns) -- either this host's map_async is unrealistically fast, or the \
+         readback call is a dead no-op; investigate before trusting the (a)-vs-(b) decision above"
+    );
+
+    println!();
+    println!(
+        "self-check OK: N=100k cull payload visible over its own run's floor, draw monotonic in V \
+         (fixed {TREND_SLACK_NS} ns slack), S14.2 stall is real work. Cull N-vs-N ordering is \
+         report-and-observe (see line above), not asserted -- see this run's printed line for \
+         which way it landed."
+    );
+}
+
+/// A throwaway 64x64 Rgba8Unorm render target -- draw timing doesn't care
+/// about pixel content, only GPU pass cost, so a fresh target per bracket
+/// avoids any accidental cross-iteration state (load/clear cost is part of
+/// what's being measured, matching `OffscreenTarget`'s own shape without
+/// pulling in its `read_pixels` readback machinery this file never uses).
+fn throwaway_target(device: &wgpu::Device) -> wgpu::TextureView {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("pass-timing-throwaway-target"),
+        size: wgpu::Extent3d { width: 64, height: 64, depth_or_array_layers: 1 },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    texture.create_view(&wgpu::TextureViewDescriptor::default())
+}
+
+/// Pre-fills EVERY record slot `0..count` with a valid-but-harmless
+/// `instance_count=0` indirect-draw command (the §14.2 "conservative
+/// max-count" design's steady-state shape for the slots a compacting cull
+/// dispatch never touches -- see this file's module doc + the §14.2
+/// section's own comment for why this is a fair, honest approximation and
+/// not a correctness shortcut: the per-token visibility COMPUTE cost is
+/// identical to strategy (a)'s, since both run the exact same shipped
+/// `CULL_WGSL`; only the OUTPUT strategy and the CPU synchronization model
+/// differ, which is what §14.2 asks to decide between).
+fn fill_zero_instance_records(queue: &wgpu::Queue, output: &CullOutputBuffers, count: u32, mesh0: (u32, u32, i32)) {
+    let (index_count, first_index, base_vertex) = mesh0;
+    let records: Vec<CullRecord> = (0..count)
+        .map(|slot| CullRecord {
+            index_count,
+            instance_count: 0,
+            first_index,
+            base_vertex,
+            first_instance: slot,
+            row: 0,
+            flags: 0,
+            reserved: 0,
+        })
+        .collect();
+    queue.write_buffer(output.buffer(), CullOutputBuffers::HEADER_BYTES, bytemuck::cast_slice(&records));
+}

--- a/crates/helio-scenedb/src/cull.rs
+++ b/crates/helio-scenedb/src/cull.rs
@@ -1,0 +1,318 @@
+//! The M3-b T5 cull compute pass: the first GPU work that consumes
+//! SceneDB's published scene data and emits indirect draw commands (design
+//! S4's β term list: `i < count` guard -> S3.1 generation validation ->
+//! mesh_index bounds check -> S11 |M3x3| world AABB -> S12 near-clip bypass
+//! -> frustum -> S14.2 bounded-atomic command-slot allocation).
+//!
+//! [`CullPass`] owns the compute pipeline plus the ONE bind-group layout it
+//! adds (group(2) -- [`crate::wgsl::CULL_WGSL`]'s module doc has the full
+//! storage-budget arithmetic). It binds `@group(0)` from an existing
+//! [`crate::SceneDbBinding`] (the cull-read set); it NEVER binds `@group(1)`
+//! (see `CULL_WGSL`'s module doc for how, not just "by convention").
+//!
+//! [`CullOutputBuffers`] owns the per-view output allocation (the combined
+//! atomics-header + `CullRecord` array `CULL_WGSL` calls `CullOutput`) --
+//! capacity-managed like [`pulsar_scenedb::gpu::ViewTokenBuffers`] (grow, or
+//! caller-sized up front; this pass does not resize it automatically, since
+//! unlike the per-view token pair this buffer's natural size is a driver
+//! policy decision -- S14.2's "CPU clamps on readback" already handles
+//! under-provisioning without silent corruption).
+
+use pulsar_scenedb::gpu::ViewTokenBuffers;
+
+use crate::wgsl::{CULL_WGSL, SCENE_BINDINGS_WGSL};
+
+const WORKGROUP_SIZE: u32 = 64;
+
+/// Standalone indirect-draw wire format (spec S14.1) -- 20 bytes, Rust twin
+/// of [`CULL_WGSL`]'s `DrawCommand` struct. Helio-owned derived data (C0):
+/// SceneDB never defines or touches this type, so it has NO twin in
+/// `pulsar_scenedb` -- this crate's own `tests/binding_layout.rs` Test 3
+/// rows are the only reflection coverage it needs.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DrawCommand {
+    pub index_count: u32,
+    pub instance_count: u32,
+    pub first_index: u32,
+    pub base_vertex: i32,
+    pub first_instance: u32,
+}
+const _: () = assert!(std::mem::size_of::<DrawCommand>() == 20);
+// SAFETY: `#[repr(C)]`, `Copy`, every field is scalar POD, no padding (5x
+// 4-byte fields, all 4-aligned) -- matches the const-asserted 20-byte size.
+unsafe impl bytemuck::Zeroable for DrawCommand {}
+unsafe impl bytemuck::Pod for DrawCommand {}
+
+/// One combined per-command-slot output record -- Rust twin of
+/// [`CULL_WGSL`]'s `CullRecord`. First 5 fields are field-for-field
+/// identical to [`DrawCommand`] (same order, same offsets 0/4/8/12/16);
+/// `row` is the design's row-valued `visible_instance_ids[slot]` (S3/R11);
+/// `flags` bit 0 ([`NEAR_CLIP_FLAG`]) carries the S12 near-clip bypass.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CullRecord {
+    pub index_count: u32,
+    pub instance_count: u32,
+    pub first_index: u32,
+    pub base_vertex: i32,
+    pub first_instance: u32,
+    pub row: u32,
+    pub flags: u32,
+    pub reserved: u32,
+}
+const _: () = assert!(std::mem::size_of::<CullRecord>() == 32);
+unsafe impl bytemuck::Zeroable for CullRecord {}
+unsafe impl bytemuck::Pod for CullRecord {}
+
+/// [`CullRecord::flags`] bit 0 (spec S12): set when the near-plane W<=0
+/// bypass fired for this instance -- downstream passes must treat it as
+/// covering an indeterminate screen-space area rather than trusting a
+/// garbage projected rect (spec S12's exact wording).
+pub const NEAR_CLIP_FLAG: u32 = 1;
+
+/// Rust twin of [`CULL_WGSL`]'s `CullUniforms` -- the cull pass's per-
+/// dispatch constant inputs: the view-proj matrix (S12's corner-projection
+/// W<=0 test), 6 world-space frustum planes in the `n.p+d>=0`-inside
+/// convention (`spatial::Frustum`'s own convention, S4's frustum term), and
+/// the three scalar bounds the shader's guards read (`count` for the
+/// `i < count` dispatch guard, `mesh_count` for the mesh_index bounds
+/// check, `capacity` for the S14.2 slot-allocation ceiling).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct CullUniforms {
+    pub view_proj: [f32; 16],
+    pub planes: [[f32; 4]; 6],
+    pub count: u32,
+    pub mesh_count: u32,
+    pub capacity: u32,
+    pub reserved: u32,
+}
+const _: () = assert!(std::mem::size_of::<CullUniforms>() == 176);
+unsafe impl bytemuck::Zeroable for CullUniforms {}
+unsafe impl bytemuck::Pod for CullUniforms {}
+
+/// Byte layout of the combined `CullOutput` buffer (`CULL_WGSL`'s module
+/// doc): a fixed 16-byte atomics header (`visible_count`/`stale_drops`/
+/// `oob_drops`/`frustum_drops`, each `u32`) followed by `capacity` many
+/// 32-byte [`CullRecord`]s.
+pub struct CullOutputBuffers {
+    buffer: wgpu::Buffer,
+    capacity: u32,
+}
+
+impl CullOutputBuffers {
+    pub const HEADER_BYTES: u64 = 16;
+    pub const RECORD_BYTES: u64 = std::mem::size_of::<CullRecord>() as u64;
+
+    /// Allocates a zero-initialized (WebGPU-guaranteed, per spec -- wgpu
+    /// conforms) `CullOutput` buffer sized for `capacity` records. `label`
+    /// names the underlying `wgpu::Buffer` for GPU-debugger identification.
+    ///
+    /// `usage` carries [`wgpu::BufferUsages::INDIRECT`] alongside `STORAGE`/
+    /// `COPY_DST`/`COPY_SRC` (M3-b T7 addition) -- `draw::DrawExecutor`
+    /// issues `draw_indexed_indirect` calls that read a `CullRecord`'s first
+    /// 20 bytes directly out of THIS buffer (see [`CullRecord`]'s doc: those
+    /// 20 bytes are field-for-field identical to `DrawCommand`, i.e. wgpu's
+    /// `DrawIndexedIndirectArgs`), which requires the source buffer to carry
+    /// `INDIRECT` usage or wgpu's validation rejects the call. Added here
+    /// (not a separate buffer) because T5/T6 already established this is
+    /// the ONE buffer indirect draws read from -- no repacking, see
+    /// `draw.rs`'s module doc for the full indirect-mechanism rationale.
+    #[must_use]
+    pub fn new(device: &wgpu::Device, label: &str, capacity: u32) -> Self {
+        let size = Self::HEADER_BYTES + capacity as u64 * Self::RECORD_BYTES;
+        let buffer = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some(label),
+            size,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_DST
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::INDIRECT,
+            mapped_at_creation: false,
+        });
+        Self { buffer, capacity }
+    }
+
+    pub fn buffer(&self) -> &wgpu::Buffer {
+        &self.buffer
+    }
+
+    pub fn capacity(&self) -> u32 {
+        self.capacity
+    }
+
+    pub fn byte_size(&self) -> u64 {
+        Self::HEADER_BYTES + self.capacity as u64 * Self::RECORD_BYTES
+    }
+
+    /// Zero the 4 atomic counters (offsets 0..16). The shader only ever
+    /// increments them -- nothing else resets them between dispatches, so a
+    /// per-frame driver reusing this buffer across frames MUST call this
+    /// before each [`CullPass::record`]. A freshly [`Self::new`]-allocated
+    /// buffer does not need it (WebGPU zero-init), but calling it anyway is
+    /// harmless and matches what a real per-frame driver does.
+    pub fn clear_counters(&self, queue: &wgpu::Queue) {
+        queue.write_buffer(&self.buffer, 0, &[0u8; Self::HEADER_BYTES as usize]);
+    }
+}
+
+/// The cull compute pass itself: one pipeline, one bind-group layout
+/// (group(2) -- [`CULL_WGSL`]'s module doc has the full storage-budget
+/// arithmetic), one uniform buffer. Stateless across dispatches beyond that
+/// (no cached bind group -- callers build a fresh group(2) bind group per
+/// [`Self::build_output_bind_group`] call whenever the underlying buffers
+/// change, mirroring `SceneDbBinding::new`'s "rebuilt, never mutated in
+/// place" idiom).
+pub struct CullPass {
+    pipeline: wgpu::ComputePipeline,
+    output_layout: wgpu::BindGroupLayout,
+    uniforms_buf: wgpu::Buffer,
+}
+
+impl CullPass {
+    /// `cull_layout` is [`crate::SceneDbBinding::cull_layout`] (group(0) --
+    /// the caller already built a `SceneDbBinding`; this pass borrows only
+    /// its cull-read layout, never `draw_layout`, matching `CULL_WGSL`'s "no
+    /// group(1)" design).
+    #[must_use]
+    pub fn new(device: &wgpu::Device, cull_layout: &wgpu::BindGroupLayout) -> Self {
+        let shader_src = format!("{SCENE_BINDINGS_WGSL}\n{CULL_WGSL}");
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("helio-scenedb-cull-shader"),
+            source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+        });
+
+        let storage_entry = |binding: u32, read_only: bool| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let output_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("helio-scenedb-cull-output-layout"),
+            entries: &[
+                storage_entry(0, true),  // cull_tokens
+                storage_entry(1, true),  // cull_expected_gens
+                storage_entry(2, false), // cull_output (counters + records)
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let uniforms_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("helio-scenedb-cull-uniforms"),
+            size: std::mem::size_of::<CullUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        // group(1) genuinely absent -- see CULL_WGSL's module doc for why
+        // this is sound (wgpu/naga validate against the entry point's
+        // reachable bindings, and `cull_main` never touches group(1)).
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("helio-scenedb-cull-pipeline-layout"),
+            bind_group_layouts: &[Some(cull_layout), None, Some(&output_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("helio-scenedb-cull-pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("cull_main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            output_layout,
+            uniforms_buf,
+        }
+    }
+
+    pub fn write_uniforms(&self, queue: &wgpu::Queue, uniforms: &CullUniforms) {
+        queue.write_buffer(&self.uniforms_buf, 0, bytemuck::bytes_of(uniforms));
+    }
+
+    /// Builds the group(2) bind group over `view`'s token pair and
+    /// `output`'s combined counters+records buffer, plus this pass's own
+    /// uniform buffer. Rebuild whenever `view`/`output`'s underlying
+    /// `wgpu::Buffer`s change (e.g. `ViewTokenBuffers::upload` grew the
+    /// buffers) -- no caching here, matching `SceneDbBinding::new`'s idiom.
+    #[must_use]
+    pub fn build_output_bind_group(
+        &self,
+        device: &wgpu::Device,
+        view: &ViewTokenBuffers,
+        output: &CullOutputBuffers,
+    ) -> wgpu::BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("helio-scenedb-cull-output-bind-group"),
+            layout: &self.output_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: view.tokens_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: view.expected_gens_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: output.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: self.uniforms_buf.as_entire_binding(),
+                },
+            ],
+        })
+    }
+
+    /// Dispatches `cull_main` over `dispatch_count` threads (one per
+    /// harvested token -- callers pass [`ViewTokenBuffers::count`]).
+    /// `cull_bind_group` is [`crate::SceneDbBinding::cull_bind_group`]
+    /// (group(0)); `output_bind_group` is
+    /// [`Self::build_output_bind_group`]'s result (group(2)). group(1) is
+    /// NEVER bound -- see [`CULL_WGSL`]'s module doc.
+    ///
+    /// No-op (does not even open a compute pass) when `dispatch_count == 0`
+    /// -- there is nothing to cull and nothing to clear (the shader itself
+    /// never runs, so it cannot touch the counters either; callers that
+    /// need a guaranteed-zeroed counter buffer for an empty view call
+    /// [`CullOutputBuffers::clear_counters`] themselves).
+    pub fn record(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        cull_bind_group: &wgpu::BindGroup,
+        output_bind_group: &wgpu::BindGroup,
+        dispatch_count: u32,
+    ) {
+        if dispatch_count == 0 {
+            return;
+        }
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("helio-scenedb-cull-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, cull_bind_group, &[]);
+        pass.set_bind_group(2, output_bind_group, &[]);
+        pass.dispatch_workgroups(dispatch_count.div_ceil(WORKGROUP_SIZE), 1, 1);
+    }
+}

--- a/crates/helio-scenedb/src/draw.rs
+++ b/crates/helio-scenedb/src/draw.rs
@@ -1,0 +1,450 @@
+//! The M3-b T7 minimal indirect-draw executor: the first GPU work that
+//! turns the cull pass's output (`crate::cull::CullOutputBuffers`) into
+//! actual pixels -- proving the C5 end-to-end path (SceneDB geometry +
+//! SceneDB transforms + cull-produced commands -> pixels). This is
+//! deliberately NOT the full Helio pass integration (that is M4): one
+//! offscreen color target, one render pipeline, one `record`-shaped API
+//! that runs ONE render pass issuing indirect draws from the cull pass's
+//! command buffer.
+//!
+//! [`wgsl::DRAW_WGSL`] (in `crate::wgsl`) is the renderer-side source of
+//! truth for the vertex/fragment shader; this module's doc comment there
+//! covers the `@group(1)`-unbound choice and the read-only `DrawRecord`/
+//! `DrawCullOutput` duplication rationale (`VERTEX_WRITABLE_STORAGE` is a
+//! non-default feature this task's device does not request). The
+//! **indirect-draw mechanism** (CPU-side loop of `draw_indexed_indirect`,
+//! not `multi_draw_indexed_indirect`) is documented in full there too --
+//! summary: both wgpu-30 methods gate on the same downlevel capability
+//! (`DownlevelFlags::INDIRECT_EXECUTION`, universal on desktop backends,
+//! not a `Features` flag), so availability was never the blocker;
+//! `multi_draw_indexed_indirect` additionally requires its indirect
+//! buffer's draw structs to be tightly packed (20-byte `DrawIndexedIndirect
+//! Args` stride), which `CullOutputBuffers`' 32-byte `CullRecord` stride
+//! does not satisfy without a repack pass this minimal executor chooses not
+//! to add.
+
+use crate::cull::CullOutputBuffers;
+use crate::wgsl::{DRAW_WGSL, SCENE_BINDINGS_WGSL};
+
+/// Rust twin of [`crate::wgsl::DRAW_WGSL`]'s `DrawUniforms` -- the draw
+/// pass's per-dispatch constant input: just the view-proj matrix (no
+/// frustum planes, no mesh/capacity bounds -- those are cull-only
+/// concerns; this pass only ever transforms already-culled geometry).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DrawUniforms {
+    pub view_proj: [f32; 16],
+}
+const _: () = assert!(std::mem::size_of::<DrawUniforms>() == 64);
+// SAFETY: `#[repr(C)]`, `Copy`, one scalar-array field, no padding.
+unsafe impl bytemuck::Zeroable for DrawUniforms {}
+unsafe impl bytemuck::Pod for DrawUniforms {}
+
+/// Deterministic `mesh_index -> RGBA8` mapping, the CPU-side twin of
+/// [`crate::wgsl::DRAW_WGSL`]'s `mesh_color` WGSL function -- MUST stay
+/// numerically identical (same multipliers, same `% 256`, same `/255.0`
+/// rounding-to-u8 story) so a test can assert a painted pixel's color
+/// against this function and know it proves the GPU-side `InstanceInfo.
+/// mesh_index -> color` lookup ran, not just that some pixel got painted.
+#[must_use]
+pub fn mesh_color_rgba8(mesh_index: u32) -> [u8; 4] {
+    let r = (mesh_index.wrapping_mul(37).wrapping_add(17)) % 256;
+    let g = (mesh_index.wrapping_mul(91).wrapping_add(53)) % 256;
+    let b = (mesh_index.wrapping_mul(131).wrapping_add(7)) % 256;
+    [r as u8, g as u8, b as u8, 255]
+}
+
+/// The offscreen color target the draw executor renders into. `Rgba8Unorm`
+/// at [`OffscreenTarget::WIDTH`]x[`OffscreenTarget::HEIGHT`] -- deliberately
+/// chosen so `WIDTH * 4` (the tightly-packed RGBA8 row stride) is ALREADY a
+/// multiple of 256 (wgpu's `copy_texture_to_buffer` `bytes_per_row`
+/// alignment requirement), so [`Self::read_pixels`] needs no manual padding
+/// or de-padding -- one `copy_texture_to_buffer` call, one contiguous
+/// `Vec<u8>` out.
+pub struct OffscreenTarget {
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+}
+
+impl OffscreenTarget {
+    pub const WIDTH: u32 = 64;
+    pub const HEIGHT: u32 = 64;
+    pub const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+    /// `WIDTH * 4` bytes (RGBA8) -- exactly 256, the wgpu `bytes_per_row`
+    /// alignment ceiling, chosen deliberately (see struct doc).
+    pub const BYTES_PER_ROW: u32 = Self::WIDTH * 4;
+    const _ALIGNED: () = assert!(Self::BYTES_PER_ROW % 256 == 0);
+
+    #[must_use]
+    pub fn new(device: &wgpu::Device, label: &str) -> Self {
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some(label),
+            size: wgpu::Extent3d {
+                width: Self::WIDTH,
+                height: Self::HEIGHT,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: Self::FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        Self { texture, view }
+    }
+
+    pub fn view(&self) -> &wgpu::TextureView {
+        &self.view
+    }
+
+    /// Copies the whole target into a `MAP_READ` staging buffer and returns
+    /// its bytes, tightly packed (`WIDTH * HEIGHT * 4`, row-major, no
+    /// padding -- see struct doc for why `bytes_per_row` needs none here).
+    pub fn read_pixels(&self, device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<u8> {
+        let byte_size = (Self::BYTES_PER_ROW * Self::HEIGHT) as u64;
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("helio-scenedb-draw-target-readback"),
+            size: byte_size,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut encoder = device.create_command_encoder(&Default::default());
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: &self.texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &staging,
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(Self::BYTES_PER_ROW),
+                    rows_per_image: Some(Self::HEIGHT),
+                },
+            },
+            wgpu::Extent3d {
+                width: Self::WIDTH,
+                height: Self::HEIGHT,
+                depth_or_array_layers: 1,
+            },
+        );
+        queue.submit([encoder.finish()]);
+        let slice = staging.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |r| {
+            r.expect("map draw target readback")
+        });
+        device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("poll");
+        let data = slice.get_mapped_range().expect("mapped range").to_vec();
+        staging.unmap();
+        data
+    }
+}
+
+/// The draw pass itself: one render pipeline, one `@group(2)` bind-group
+/// layout (`draw_cull_output`/`draw_uniforms`, `crate::wgsl::DRAW_WGSL`'s
+/// module doc has the full rationale), one uniform buffer. Stateless across
+/// dispatches beyond that -- same "rebuilt, never mutated in place" idiom
+/// [`crate::cull::CullPass`] and [`crate::SceneDbBinding`] both follow.
+pub struct DrawExecutor {
+    pipeline: wgpu::RenderPipeline,
+    output_layout: wgpu::BindGroupLayout,
+    uniforms_buf: wgpu::Buffer,
+}
+
+impl DrawExecutor {
+    /// `cull_layout` is [`crate::SceneDbBinding::cull_layout`] (`@group(0)`
+    /// -- the caller already built a `SceneDbBinding`; this pass borrows
+    /// only its cull-read layout, and only two of its five entries
+    /// (`instances`/`instance_info`) are actually reachable from `vs_main`/
+    /// `fs_main` -- never `draw_layout`, matching the plan's "prefer not
+    /// binding it" instruction).
+    #[must_use]
+    pub fn new(device: &wgpu::Device, cull_layout: &wgpu::BindGroupLayout) -> Self {
+        let shader_src = format!("{SCENE_BINDINGS_WGSL}\n{DRAW_WGSL}");
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("helio-scenedb-draw-shader"),
+            source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+        });
+
+        let output_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("helio-scenedb-draw-output-layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let uniforms_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("helio-scenedb-draw-uniforms"),
+            size: std::mem::size_of::<DrawUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        // group(1) genuinely absent -- see DRAW_WGSL's module doc (mirrors
+        // CULL_WGSL's own "never bound" trick for the exact same reason:
+        // vs_main/fs_main never reference clusters/meshlets/cell_meta/
+        // materials, so wgpu/naga's reachability-based validation permits
+        // a pipeline layout with no entry at that index at all).
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("helio-scenedb-draw-pipeline-layout"),
+            bind_group_layouts: &[Some(cull_layout), None, Some(&output_layout)],
+            immediate_size: 0,
+        });
+
+        let vertex_layout = wgpu::VertexBufferLayout {
+            array_stride: 12, // vec3<f32> local position, GeometryArena's stride for this trivial mesh
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &[wgpu::VertexAttribute {
+                format: wgpu::VertexFormat::Float32x3,
+                offset: 0,
+                shader_location: 0,
+            }],
+        };
+
+        let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("helio-scenedb-draw-pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader,
+                entry_point: Some("vs_main"),
+                compilation_options: Default::default(),
+                buffers: &[Some(vertex_layout)],
+            },
+            primitive: wgpu::PrimitiveState {
+                topology: wgpu::PrimitiveTopology::TriangleList,
+                // No backface culling: this executor's job is to prove the
+                // cull-to-draw handoff and the transform/color lookups, not
+                // to exercise winding-order correctness -- irrelevant here
+                // and would only add a way for an unrelated geometry choice
+                // to accidentally fail Test 4.
+                cull_mode: None,
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            fragment: Some(wgpu::FragmentState {
+                module: &shader,
+                entry_point: Some("fs_main"),
+                compilation_options: Default::default(),
+                targets: &[Some(wgpu::ColorTargetState {
+                    format: OffscreenTarget::FORMAT,
+                    blend: None,
+                    write_mask: wgpu::ColorWrites::ALL,
+                })],
+            }),
+            multiview_mask: None,
+            cache: None,
+        });
+
+        Self {
+            pipeline,
+            output_layout,
+            uniforms_buf,
+        }
+    }
+
+    pub fn write_uniforms(&self, queue: &wgpu::Queue, uniforms: &DrawUniforms) {
+        queue.write_buffer(&self.uniforms_buf, 0, bytemuck::bytes_of(uniforms));
+    }
+
+    /// Builds the `@group(2)` bind group over `output`'s combined
+    /// counters+records buffer (read-only here -- see `DRAW_WGSL`'s module
+    /// doc for why this is a distinct read-only WGSL view of the SAME
+    /// buffer `crate::cull::CullPass` writes) and this pass's own uniform
+    /// buffer. Rebuild whenever `output`'s underlying `wgpu::Buffer`
+    /// changes, mirroring `CullPass::build_output_bind_group`'s idiom.
+    #[must_use]
+    pub fn build_output_bind_group(
+        &self,
+        device: &wgpu::Device,
+        output: &CullOutputBuffers,
+    ) -> wgpu::BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("helio-scenedb-draw-output-bind-group"),
+            layout: &self.output_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: output.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: self.uniforms_buf.as_entire_binding(),
+                },
+            ],
+        })
+    }
+
+    /// Records ONE render pass into `target`: clears to transparent black,
+    /// binds `vertex_buffer`/`index_buffer` (callers pass
+    /// `GeometryArena::vertex_buffer`/`index_buffer` -- the real SceneDB-
+    /// owned geometry residency, not a test-local buffer), then issues
+    /// `command_count` `draw_indexed_indirect` calls, one per command slot,
+    /// each reading its 20-byte `DrawIndexedIndirectArgs` prefix directly
+    /// out of `output`'s buffer at `HEADER_BYTES + slot * RECORD_BYTES`
+    /// (see this module's doc for why not `multi_draw_indexed_indirect`).
+    ///
+    /// `command_count` is the CPU-clamped visible-command count (design
+    /// S14.2: `min(readback visible_count, output.capacity())`) -- the
+    /// caller already has this from reading back `output`'s counters for
+    /// its own assertions (the same readback pattern `tests/cull_pass.rs`
+    /// established), so this function does not re-read it itself; it only
+    /// consumes the number, never derives it, keeping this a pure
+    /// `record`-shaped API with no hidden synchronous stalls of its own.
+    ///
+    /// `scene_cull_bind_group` is [`crate::SceneDbBinding::cull_bind_group`]
+    /// (`@group(0)`); `output_bind_group` is
+    /// [`Self::build_output_bind_group`]'s result (`@group(2)`). `@group(1)`
+    /// is NEVER bound -- see this module's doc.
+    ///
+    /// A `command_count` of 0 still opens the render pass (so the clear
+    /// happens -- callers that want a determinate empty frame get one)
+    /// but issues no draw calls.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        scene_cull_bind_group: &wgpu::BindGroup,
+        output_bind_group: &wgpu::BindGroup,
+        output: &CullOutputBuffers,
+        vertex_buffer: &wgpu::Buffer,
+        index_buffer: &wgpu::Buffer,
+        command_count: u32,
+    ) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("helio-scenedb-draw-pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 0.0,
+                    }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        if command_count == 0 {
+            return;
+        }
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, scene_cull_bind_group, &[]);
+        pass.set_bind_group(2, output_bind_group, &[]);
+        pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+        for slot in 0..command_count {
+            let offset =
+                CullOutputBuffers::HEADER_BYTES + slot as u64 * CullOutputBuffers::RECORD_BYTES;
+            pass.draw_indexed_indirect(output.buffer(), offset);
+        }
+    }
+
+    /// The strongest no-readback alternative to [`Self::record`]'s CPU-side
+    /// per-slot loop (M3-b T9 review, defect 1): ONE
+    /// `RenderPass::multi_draw_indexed_indirect` call issuing `count`
+    /// GPU-side indirect draws, instead of `count` individual
+    /// `draw_indexed_indirect` CPU calls. Gated only by
+    /// `DownlevelFlags::INDIRECT_EXECUTION` (universal on desktop Vulkan/
+    /// DX12/Metal, verified against `wgpu-30.0.0/src/api/render_pass.rs` --
+    /// NOT behind `Features::MULTI_DRAW_INDIRECT_COUNT`, which gates only
+    /// the separate `_count` variant), so this needs no extra
+    /// `wgpu::Features` beyond what [`Self::record`] already requires.
+    ///
+    /// `multi_draw_indexed_indirect`'s own doc requires its indirect
+    /// buffer's records to be TIGHTLY PACKED 20-byte
+    /// `DrawIndexedIndirectArgs` -- [`crate::cull::CullOutputBuffers`]'s
+    /// `CullRecord` stride is 32 bytes (this crate's own module docs have
+    /// the group(2) storage-budget reason those extra 12 bytes exist), so
+    /// this method does NOT read `output`'s indirect args directly (unlike
+    /// [`Self::record`]) -- callers pass a SEPARATE, already tightly-packed
+    /// `indirect_buffer` as the args source, produced by
+    /// [`crate::repack::RepackPass`] (M3-b T9-followup: promoted out of the
+    /// bench-local prototype into a real library capability -- see that
+    /// module's doc and [`crate::wgsl::REPACK_WGSL`]'s doc for the full
+    /// 32->20 byte field contract, including why `first_instance` MUST
+    /// survive the repack unchanged). `output_bind_group` is STILL `output`'s own group(2) bind
+    /// group, unchanged from [`Self::record`] -- the vertex shader's row
+    /// lookup (`draw_cull_output.records[iid].row`, `wgsl.rs`'s
+    /// `DRAW_WGSL` doc) reads the ORIGINAL 32-byte-strided `CullRecord`
+    /// buffer, which the tightly-packed indirect-args buffer does not
+    /// carry (no `row` field); only the indirect draw ARGS come from the
+    /// packed buffer, not the row-lookup data.
+    #[allow(clippy::too_many_arguments)]
+    pub fn record_multi_indirect(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        target: &wgpu::TextureView,
+        scene_cull_bind_group: &wgpu::BindGroup,
+        output_bind_group: &wgpu::BindGroup,
+        indirect_buffer: &wgpu::Buffer,
+        indirect_offset: wgpu::BufferAddress,
+        count: u32,
+        vertex_buffer: &wgpu::Buffer,
+        index_buffer: &wgpu::Buffer,
+    ) {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("helio-scenedb-draw-pass-multi-indirect"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: target,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(wgpu::Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 0.0,
+                        a: 0.0,
+                    }),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        if count == 0 {
+            return;
+        }
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, scene_cull_bind_group, &[]);
+        pass.set_bind_group(2, output_bind_group, &[]);
+        pass.set_vertex_buffer(0, vertex_buffer.slice(..));
+        pass.set_index_buffer(index_buffer.slice(..), wgpu::IndexFormat::Uint32);
+        pass.multi_draw_indexed_indirect(indirect_buffer, indirect_offset, count);
+    }
+}

--- a/crates/helio-scenedb/src/lib.rs
+++ b/crates/helio-scenedb/src/lib.rs
@@ -1,0 +1,321 @@
+//! `helio-scenedb`: the Helio <-> SceneDB binding seam (M3-a T9, design
+//! Rev 2 S5). This is the ONE crate in the Helio workspace allowed to depend
+//! on `pulsar_scenedb` (CONTRACTS C0: SceneDB never depends on Helio; this is
+//! the inverse edge, and it lives entirely on the Helio side).
+//!
+//! [`SceneDbBinding`] binds every SceneDB-owned GPU buffer relevant to
+//! rendering (instance transforms, instance info, the slot/generation
+//! mirrors, the mesh/cluster/meshlet asset tables, and per-cell metadata)
+//! into TWO read-only bind groups (M3-b T4, contract #47 -- see the struct
+//! doc below) that Helio's render/compute passes consume directly -- no
+//! data ever crosses through a CPU-side copy. [`wgsl::SCENE_BINDINGS_WGSL`]
+//! is the renderer-side source of truth for the struct layouts and the
+//! `@group`/`@binding` indices; `tests/seam_smoke.rs` is the proof that the
+//! whole chain -- SceneDB write API, frame boundary, GPU buffer, these bind
+//! groups, a real shader, a Helio-owned output buffer, readback -- works
+//! byte-exact on the actual vendored wgpu-30 stack.
+
+pub mod cull;
+pub mod draw;
+pub mod repack;
+pub mod wgsl;
+
+use pulsar_scenedb::gpu::{
+    ClusterBuffer, GeometryArena, MaterialRegistry, MeshRegistry, MeshletBuffer, SceneGpuStore,
+};
+
+/// Owned Helio adapter for SceneDB's authoritative render resources.
+///
+/// Construction creates only Helio bind-group objects and clones lightweight
+/// handles to SceneDB's geometry buffers. It does not copy scene records,
+/// upload geometry, or create a parallel scene snapshot.
+///
+/// The underlying SceneDB stores use fixed-capacity GPU allocations. If a
+/// future SceneDB version replaces any of those buffers during growth, callers
+/// must construct and attach a new source after that replacement.
+pub struct SceneDbRenderSource {
+    binding: SceneDbBinding,
+    vertex_buffer: wgpu::Buffer,
+    index_buffer: wgpu::Buffer,
+}
+
+impl SceneDbRenderSource {
+    /// Binds the currently published SceneDB stores into Helio.
+    pub fn new(
+        device: &wgpu::Device,
+        store: &SceneGpuStore,
+        meshes: &MeshRegistry,
+        clusters: &ClusterBuffer,
+        meshlets: &MeshletBuffer,
+        materials: &MaterialRegistry,
+        geometry: &GeometryArena,
+    ) -> Self {
+        Self {
+            binding: SceneDbBinding::new(device, store, meshes, clusters, meshlets, materials),
+            vertex_buffer: geometry.vertex_buffer().clone(),
+            index_buffer: geometry.index_buffer().clone(),
+        }
+    }
+
+    /// Borrows the authoritative GPU state for publication to a render frame.
+    #[inline]
+    pub fn frame_resources(&self) -> libhelio::SceneDbFrameResources<'_> {
+        libhelio::SceneDbFrameResources {
+            cull_bind_group: &self.binding.cull_bind_group,
+            draw_bind_group: &self.binding.draw_bind_group,
+            vertex_buffer: &self.vertex_buffer,
+            index_buffer: &self.index_buffer,
+        }
+    }
+
+    /// Exposes layouts and bind groups to passes created for this source.
+    #[inline]
+    pub fn binding(&self) -> &SceneDbBinding {
+        &self.binding
+    }
+}
+
+/// The Helio-side handle to every SceneDB-owned GPU buffer, split across two
+/// read-only bind groups ([`wgsl::SCENE_BINDINGS_WGSL`]) -- M3-b T4, closing
+/// perf-validation report contract #47 (the seam's original single 9-entry
+/// group was ONE OVER the WebGPU default per-stage storage-buffer budget,
+/// `Limits::default().max_storage_buffers_per_shader_stage == 8`).
+///
+/// ## `@group(0)` -- the cull-read set (`cull_layout` / `cull_bind_group`)
+///
+/// | binding | contents            | source accessor                        |
+/// |---------|----------------------|-----------------------------------------|
+/// | 0       | instance transforms  | `SceneGpuStore::transform_buffer`       |
+/// | 1       | instance info        | `SceneGpuStore::instance_info_buffer`   |
+/// | 2       | slot mirror          | `SceneGpuStore::slot_mirror_buffer`     |
+/// | 3       | generations          | `SceneGpuStore::generation_buffer`      |
+/// | 4       | mesh configurator    | `MeshRegistry::buffer`                  |
+///
+/// ## `@group(1)` -- the draw/material set (`draw_layout` / `draw_bind_group`)
+///
+/// | binding | contents            | source accessor                        |
+/// |---------|----------------------|-----------------------------------------|
+/// | 0       | cluster DAG          | `ClusterBuffer::buffer`                 |
+/// | 1       | meshlets             | `MeshletBuffer::buffer`                 |
+/// | 2       | cell metadata        | `SceneGpuStore::cell_metadata_buffer`   |
+/// | 3       | material registry    | `MaterialRegistry::buffer`              |
+///
+/// `@group(2)` is RESERVED for M3-b T5's per-view `ViewTokenBuffers`
+/// (`tokens`, `expected_gens`) -- NOT added by this task; T5 claims that
+/// index without renumbering anything here.
+///
+/// Geometry (vertex/index) buffers bind at draw time, not here (they vary
+/// per draw call); textures bind through Helio's own bindless array. Every
+/// entry above is a read-only storage buffer -- SceneDB owns the write path
+/// (`write_transform`/`write_instance_info`/the frame-boundary drivers,
+/// `MeshRegistry::register`, `MaterialRegistry::register`,
+/// `StreamingGrid::write_cell_metadata`); Helio only ever reads.
+///
+/// ## Visibility split and the per-stage arithmetic (M3-b T4)
+///
+/// The split is not just "cull entries vs. draw entries" -- within
+/// `@group(0)`, TWO of the five entries (`instances`, `instance_info`) also
+/// need to be readable from the vertex/fragment stages, because the β draw
+/// executor (M3-b T7, design's minimal indirect-draw path) fetches the
+/// instance transform (via `visible_instance_ids` + instance index) and
+/// reads `InstanceInfo.mesh_index` to pick a flat output color -- it never
+/// touches `slot_mirror`/`generations`/`mesh_meta`, which are cull-internal
+/// bookkeeping (generation validation and the mesh-bounds/AABB check, design
+/// §4's β term list). Giving the WHOLE of `@group(0)` blanket
+/// `VERTEX_FRAGMENT | COMPUTE` visibility (the group-level reading of the
+/// plan's instruction) would put `@group(0)`'s 5 entries and `@group(1)`'s 4
+/// draw entries in the SAME vertex/fragment budget -- 9, busting the very
+/// 8-entry default limit this task exists to fix, just on a different stage
+/// than #47's original compute-stage MISS. Per-ENTRY visibility avoids that
+/// while still giving the cull compute pass everything it needs:
+///
+/// ```text
+/// @group(0) (cull-read set, 5 entries)
+///   binding 0 instances       -- VERTEX_FRAGMENT | COMPUTE (cull transform fetch + draw vertex fetch)
+///   binding 1 instance_info   -- VERTEX_FRAGMENT | COMPUTE (cull mesh_index bounds check + draw flat-color pick)
+///   binding 2 slot_mirror     -- COMPUTE only (cull generation-validation indexing)
+///   binding 3 generations     -- COMPUTE only (cull generation-validation)
+///   binding 4 mesh_meta       -- COMPUTE only (cull mesh-bounds check + local AABB)
+///
+/// @group(1) (draw/material set, 4 entries) -- all VERTEX_FRAGMENT only,
+/// cull never binds this group:
+///   binding 0 clusters, binding 1 meshlets, binding 2 cell_meta, binding 3 materials
+/// ```
+///
+/// **Per-stage totals (arithmetic, current M3-b T4 state, before T5's
+/// `@group(2)`):**
+///
+/// - COMPUTE: group0's COMPUTE-visible entries (5) + group1's COMPUTE-visible
+///   entries (0, none of group1 is COMPUTE-visible) = **5 / 8** (3 headroom).
+///   T5 adds `ViewTokenBuffers` (`tokens` + `expected_gens`, COMPUTE-only,
+///   `@group(2)`, 2 entries) on top of this: 5 + 2 = **7 / 8** (1 headroom
+///   left for whatever the cull pass's own output buffers turn out to need
+///   in this same pipeline layout -- likely their own group, per the T4
+///   smoke test's own out-buffer pattern below, not a claim on this
+///   remaining 1).
+/// - VERTEX: group0's VERTEX_FRAGMENT-visible entries (2: `instances`,
+///   `instance_info`) + group1's VERTEX_FRAGMENT-visible entries (4, all of
+///   group1) = **6 / 8** (2 headroom).
+/// - FRAGMENT: identical to VERTEX (same two groups, same visibility bits)
+///   = **6 / 8** (2 headroom).
+///
+/// This IS the budget-relevant choice the plan calls out: it is what lets
+/// `tests/seam_smoke.rs` drop `adapter.limits()` for `wgpu::Limits::
+/// default()` and still pass (its own compute pipeline only ever binds
+/// `@group(0)` for the SceneDB side -- 5 COMPUTE-visible entries -- plus its
+/// own 2 output buffers at `@group(2)`, `5 + 2 = 7 ≤ 8`; `@group(1)` is
+/// still constructed and bound at pipeline-layout index 1 so the shader
+/// module's declarations of it type-check and the pipeline layout is
+/// positionally valid, but none of its entries are COMPUTE-visible so it
+/// contributes 0 to that stage's count).
+pub struct SceneDbBinding {
+    pub cull_layout: wgpu::BindGroupLayout,
+    pub cull_bind_group: wgpu::BindGroup,
+    pub draw_layout: wgpu::BindGroupLayout,
+    pub draw_bind_group: wgpu::BindGroup,
+}
+
+impl SceneDbBinding {
+    /// Rebuilt at renderer construction -- Test 13's mechanism (M3-b): the
+    /// bind groups are torn down and rebuilt across a renderer drop/rebind
+    /// window, never mutated in place, so this constructor is the ONLY way
+    /// a `SceneDbBinding` comes into existence.
+    ///
+    /// ## Signature note (checked against the plan's sketch, no deviation)
+    ///
+    /// The M3-a task spec speculated that binding 7 (cell metadata) might
+    /// need an extra `&StreamingGrid` parameter, since `StreamingGrid` is
+    /// what classifies domains and computes alpha. It does not: cell
+    /// metadata's GPU buffer is allocated by, and its accessor lives on,
+    /// `SceneGpuStore` itself (`cell_metadata_buffer()`, `gpu/scene_store.rs`
+    /// line ~796) -- `StreamingGrid::write_cell_metadata(queue, buf)` only
+    /// *writes into* that buffer (obtained by the caller from `store`), it
+    /// does not own or expose it. Binding (read-only, at renderer
+    /// construction) needs only the buffer handle, which `store` already
+    /// provides. So this signature matches the plan's sketch exactly, with
+    /// no extra parameter -- verified by reading `gpu/scene_store.rs` and
+    /// `gpu/grid.rs` (`grep pub fn.*buffer` finds `cell_metadata_buffer` on
+    /// `SceneGpuStore`; `grid.rs` exposes no buffer accessor of its own).
+    /// Unchanged by the M3-b T4 group split (same five source stores feed
+    /// both groups; only the bind-group/layout construction below changed).
+    pub fn new(
+        device: &wgpu::Device,
+        store: &SceneGpuStore,
+        meshes: &MeshRegistry,
+        clusters: &ClusterBuffer,
+        meshlets: &MeshletBuffer,
+        materials: &MaterialRegistry,
+    ) -> Self {
+        // -- @group(0): the cull-read set. Per-entry visibility (see this
+        // struct's doc comment for the full arithmetic): `instances` and
+        // `instance_info` are also read by the draw pass's vertex/fragment
+        // stages (M3-b T7), everything else here is cull-compute-only.
+        let cull_shared_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT | wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let cull_only_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let cull_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("scenedb-cull-binding-layout"),
+            entries: &[
+                cull_shared_entry(0), // instances
+                cull_shared_entry(1), // instance_info
+                cull_only_entry(2),   // slot_mirror
+                cull_only_entry(3),   // generations
+                cull_only_entry(4),   // mesh_meta
+            ],
+        });
+        let cull_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("scenedb-cull-binding"),
+            layout: &cull_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: store.transform_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: store.instance_info_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: store.slot_mirror_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: store.generation_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: meshes.buffer().as_entire_binding(),
+                },
+            ],
+        });
+
+        // -- @group(1): the draw/material set. All entries VERTEX_FRAGMENT
+        // only -- the cull compute pass never binds this group.
+        let draw_entry = |binding: u32| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let draw_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("scenedb-draw-binding-layout"),
+            entries: &[
+                draw_entry(0), // clusters
+                draw_entry(1), // meshlets
+                draw_entry(2), // cell_meta
+                draw_entry(3), // materials
+            ],
+        });
+        let draw_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("scenedb-draw-binding"),
+            layout: &draw_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: clusters.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: meshlets.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: store.cell_metadata_buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 3,
+                    resource: materials.buffer().as_entire_binding(),
+                },
+            ],
+        });
+
+        Self {
+            cull_layout,
+            cull_bind_group,
+            draw_layout,
+            draw_bind_group,
+        }
+    }
+}

--- a/crates/helio-scenedb/src/repack.rs
+++ b/crates/helio-scenedb/src/repack.rs
@@ -1,0 +1,215 @@
+//! The M3-b T9-followup repack pass: promotes the compute-shader repack
+//! `benches/pass_timing.rs` prototyped bench-local (T9 review, strategy
+//! (b')'s worked example) into a real library capability. This is the
+//! bridge `DrawExecutor::record_multi_indirect` (`draw.rs`, the T9-
+//! recommended default for M3-γ/M4) needs but cannot provide itself:
+//! `multi_draw_indexed_indirect` requires a TIGHTLY PACKED 20-byte
+//! `DrawIndexedIndirectArgs` array, but [`crate::cull::CullOutputBuffers`]'s
+//! `CullRecord` stride is 32 bytes (`cull.rs`'s module doc has the
+//! group(2) storage-budget reason those extra 12 bytes exist). One GPU-side
+//! compute dispatch bridges the gap: read each `CullRecord`'s first 20
+//! bytes, write them densely to a separate buffer. No CPU readback, no CPU
+//! stall.
+//!
+//! [`crate::wgsl::REPACK_WGSL`]'s module doc has the full 32->20 byte field
+//! contract (which `CullRecord` field maps to which packed-args field, and
+//! why `first_instance` specifically MUST survive unchanged -- it is the
+//! §14.1 command-slot bindless key `DRAW_WGSL`'s `vs_main` resolves
+//! `draw_cull_output.records[iid].row` through). Read that doc before
+//! touching either side of this contract.
+//!
+//! A real dense (non-compacting) cull-shader variant that writes the packed
+//! format directly and never needs a repack pass at all is M3-γ/M4 scope,
+//! not this task's.
+
+use crate::cull::CullOutputBuffers;
+use crate::wgsl::REPACK_WGSL;
+
+/// Rust twin of [`REPACK_WGSL`]'s `RepackUniforms` -- the repack pass's
+/// per-dispatch constant input: just the dispatch bound (`capacity`, the
+/// same value the cull pass's own `CullUniforms::capacity` names -- how
+/// many slots exist in the source `CullOutputBuffers`/destination packed
+/// buffer, NOT the cull pass's measured `visible_count`; repacking every
+/// slot, visible or not, is what lets strategy (b')'s "conservative
+/// max-count" steady-state pre-fill -- `instance_count == 0` on
+/// never-touched tail slots -- flow through the repack unchanged, matching
+/// (b)'s own no-readback design).
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RepackUniforms {
+    pub capacity: u32,
+    pub reserved: [u32; 3],
+}
+const _: () = assert!(std::mem::size_of::<RepackUniforms>() == 16);
+// SAFETY: `#[repr(C)]`, `Copy`, scalar/array-of-scalar fields only, no
+// padding (4x 4-byte fields, all 4-aligned).
+unsafe impl bytemuck::Zeroable for RepackUniforms {}
+unsafe impl bytemuck::Pod for RepackUniforms {}
+
+/// The repack pass itself: one compute pipeline, one `@group(0)` bind-group
+/// layout (`input`/`packed`/`u` -- [`REPACK_WGSL`]'s module doc has the
+/// binding-layout rationale), one uniform buffer. Stateless across
+/// dispatches beyond that, matching [`crate::cull::CullPass`]'s and
+/// [`crate::draw::DrawExecutor`]'s "rebuilt, never mutated in place" idiom.
+pub struct RepackPass {
+    pipeline: wgpu::ComputePipeline,
+    layout: wgpu::BindGroupLayout,
+    uniform_buf: wgpu::Buffer,
+}
+
+impl RepackPass {
+    #[must_use]
+    pub fn new(device: &wgpu::Device) -> Self {
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("helio-scenedb-repack-shader"),
+            source: wgpu::ShaderSource::Wgsl(REPACK_WGSL.into()),
+        });
+        let storage_entry = |binding: u32, read_only: bool| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility: wgpu::ShaderStages::COMPUTE,
+            ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+            },
+            count: None,
+        };
+        let layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("helio-scenedb-repack-layout"),
+            entries: &[
+                storage_entry(0, true), // input (CullOutputBuffers, whole-buffer bind -- see REPACK_WGSL doc)
+                storage_entry(1, false), // packed (destination, tightly-packed DrawIndexedIndirectArgs)
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("helio-scenedb-repack-pipeline-layout"),
+            bind_group_layouts: &[Some(&layout)],
+            immediate_size: 0,
+        });
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("helio-scenedb-repack-pipeline"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("repack_main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+        let uniform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("helio-scenedb-repack-uniforms"),
+            size: std::mem::size_of::<RepackUniforms>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        Self {
+            pipeline,
+            layout,
+            uniform_buf,
+        }
+    }
+
+    pub fn write_capacity(&self, queue: &wgpu::Queue, capacity: u32) {
+        queue.write_buffer(
+            &self.uniform_buf,
+            0,
+            bytemuck::bytes_of(&RepackUniforms {
+                capacity,
+                reserved: [0; 3],
+            }),
+        );
+    }
+
+    /// Builds the `@group(0)` bind group over `cull_output`'s combined
+    /// counters+records buffer (read-only source, whole-buffer bind -- see
+    /// [`REPACK_WGSL`]'s doc) and `packed_buf` (the write target -- callers
+    /// pass a buffer sized by [`packed_indirect_buffer`]). Rebuild whenever
+    /// either underlying `wgpu::Buffer` changes, mirroring `CullPass::
+    /// build_output_bind_group`'s idiom.
+    #[must_use]
+    pub fn build_bind_group(
+        &self,
+        device: &wgpu::Device,
+        cull_output: &CullOutputBuffers,
+        packed_buf: &wgpu::Buffer,
+    ) -> wgpu::BindGroup {
+        device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("helio-scenedb-repack-bind-group"),
+            layout: &self.layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: cull_output.buffer().as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: packed_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 2,
+                    resource: self.uniform_buf.as_entire_binding(),
+                },
+            ],
+        })
+    }
+
+    /// Dispatches `repack_main` over `capacity` threads (one per record
+    /// slot -- callers pass the SAME `capacity` [`Self::write_capacity`]
+    /// last wrote, matching [`crate::cull::CullPass::record`]'s
+    /// dispatch-count-mirrors-uniform idiom). No-op (does not even open a
+    /// compute pass) when `capacity == 0`.
+    pub fn record(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        bind_group: &wgpu::BindGroup,
+        capacity: u32,
+    ) {
+        if capacity == 0 {
+            return;
+        }
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("helio-scenedb-repack-pass"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, bind_group, &[]);
+        pass.dispatch_workgroups(capacity.div_ceil(64), 1, 1);
+    }
+}
+
+/// Byte stride of one packed record -- identical to
+/// [`crate::cull::DrawCommand`]'s size (the packed buffer's WGSL-side
+/// `PackedArgs` struct and `DrawCommand` describe the same 20-byte
+/// `DrawIndexedIndirectArgs` shape; this reuses that existing const-asserted
+/// Rust type as the single source of truth rather than a second literal
+/// `20` living here too).
+pub const PACKED_RECORD_BYTES: u64 = std::mem::size_of::<crate::cull::DrawCommand>() as u64;
+
+/// Allocates a tightly-packed (20 B/record) `DrawIndexedIndirectArgs`-shaped
+/// buffer -- [`RepackPass`]'s output, and `multi_draw_indexed_indirect`'s
+/// (`DrawExecutor::record_multi_indirect`'s) required input shape. `usage`
+/// carries `STORAGE` (the repack pass's compute-shader write target),
+/// `INDIRECT` (wgpu's validation requirement for a buffer
+/// `multi_draw_indexed_indirect` reads its args from), and `COPY_SRC`
+/// (mirrors [`crate::cull::CullOutputBuffers::new`]'s own usage set --
+/// tests/spot-checks need to read the repacked bytes back to verify the
+/// 32->20 byte contract, `tests/draw_multi_indirect_equivalence.rs`'s job).
+#[must_use]
+pub fn packed_indirect_buffer(device: &wgpu::Device, capacity: u32) -> wgpu::Buffer {
+    device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("helio-scenedb-repacked-indirect"),
+        size: capacity.max(1) as u64 * PACKED_RECORD_BYTES,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::INDIRECT
+            | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    })
+}

--- a/crates/helio-scenedb/src/wgsl.rs
+++ b/crates/helio-scenedb/src/wgsl.rs
@@ -1,0 +1,644 @@
+//! The renderer-side source of truth for the SceneDB<->Helio seam WGSL
+//! (M3-a T9, design Rev 2 S5; two-group split M3-b T4, contract #47).
+//!
+//! Every struct text below is mirrored VERBATIM from `pulsar_scenedb`'s
+//! `tests/gpu_layout.rs` (Test 3's host-vs-naga byte-exact layout proof:
+//! `M2A_WGSL`'s `Instance`, `M2B_WGSL`'s `MeshMetadata`/`ClusterNode`,
+//! `M3A_WGSL`'s `InstanceInfo`, `M3A_MESHLET_WGSL`'s `MeshletEntry`,
+//! `M3A_MATERIAL_WGSL`'s `MaterialRow`) -- field names, field order, and
+//! scalar-only shape are all load-bearing:
+//! naga's `Layouter` computes offsets purely from declaration order and
+//! scalar type, so any drift here (a reordered field, a renamed field, a
+//! vector type standing in for scalars) breaks the byte-exact guarantee
+//! Test 3 proves on the `pulsar_scenedb` side, even though this copy would
+//! still parse. Do not hand-edit a field here without updating
+//! `tests/gpu_layout.rs` in lockstep (and this crate's own Test 3 harness,
+//! `crates/helio-scenedb/tests/binding_layout.rs`, M3-a T10).
+//!
+//! `CellMeta` is new here (M3-a T9, no `pulsar_scenedb`-side WGSL twin yet):
+//! it mirrors `StreamingGrid::write_cell_metadata`'s packing
+//! (`pulsar_scenedb::gpu::grid`) byte-for-byte -- 8 bytes total, `f32 alpha`
+//! at offset 0, `u32 domain` at offset 4 (`Domain::Outer` = 0,
+//! `Domain::Margin` = 1, `Domain::Inner` = 2).
+//!
+//! ## Bindings — two groups (M3-b T4, closes contract #47)
+//!
+//! M3-a shipped all 9 buffers in one `@group(0)`, one storage buffer over
+//! the WebGPU default per-stage limit
+//! (`Limits::default().max_storage_buffers_per_shader_stage == 8`) --
+//! flagged as a hard M3-b requirement on [`crate::SceneDbBinding`]'s doc
+//! comment since M3-a T9/T11 (perf-validation report contract #47, MISS).
+//! M3-b splits the seam along its actual consumer boundary instead of
+//! raising device limits:
+//!
+//! - **`@group(0)` -- the cull-read set.** Everything the β cull compute
+//!   pass's term list touches (design §4: transform fetch, `InstanceInfo.
+//!   mesh_index` bounds check, `generations[slot_mirror[row]]` validation,
+//!   `MeshMetadata` local-AABB lookup). 5 entries.
+//! - **`@group(1)` -- the draw/material set.** Everything the draw pass
+//!   consumes once M3-β/γ passes exist (cluster DAG + meshlets for VG
+//!   traversal, γ scope; materials for shading; cell metadata for
+//!   domain/alpha). 4 entries. The cull pass never binds this group.
+//! - **`@group(2)` is NOT declared in this constant** -- it is declared by
+//!   [`CULL_WGSL`] below (M3-b T5: `cull_tokens`/`cull_expected_gens`/
+//!   `cull_output`/`cull_uniforms`, the cull pass's own per-view inputs and
+//!   outputs), which `CullPass::new` concatenates after this one at shader-
+//!   build time. T4 deliberately left this index untouched in
+//!   `SCENE_BINDINGS_WGSL` so T5 could claim it without renumbering
+//!   anything here.
+//!
+//! | group | binding | contents           | element type    |
+//! |-------|---------|---------------------|------------------|
+//! | 0     | 0       | instance transforms | `Instance`       |
+//! | 0     | 1       | instance info        | `InstanceInfo`   |
+//! | 0     | 2       | slot mirror          | `u32`            |
+//! | 0     | 3       | generations          | `u32`            |
+//! | 0     | 4       | mesh configurator    | `MeshMetadata`   |
+//! | 1     | 0       | cluster DAG          | `ClusterNode`    |
+//! | 1     | 1       | meshlets              | `MeshletEntry`   |
+//! | 1     | 2       | cell metadata         | `CellMeta`       |
+//! | 1     | 3       | material registry     | `MaterialRow`    |
+//!
+//! SceneDB owns every write path (`write_transform`/`write_instance_info`/
+//! the frame-boundary drivers, `MeshRegistry::register`,
+//! `StreamingGrid::write_cell_metadata`, ...); Helio only ever reads through
+//! this bind group pair.
+//!
+//! `MaterialRow` (M3-a T11, Rev 2.4 R8 approved 2026-07-16): 64 bytes, 16
+//! scalar fields -- PBR params, four bindless texture slot indices
+//! (sentinel `0xFFFF_FFFF` = unbound), a Radiant shader-graph index
+//! (sentinel `0xFFFF_FFFF` = default PBR template), feature flags (bits 0-3
+//! defined, 4-31 reserved), and an alpha-test cutoff. See
+//! `pulsar_scenedb::gpu::MaterialRow`'s doc comment for the full field-by-
+//! field rationale; this struct text must stay byte-identical to that
+//! type's layout (this crate's own Test 3 harness,
+//! `crates/helio-scenedb/tests/binding_layout.rs`, asserts it).
+//!
+//! Geometry (vertex/index) buffers bind at draw time (they vary per draw
+//! call, unlike everything above which is one persistent SSBO per frame);
+//! textures bind through Helio's own bindless array. Neither lives in
+//! either group.
+pub const SCENE_BINDINGS_WGSL: &str = r#"
+struct Instance {
+    transform: mat4x4<f32>,
+}
+
+struct InstanceInfo {
+    mesh_index: u32,
+    flags: u32,
+}
+
+struct MeshMetadata {
+    vertex_offset: u32, index_offset: u32, index_count: u32, base_vertex: i32,
+    material_index: u32, lod_count: u32,
+    lod_d0: f32, lod_d1: f32, lod_d2: f32, lod_d3: f32,
+    aabb_cx: f32, aabb_cy: f32, aabb_cz: f32,
+    cluster_table_offset: u32,
+    aabb_ex: f32, aabb_ey: f32, aabb_ez: f32,
+    meshlet_count: u32,
+}
+
+struct ClusterNode {
+    meshlet_offset: u32, meshlet_count: u32, parent_error: f32, self_error: f32,
+    group_id: u32, child_offset: u32, child_count: u32, padding: u32,
+    bs_x: f32, bs_y: f32, bs_z: f32, bs_w: f32,
+}
+
+struct MeshletEntry {
+    sphere_x: f32, sphere_y: f32, sphere_z: f32, sphere_radius: f32,
+    cone_packed: u32, data_offset: u32, counts_packed: u32, reserved: u32,
+}
+
+struct CellMeta {
+    alpha: f32,
+    domain: u32,
+}
+
+struct MaterialRow {
+    base_color: u32,
+    metallic: f32, roughness: f32, normal_scale: f32,
+    emissive_r: f32, emissive_g: f32, emissive_b: f32, emissive_intensity: f32,
+    tex_albedo: u32, tex_normal: u32, tex_metallic_roughness: u32, tex_emissive: u32,
+    radiant_graph_index: u32,
+    flags: u32,
+    alpha_cutoff: f32,
+    reserved: u32,
+}
+
+// group 0 -- cull-read set (5 entries; see this file's module doc for the
+// per-stage arithmetic and crate::SceneDbBinding for the visibility split).
+@group(0) @binding(0) var<storage, read> instances: array<Instance>;
+@group(0) @binding(1) var<storage, read> instance_info: array<InstanceInfo>;
+@group(0) @binding(2) var<storage, read> slot_mirror: array<u32>;
+@group(0) @binding(3) var<storage, read> generations: array<u32>;
+@group(0) @binding(4) var<storage, read> mesh_meta: array<MeshMetadata>;
+
+// group 1 -- draw/material set (4 entries). Cull never binds this group.
+// group 2 is RESERVED for M3-b T5's per-view ViewTokenBuffers -- not
+// declared here.
+@group(1) @binding(0) var<storage, read> clusters: array<ClusterNode>;
+@group(1) @binding(1) var<storage, read> meshlets: array<MeshletEntry>;
+@group(1) @binding(2) var<storage, read> cell_meta: array<CellMeta>;
+@group(1) @binding(3) var<storage, read> materials: array<MaterialRow>;
+"#;
+
+/// The M3-b T5 cull compute pass: `CullPass::new` concatenates this AFTER
+/// [`SCENE_BINDINGS_WGSL`] (`format!("{SCENE_BINDINGS_WGSL}\n{CULL_WGSL}")`,
+/// the same wholesale-embedding idiom `tests/seam_smoke.rs` established for
+/// M3-b T4) to get `cull_main`'s full source: group(0) (`instances`,
+/// `instance_info`, `slot_mirror`, `generations`, `mesh_meta`) comes from
+/// `SCENE_BINDINGS_WGSL`; this module supplies group(2) — the cull pass's
+/// own per-view inputs/outputs (design S4, S14).
+///
+/// ## group(1) is genuinely never bound (design S4: "cull never binds
+/// group 1")
+///
+/// `SCENE_BINDINGS_WGSL` also declares `@group(1)`'s four draw/material
+/// bindings, but `cull_main` below never references any of them (`clusters`/
+/// `meshlets`/`cell_meta`/`materials` go untouched). `CullPass::new` passes
+/// `bind_group_layouts: &[Some(cull_layout), None, Some(output_layout)]` to
+/// `create_pipeline_layout` — wgpu 30's `PipelineLayoutDescriptor::
+/// bind_group_layouts` is `&[Option<&BindGroupLayout>]` (sparse; the M3-b T4
+/// smoke test bound all three positions with `Some`, but the type has always
+/// supported gaps), so group(1) has NO layout at pipeline-layout index 1 at
+/// all, and `CullPass::record` never calls `set_bind_group(1, ..)`. This is
+/// stronger than "declared but unused, bound anyway for positional validity"
+/// (T4's smoke-test pattern): here group(1) is genuinely absent from the
+/// pipeline. This works because wgpu/naga's pipeline-layout validation
+/// checks bindings *reachable from the entry point* (`cull_main`), not every
+/// module-scope declaration in the shader source — `tests/cull_pass.rs`'s
+/// passing dispatch is the empirical proof, alongside this doc's reasoning.
+///
+/// ## group(2) storage-buffer budget arithmetic (the task's explicit ≤3
+/// requirement, on top of group(0)'s 5 COMPUTE-visible entries: 5+3=8, the
+/// WebGPU default `max_storage_buffers_per_shader_stage` ceiling — #47 must
+/// stay closed)
+///
+/// The design lists FIVE logical group(2) inputs/outputs (tokens,
+/// expected_gens, the output command buffer, the visible-id buffer, the
+/// atomic counter) plus a uniform block. Five storage buffers would blow
+/// the budget (5 + 5 = 10 > 8). This module ships exactly THREE storage
+/// bindings by combining the last three into one:
+///
+/// - binding 0: `cull_tokens: array<u32>` — [`pulsar_scenedb::gpu::
+///   ViewTokenBuffers::tokens_buffer`], read-only (producer-owned, cannot be
+///   merged with binding 1 — two independently allocated `wgpu::Buffer`s).
+/// - binding 1: `cull_expected_gens: array<u32>` —
+///   [`pulsar_scenedb::gpu::ViewTokenBuffers::expected_gens_buffer`],
+///   read-only (same reason).
+/// - binding 2: `cull_output: CullOutput` (read_write) — COMBINES the
+///   atomic counters (`visible_count`/`stale_drops`/`oob_drops`/
+///   `frustum_drops`, a fixed 16-byte header) AND the per-command-slot
+///   output array (`records: array<CullRecord>`) in ONE binding. Each
+///   `CullRecord`'s first 20 bytes (`index_count`/`instance_count`/
+///   `first_index`/`base_vertex`/`first_instance`) are field-for-field
+///   identical to the standalone `DrawCommand` struct below (same order,
+///   same offsets) — a future repack into a tightly-packed
+///   `array<DrawCommand>` for `multi_draw_indexed_indirect` (M3-b T7's
+///   scope; T7 "documents its choice" per the plan, may pick a
+///   count-clamped loop instead and avoid repacking entirely) is a
+///   fixed-stride copy, not a redesign. `row` stays its OWN field — the
+///   design's row-valued `visible_instance_ids[command_slot] = row` (S3,
+///   R11) is never folded into `flags` or the command fields, only
+///   co-located in the same binding to fit the budget. `flags` bit 0 is the
+///   S12 near-clip carry (see [`CULL_WGSL`]'s `NEAR_CLIP_FLAG` doc).
+/// - binding 3: `cull_uniforms: CullUniforms` (`var<uniform>`, NOT a
+///   storage buffer — uniform buffers have their own separate WebGPU limit,
+///   `max_uniform_buffers_per_shader_stage` default 12, untouched by this
+///   arithmetic) — the view-proj matrix (S12 near-clip corner projection),
+///   6 frustum planes (S4 frustum term), and `count`/`mesh_count`/
+///   `capacity` (the `i < count` guard, the mesh-table bounds-check ceiling,
+///   and the S14.2 slot-allocation ceiling).
+///
+/// **Arithmetic:** group(0) COMPUTE-visible entries (5, `SceneDbBinding`'s
+/// doc comment) + group(2) storage entries (3, `cull_tokens`/
+/// `cull_expected_gens`/`cull_output`; `cull_uniforms` doesn't count) =
+/// **8 / 8** — at the ceiling, not over it. No more than 3 was available;
+/// this design uses exactly 3.
+pub const CULL_WGSL: &str = r#"
+// Standalone indirect-draw wire format (spec S14.1) -- 20 bytes, matches
+// wgpu's DrawIndexedIndirectArgs field-for-field. Declared here purely so
+// Test 3 pins the wire format byte-exact for M3-b T7's future indirect-draw
+// executor; the ACTUAL group(2) binding below uses CullRecord, whose first
+// 20 bytes are IDENTICAL field-for-field (see this file's module doc).
+struct DrawCommand {
+    index_count: u32,
+    instance_count: u32,
+    first_index: u32,
+    base_vertex: i32,
+    first_instance: u32,
+}
+
+// One combined per-command-slot output record (module doc: the group(2)
+// storage-budget packing). First 5 fields identical to DrawCommand
+// field-for-field (offsets 0/4/8/12/16); `row` is the design's row-valued
+// visible_instance_ids[slot] (S3/R11 -- command-slot-keyed, ROW-valued,
+// its own field, never folded into `flags` or the command fields); `flags`
+// bit 0 (NEAR_CLIP_FLAG) carries the S12 near-clip bypass for this slot.
+struct CullRecord {
+    index_count: u32,
+    instance_count: u32,
+    first_index: u32,
+    base_vertex: i32,
+    first_instance: u32,
+    row: u32,
+    flags: u32,
+    reserved: u32,
+}
+
+const NEAR_CLIP_FLAG: u32 = 1u;
+
+// Fixed 16-byte atomic-counters header, followed by the per-slot record
+// array (S14.2 bounded-atomic allocation: overflowing threads still
+// atomicAdd `visible_count` but do NOT write past `capacity` -- the CPU
+// clamps on readback, Test 5 in T8).
+struct CullOutput {
+    visible_count: atomic<u32>,
+    stale_drops: atomic<u32>,
+    oob_drops: atomic<u32>,
+    frustum_drops: atomic<u32>,
+    records: array<CullRecord>,
+}
+
+struct CullUniforms {
+    view_proj: mat4x4<f32>,
+    planes: array<vec4<f32>, 6>,
+    count: u32,
+    mesh_count: u32,
+    capacity: u32,
+    reserved: u32,
+}
+
+@group(2) @binding(0) var<storage, read> cull_tokens: array<u32>;
+@group(2) @binding(1) var<storage, read> cull_expected_gens: array<u32>;
+@group(2) @binding(2) var<storage, read_write> cull_output: CullOutput;
+@group(2) @binding(3) var<uniform> cull_uniforms: CullUniforms;
+
+// S11: |M3x3| absolute-value world-extent transform.
+fn abs_mat3(m: mat4x4<f32>) -> mat3x3<f32> {
+    return mat3x3<f32>(abs(m[0].xyz), abs(m[1].xyz), abs(m[2].xyz));
+}
+
+// Positive-vertex AABB-vs-plane test (n.p+d>=0 convention, spatial.rs's
+// Frustum doc): true if the box is at least partially on the inside side of
+// `plane`; false only when the box is ENTIRELY outside it.
+fn plane_test(center: vec3<f32>, extents: vec3<f32>, plane: vec4<f32>) -> bool {
+    let r = extents.x * abs(plane.x) + extents.y * abs(plane.y) + extents.z * abs(plane.z);
+    let d = dot(plane.xyz, center) + plane.w;
+    return d >= -r;
+}
+
+@compute @workgroup_size(64)
+fn cull_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= cull_uniforms.count) {
+        return;
+    }
+    let row = cull_tokens[i];
+
+    // -- S3.1 generation validation: generations[slot_mirror[row]] vs the
+    // harvest-time expected_gens[i] snapshot (view_upload.rs's own doc
+    // comment states this exact indexing -- verified against
+    // scene_store.rs: slot_mirror[global_row] = slot_base + local_slot,
+    // and generations is written at that SAME slot_base + local_slot index
+    // (write_generation), so slot_mirror's stored value already IS the
+    // generations-buffer index; no extra base offset applies here). --
+    let slot = slot_mirror[row];
+    let live_gen = generations[slot];
+    if (live_gen != cull_expected_gens[i]) {
+        atomicAdd(&cull_output.stale_drops, 1u);
+        return;
+    }
+
+    // -- mesh_index bounds check (M3-a T4 recycled-tail defense, REQUIRED:
+    // recycled-region tail bytes are contractually undefined until
+    // written). --
+    let mesh_index = instance_info[row].mesh_index;
+    if (mesh_index >= cull_uniforms.mesh_count) {
+        atomicAdd(&cull_output.oob_drops, 1u);
+        return;
+    }
+
+    let mesh = mesh_meta[mesh_index];
+    let m = instances[row].transform;
+
+    // -- S11 |M3x3| world AABB. --
+    let local_center = vec3<f32>(mesh.aabb_cx, mesh.aabb_cy, mesh.aabb_cz);
+    let local_extents = vec3<f32>(mesh.aabb_ex, mesh.aabb_ey, mesh.aabb_ez);
+    let world_center = (m * vec4<f32>(local_center, 1.0)).xyz;
+    let world_extents = abs_mat3(m) * local_extents;
+
+    // -- S12 near-plane guard: project all 8 world AABB corners through the
+    // view-proj matrix; W<=0 on ANY corner bypasses culling entirely and
+    // marks the instance visible with the near-clip flag set (S12.1). --
+    var near_clip = false;
+    for (var c: u32 = 0u; c < 8u; c = c + 1u) {
+        let sx = select(-1.0, 1.0, (c & 1u) != 0u);
+        let sy = select(-1.0, 1.0, (c & 2u) != 0u);
+        let sz = select(-1.0, 1.0, (c & 4u) != 0u);
+        let corner = world_center + vec3<f32>(sx, sy, sz) * world_extents;
+        let clip = cull_uniforms.view_proj * vec4<f32>(corner, 1.0);
+        if (clip.w <= 0.0) {
+            near_clip = true;
+        }
+    }
+
+    var visible = true;
+    if (!near_clip) {
+        for (var p: u32 = 0u; p < 6u; p = p + 1u) {
+            if (!plane_test(world_center, world_extents, cull_uniforms.planes[p])) {
+                visible = false;
+            }
+        }
+        if (!visible) {
+            atomicAdd(&cull_output.frustum_drops, 1u);
+            return;
+        }
+    }
+
+    // -- S14.2 bounded-atomic slot allocation: overflowing threads still
+    // bump visible_count (so the CPU can clamp and know how many were
+    // dropped) but never write past capacity. --
+    let out_slot = atomicAdd(&cull_output.visible_count, 1u);
+    if (out_slot < cull_uniforms.capacity) {
+        var flags = 0u;
+        if (near_clip) {
+            flags = NEAR_CLIP_FLAG;
+        }
+        cull_output.records[out_slot] = CullRecord(
+            mesh.index_count,
+            1u,
+            mesh.index_offset,
+            mesh.base_vertex,
+            out_slot,
+            row,
+            flags,
+            0u,
+        );
+    }
+}
+"#;
+
+/// The M3-b T7 minimal indirect-draw executor: `DrawExecutor::new`
+/// concatenates this AFTER [`SCENE_BINDINGS_WGSL`]
+/// (`format!("{SCENE_BINDINGS_WGSL}\n{DRAW_WGSL}")`, the same idiom
+/// [`CULL_WGSL`] established) to get `vs_main`/`fs_main`'s full source:
+/// `@group(0)` (`instances`, `instance_info` -- the only two of
+/// `SCENE_BINDINGS_WGSL`'s five group(0) entries this module's shader
+/// bodies actually reference) comes from `SCENE_BINDINGS_WGSL`; this module
+/// supplies `@group(2)` -- the draw pass's own per-view inputs (design
+/// S4/S14.1/S14.2: `first_instance` (== command slot) -> `visible_instance_
+/// ids[slot]` -> row -> `instances[row]`).
+///
+/// ## `@group(1)` is never bound (mirrors [`CULL_WGSL`]'s own choice)
+///
+/// `vs_main`/`fs_main` read `InstanceInfo.mesh_index` only to pick a flat
+/// output color -- they never touch `clusters`/`meshlets`/`cell_meta`/
+/// `materials`. `DrawExecutor::new` passes `bind_group_layouts: &[Some(cull_
+/// layout), None, Some(output_layout)]` to `create_pipeline_layout`, so
+/// `@group(1)` has no layout at pipeline-layout index 1 at all -- the plan's
+/// "prefer not binding it and say so" instruction, taken literally, for the
+/// exact reason [`CULL_WGSL`]'s module doc already established works
+/// (wgpu/naga's pipeline-layout validation checks bindings *reachable from
+/// the entry point*, not every module-scope declaration).
+///
+/// ## Why `@group(2)` re-declares `CullRecord`'s byte layout instead of
+/// reusing [`CULL_WGSL`]'s `CullOutput`/`CullRecord` types (M3-b T7)
+///
+/// `CullOutput`'s 16-byte atomics header (`visible_count`/etc, all
+/// `atomic<u32>`) forces its storage variable to be declared
+/// `var<storage, read_write>` (WGSL requires read_write access for a
+/// binding that contains atomic fields, regardless of whether the shader
+/// actually calls an atomic op on them). A `read_write` storage buffer
+/// bound to the VERTEX stage requires `wgpu::Features::
+/// VERTEX_WRITABLE_STORAGE` -- a NON-default feature this task's device
+/// (`wgpu::Limits::default()`, no extra `required_features`) does not
+/// request. So `vs_main` cannot bind `CullOutput` as-is. Instead this
+/// module declares `DrawRecord` (identical 8 scalar fields, same offsets,
+/// to [`CULL_WGSL`]'s `CullRecord` -- MUST stay byte-identical, see
+/// `crate::cull::CullRecord`'s doc) and `DrawCullOutput` (the same 16-byte
+/// header, as four plain non-atomic `u32` fields, followed by
+/// `records: array<DrawRecord>`) purely so the header+array CAN be bound
+/// `var<storage, read>` -- `read`-only access needs no feature request, and
+/// `vs_main` only ever READS `.records[iid].row`, never writes. Both
+/// declarations describe the EXACT SAME buffer bytes [`crate::cull::
+/// CullOutputBuffers`] already allocates (M3-b T5) -- this is a second,
+/// read-only WGSL *view* of that buffer, not a second buffer or a repack.
+///
+/// ## The indirect-draw mechanism (M3-b T7's required choice, documented
+/// again at the call site in `draw.rs`)
+///
+/// `DrawExecutor::record` issues a CPU-side loop of `RenderPass::
+/// draw_indexed_indirect` calls, one per command slot, each pointing
+/// directly at `CullOutputBuffers::HEADER_BYTES + slot * RECORD_BYTES` --
+/// NOT `multi_draw_indexed_indirect`. Both wgpu-30 methods gate on the same
+/// downlevel capability (`DownlevelFlags::INDIRECT_EXECUTION`, universally
+/// true on desktop Vulkan/DX12/Metal, not a `Features` flag at all), so
+/// availability was never the blocker; `multi_draw_indexed_indirect`'s own
+/// doc comment requires its indirect buffer's draw structs to be "tightly
+/// packed" (wgpu's `DrawIndexedIndirectArgs`, 20 bytes, no gaps) --
+/// `CullOutputBuffers`' `CullRecord` stride is 32 bytes (the S14.1 command
+/// fields plus `row`/`flags`/`reserved`, `crate::cull`'s module doc has the
+/// group(2) storage-budget reason those live in ONE record), so a single
+/// `multi_draw_indexed_indirect(..., count)` call cannot read it directly --
+/// it would require a repack pass into a second, tightly-packed
+/// `array<DrawCommand>` buffer first. The per-slot loop reads the EXACT
+/// same 32-byte-strided buffer the cull pass wrote (each `CullRecord`'s
+/// first 20 bytes are field-for-field a valid `DrawIndexedIndirectArgs`,
+/// `crate::cull::CullRecord`'s doc), so it needs no extra buffer, no extra
+/// pass, and no extra feature -- the right minimal choice for this
+/// deliberately-not-the-full-integration executor (M4 owns any real
+/// per-frame draw-call-count optimization).
+pub const DRAW_WGSL: &str = r#"
+struct DrawRecord {
+    index_count: u32,
+    instance_count: u32,
+    first_index: u32,
+    base_vertex: i32,
+    first_instance: u32,
+    row: u32,
+    flags: u32,
+    reserved: u32,
+}
+
+struct DrawCullOutput {
+    visible_count: u32,
+    stale_drops: u32,
+    oob_drops: u32,
+    frustum_drops: u32,
+    records: array<DrawRecord>,
+}
+
+struct DrawUniforms {
+    view_proj: mat4x4<f32>,
+}
+
+@group(2) @binding(0) var<storage, read> draw_cull_output: DrawCullOutput;
+@group(2) @binding(1) var<uniform> draw_uniforms: DrawUniforms;
+
+// Deterministic mesh_index -> flat RGBA color, so a test can identify WHICH
+// instance painted a given pixel from its color alone (house law:
+// self-verifying guards must prove the row->instance_info lookup, not just
+// that pixels exist). Arbitrary but fixed multipliers -- callers that need
+// the SAME mapping on the CPU side reproduce this exact formula (documented
+// in `draw.rs`'s Test 4).
+fn mesh_color(idx: u32) -> vec4<f32> {
+    let r = f32((idx * 37u + 17u) % 256u) / 255.0;
+    let g = f32((idx * 91u + 53u) % 256u) / 255.0;
+    let b = f32((idx * 131u + 7u) % 256u) / 255.0;
+    return vec4<f32>(r, g, b, 1.0);
+}
+
+struct VsOut {
+    @builtin(position) clip_pos: vec4<f32>,
+    @location(0) @interpolate(flat) mesh_index: u32,
+}
+
+// S14.1/S14.2: `first_instance` (== command slot, the bindless lookup key)
+// arrives here as the `instance_index` builtin -- WebGPU's indirect-draw
+// semantics set it to `first_instance + <local index within instance_
+// count>`, and every command this pass draws has `instance_count == 1`, so
+// `iid` is exactly the command slot the cull pass allocated. That slot
+// indexes `draw_cull_output.records[iid].row` -- the row-valued lookup the
+// design calls `visible_instance_ids[command_slot] = row` (co-located in
+// this buffer rather than a standalone array, `crate::wgsl`'s CULL_WGSL doc
+// has the group(2) storage-budget reason) -- which in turn indexes
+// `instances`/`instance_info` (SCENE_BINDINGS_WGSL's group(0), the pinned
+// column-major transform convention, no transpose).
+@vertex
+fn vs_main(@location(0) local_pos: vec3<f32>, @builtin(instance_index) iid: u32) -> VsOut {
+    let row = draw_cull_output.records[iid].row;
+    let m = instances[row].transform;
+    let world = m * vec4<f32>(local_pos, 1.0);
+    var out: VsOut;
+    out.clip_pos = draw_uniforms.view_proj * world;
+    out.mesh_index = instance_info[row].mesh_index;
+    return out;
+}
+
+@fragment
+fn fs_main(in: VsOut) -> @location(0) vec4<f32> {
+    return mesh_color(in.mesh_index);
+}
+"#;
+
+/// The M3-b T9-followup repack pass: `crate::repack::RepackPass::new`
+/// concatenates NOTHING before this (unlike [`CULL_WGSL`]/[`DRAW_WGSL`],
+/// this module's ONE entry point (`repack_main`) never touches
+/// `SCENE_BINDINGS_WGSL`'s `@group(0)` at all -- it only reads
+/// [`crate::cull::CullOutputBuffers`]'s own buffer and writes a second,
+/// tightly-packed one, so it needs no scene bindings). Promoted (M3-b T9
+/// review, defect 2) out of `benches/pass_timing.rs`'s bench-local
+/// `REPACK_WGSL`/`RepackPass` into this crate proper, so
+/// `DrawExecutor::record_multi_indirect` (`draw.rs`, strategy (b') -- the
+/// T9-recommended default for M3-γ/M4) has a real library-shipped source of
+/// the tightly-packed indirect-args buffer it requires, not just a
+/// throwaway bench probe.
+///
+/// ## The 32 -> 20 byte contract (read this before touching either side)
+///
+/// [`crate::cull::CullRecord`] (32 bytes, `cull.rs`'s doc) and
+/// `PackedArgs`/[`crate::cull::DrawCommand`] (20 bytes, wgpu's
+/// `DrawIndexedIndirectArgs` shape) share the SAME first 5 fields, in the
+/// SAME order, at the SAME offsets -- `crate::cull::CullRecord`'s own doc
+/// states this explicitly ("First 5 fields are field-for-field identical to
+/// `DrawCommand`"). `repack_main` below does exactly that: read one
+/// `CullRecord`, write its first 5 fields verbatim, drop the trailing 3
+/// (`row`, `flags`, `reserved` -- cull-internal bookkeeping the packed
+/// indirect-args buffer has no room for and no use for: `multi_draw_indexed_
+/// indirect` never reads past byte 20 of each record).
+///
+/// | `CullRecord` field (offset) | -> | `PackedArgs` field (offset) | kept? |
+/// |------------------------------|----|-------------------------------|-------|
+/// | `index_count`   (0)          | -> | `index_count`   (0)           | yes   |
+/// | `instance_count` (4)         | -> | `instance_count` (4)          | yes   |
+/// | `first_index`   (8)          | -> | `first_index`   (8)           | yes   |
+/// | `base_vertex`   (12, i32)    | -> | `base_vertex`   (12, i32)     | yes   |
+/// | `first_instance` (16)        | -> | `first_instance` (16)         | yes -- **MUST survive unchanged** |
+/// | `row`           (20)         | -> | (none)                        | dropped |
+/// | `flags`         (24)         | -> | (none)                        | dropped |
+/// | `reserved`      (28)         | -> | (none)                        | dropped |
+///
+/// **`first_instance` is the one field a repack bug can get away with
+/// scrambling without an obviously-broken draw** (unlike e.g. swapping
+/// `index_count`/`first_index`, which paints garbage geometry immediately).
+/// `DRAW_WGSL`'s own module doc pins why: every packed record has
+/// `instance_count == 1u` (cull_main's own construction, `CULL_WGSL`), so
+/// WebGPU's indirect-draw semantics set `@builtin(instance_index)` to
+/// EXACTLY the packed record's `first_instance` value, and `vs_main` uses
+/// that as `iid` to index `draw_cull_output.records[iid].row` -- the SAME
+/// 32-byte-strided `CullOutputBuffers` buffer this repack pass read FROM,
+/// unchanged, side-by-side with the packed buffer `multi_draw_indexed_
+/// indirect` reads its args from. Since cull_main allocates output slots
+/// with a monotonic `atomicAdd(&cull_output.visible_count, 1u)` and stamps
+/// each record's `first_instance` with that SAME `out_slot`, a `CullRecord`
+/// at buffer position `i` always has `first_instance == i` in this design --
+/// so `packed[i].first_instance` staying `== i` is what lets `records[iid]`
+/// resolve back to the CORRECT row (S14.1's "`first_instance` == command
+/// slot" bindless key, `cull.rs`/`draw.rs`'s own docs). A repack that
+/// dropped, zeroed, or shifted `first_instance` would still produce a
+/// visually plausible frame (draws still fire, geometry still valid) but
+/// with WRONG per-instance row/color/transform lookups -- exactly the class
+/// of bug `tests/draw_multi_indirect_equivalence.rs`'s byte-identical
+/// comparison against strategy (a) exists to catch.
+///
+/// ## Binding layout note (mirrors `DRAW_WGSL`'s own group(2) trick)
+///
+/// `input` binds the WHOLE `CullOutputBuffers` buffer at offset 0 (not a
+/// byte-offset view starting at the records array, offset
+/// [`crate::cull::CullOutputBuffers::HEADER_BYTES`]) -- a storage-buffer
+/// bind offset must respect `min_storage_buffer_offset_alignment` (this
+/// crate's default-limits test hosts report 256; `HEADER_BYTES` is 16, so
+/// an offset-16 binding is rejected by wgpu validation). Binding the whole
+/// buffer and indexing `input.records[i]` inside WGSL sidesteps the
+/// alignment requirement entirely -- the same trick [`DRAW_WGSL`] already
+/// uses for its own `@group(2)` view of this same buffer.
+pub const REPACK_WGSL: &str = r#"
+struct CullRecord {
+    index_count: u32,
+    instance_count: u32,
+    first_index: u32,
+    base_vertex: i32,
+    first_instance: u32,
+    row: u32,
+    flags: u32,
+    reserved: u32,
+}
+
+struct RepackInput {
+    visible_count: u32,
+    stale_drops: u32,
+    oob_drops: u32,
+    frustum_drops: u32,
+    records: array<CullRecord>,
+}
+
+struct PackedArgs {
+    index_count: u32,
+    instance_count: u32,
+    first_index: u32,
+    base_vertex: i32,
+    first_instance: u32,
+}
+
+struct RepackUniforms {
+    capacity: u32,
+    reserved0: u32,
+    reserved1: u32,
+    reserved2: u32,
+}
+
+@group(0) @binding(0) var<storage, read> input: RepackInput;
+@group(0) @binding(1) var<storage, read_write> packed: array<PackedArgs>;
+@group(0) @binding(2) var<uniform> u: RepackUniforms;
+
+@compute @workgroup_size(64)
+fn repack_main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let i = gid.x;
+    if (i >= u.capacity) {
+        return;
+    }
+    let r = input.records[i];
+    packed[i] = PackedArgs(r.index_count, r.instance_count, r.first_index, r.base_vertex, r.first_instance);
+}
+"#;

--- a/crates/helio-scenedb/tests/binding_layout.rs
+++ b/crates/helio-scenedb/tests/binding_layout.rs
@@ -1,0 +1,393 @@
+//! Test 3 (C5): host struct offsets vs naga reflection of the ACTUAL seam
+//! WGSL (`helio_scenedb::wgsl::SCENE_BINDINGS_WGSL`) — byte-exact, mirroring
+//! `pulsar_scenedb/tests/gpu_layout.rs`'s harness one-for-one (M3-a T10).
+//!
+//! This is deliberately NOT a copy of the struct text reflected on the
+//! SceneDB side: it parses the renderer-side source of truth directly (the
+//! `pub const SCENE_BINDINGS_WGSL` Helio's real shaders will `format!` their
+//! own bindings around), so any drift between the two WGSL copies — the
+//! exact hazard `wgsl.rs`'s doc comment warns about — fails HERE, on the
+//! Helio side, not just on the SceneDB side. This harness is what M3-b/-g
+//! extend for every new shader struct that joins `SCENE_BINDINGS_WGSL`.
+//!
+//! Pure naga (WGSL front-end parse + `Layouter`) — no GPU device, no
+//! adapter, no `pollster`. Safe to run anywhere `cargo test` runs.
+
+use helio_scenedb::cull::{CullRecord, CullUniforms, DrawCommand};
+use helio_scenedb::draw::DrawUniforms;
+use helio_scenedb::wgsl::{CULL_WGSL, DRAW_WGSL, SCENE_BINDINGS_WGSL};
+use pulsar_scenedb::gpu::{ClusterNode, InstanceInfo, MaterialRow, MeshMetadata, MeshletEntry};
+
+/// Reflect (size, [(member_name, offset)]) for a named struct in WGSL source.
+/// Ported verbatim from `pulsar_scenedb/tests/gpu_layout.rs::wgsl_struct_
+/// layout` (naga 30 API — same crate major as `pulsar_scenedb`'s `gpu`
+/// feature dev-dep; T1 already migrated this helper to naga 30, so the API
+/// transfers directly with no adaptation needed).
+fn wgsl_struct_layout(src: &str, name: &str) -> (u32, Vec<(String, u32)>) {
+    let module = naga::front::wgsl::parse_str(src).expect("valid WGSL");
+    let mut layouter = naga::proc::Layouter::default();
+    layouter.update(module.to_ctx()).expect("layout");
+    let (handle, ty) = module
+        .types
+        .iter()
+        .find(|(_, t)| t.name.as_deref() == Some(name))
+        .unwrap_or_else(|| panic!("struct {name} not found"));
+    let naga::TypeInner::Struct { members, .. } = &ty.inner else {
+        panic!("{name} is not a struct");
+    };
+    let size = layouter[handle].size;
+    let offsets = members
+        .iter()
+        .map(|m| (m.name.clone().unwrap_or_default(), m.offset))
+        .collect();
+    (size, offsets)
+}
+
+#[test]
+fn instance_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "Instance");
+    // Host element: [f32; 16], 64 bytes, transform at offset 0 (C5).
+    assert_eq!(size, 64, "WGSL Instance size == size_of::<[f32; 16]>()");
+    assert_eq!(size as usize, std::mem::size_of::<[f32; 16]>());
+    assert_eq!(members, vec![("transform".to_string(), 0)]);
+}
+
+#[test]
+fn instance_info_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "InstanceInfo");
+    // Host element: `pulsar_scenedb::gpu::InstanceInfo` (`spatial.rs`, C5
+    // amendment — cull's token->mesh link).
+    assert_eq!(size, 8, "WGSL InstanceInfo size == size_of::<InstanceInfo>()");
+    assert_eq!(size as usize, std::mem::size_of::<InstanceInfo>());
+    assert_eq!(
+        members,
+        vec![("mesh_index".to_string(), 0), ("flags".to_string(), 4)]
+    );
+}
+
+#[test]
+fn mesh_metadata_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "MeshMetadata");
+    // Host element: `pulsar_scenedb::gpu::MeshMetadata`, 72 bytes (C5/§6.1).
+    assert_eq!(size, 72, "WGSL MeshMetadata size == size_of::<MeshMetadata>()");
+    assert_eq!(size as usize, std::mem::size_of::<MeshMetadata>());
+    assert_eq!(
+        members,
+        vec![
+            ("vertex_offset".to_string(), 0),
+            ("index_offset".to_string(), 4),
+            ("index_count".to_string(), 8),
+            ("base_vertex".to_string(), 12),
+            ("material_index".to_string(), 16),
+            ("lod_count".to_string(), 20),
+            ("lod_d0".to_string(), 24),
+            ("lod_d1".to_string(), 28),
+            ("lod_d2".to_string(), 32),
+            ("lod_d3".to_string(), 36),
+            ("aabb_cx".to_string(), 40),
+            ("aabb_cy".to_string(), 44),
+            ("aabb_cz".to_string(), 48),
+            ("cluster_table_offset".to_string(), 52),
+            ("aabb_ex".to_string(), 56),
+            ("aabb_ey".to_string(), 60),
+            ("aabb_ez".to_string(), 64),
+            ("meshlet_count".to_string(), 68),
+        ]
+    );
+}
+
+#[test]
+fn cluster_node_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "ClusterNode");
+    // Host element: `pulsar_scenedb::gpu::ClusterNode`, 48 bytes (C5).
+    assert_eq!(size, 48, "WGSL ClusterNode size == size_of::<ClusterNode>()");
+    assert_eq!(size as usize, std::mem::size_of::<ClusterNode>());
+    assert_eq!(
+        members,
+        vec![
+            ("meshlet_offset".to_string(), 0),
+            ("meshlet_count".to_string(), 4),
+            ("parent_error".to_string(), 8),
+            ("self_error".to_string(), 12),
+            ("group_id".to_string(), 16),
+            ("child_offset".to_string(), 20),
+            ("child_count".to_string(), 24),
+            ("padding".to_string(), 28),
+            ("bs_x".to_string(), 32),
+            ("bs_y".to_string(), 36),
+            ("bs_z".to_string(), 40),
+            ("bs_w".to_string(), 44),
+        ]
+    );
+}
+
+#[test]
+fn meshlet_entry_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "MeshletEntry");
+    // Host element: `pulsar_scenedb::gpu::MeshletEntry`, 32 bytes (C5
+    // amendment / punch-list R12).
+    assert_eq!(size, 32, "WGSL MeshletEntry size == size_of::<MeshletEntry>()");
+    assert_eq!(size as usize, std::mem::size_of::<MeshletEntry>());
+    assert_eq!(
+        members,
+        vec![
+            ("sphere_x".to_string(), 0),
+            ("sphere_y".to_string(), 4),
+            ("sphere_z".to_string(), 8),
+            ("sphere_radius".to_string(), 12),
+            ("cone_packed".to_string(), 16),
+            ("data_offset".to_string(), 20),
+            ("counts_packed".to_string(), 24),
+            ("reserved".to_string(), 28),
+        ]
+    );
+}
+
+/// M3-a T11 (Rev 2.4 R8, approved 2026-07-16): host
+/// `pulsar_scenedb::gpu::MaterialRow` vs naga reflection of the ACTUAL seam
+/// WGSL's `MaterialRow` (`@group(1) @binding(3)` post-M3-b-T4-split; was
+/// "binding 8" pre-split, in the original single-group layout), byte-exact
+/// -- Rust-twin
+/// `std::mem::size_of` cross-check mirrors every other struct test in this
+/// file. 16 scalar fields, all 16 offsets asserted.
+#[test]
+fn material_row_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "MaterialRow");
+    // Host element: `pulsar_scenedb::gpu::MaterialRow`, 64 bytes (C5/§10.1,
+    // Rev 2.4 R8).
+    assert_eq!(size, 64, "WGSL MaterialRow size == size_of::<MaterialRow>()");
+    assert_eq!(size as usize, std::mem::size_of::<MaterialRow>());
+    assert_eq!(
+        members,
+        vec![
+            ("base_color".to_string(), 0),
+            ("metallic".to_string(), 4),
+            ("roughness".to_string(), 8),
+            ("normal_scale".to_string(), 12),
+            ("emissive_r".to_string(), 16),
+            ("emissive_g".to_string(), 20),
+            ("emissive_b".to_string(), 24),
+            ("emissive_intensity".to_string(), 28),
+            ("tex_albedo".to_string(), 32),
+            ("tex_normal".to_string(), 36),
+            ("tex_metallic_roughness".to_string(), 40),
+            ("tex_emissive".to_string(), 44),
+            ("radiant_graph_index".to_string(), 48),
+            ("flags".to_string(), 52),
+            ("alpha_cutoff".to_string(), 56),
+            ("reserved".to_string(), 60),
+        ]
+    );
+}
+
+/// `CellMeta` has no Rust twin type (`wgsl.rs`'s doc comment, M3-a T9): the
+/// streaming grid packs `(f32 alpha, u32 domain)` manually into a raw byte
+/// buffer at `dense_id * 8` in `StreamingGrid::write_cell_metadata`
+/// (`pulsar_scenedb/src/gpu/grid.rs` lines 377-388) rather than through a
+/// `#[repr(C)]` struct + typed-slice `write_buffer`. So this test asserts
+/// the WGSL side only — size and both field offsets — with this comment as
+/// the pointer to the CPU-side packing it must stay byte-compatible with:
+/// `alpha.to_le_bytes()` at `offset..offset+4`, `domain_code.to_le_bytes()`
+/// at `offset+4..offset+8` (`Domain::Outer` = 0, `Margin` = 1, `Inner` = 2).
+#[test]
+fn cell_meta_struct_is_byte_exact() {
+    let (size, members) = wgsl_struct_layout(SCENE_BINDINGS_WGSL, "CellMeta");
+    assert_eq!(size, 8, "WGSL CellMeta size == 8 bytes (grid.rs:377-388 packing)");
+    assert_eq!(
+        members,
+        vec![("alpha".to_string(), 0), ("domain".to_string(), 4)]
+    );
+}
+
+/// M3-b T5: [`CULL_WGSL`]'s struct declarations reference nothing outside
+/// themselves EXCEPT `cull_main`'s body, which reads `SCENE_BINDINGS_WGSL`'s
+/// group(0) globals (`instances`/`instance_info`/`slot_mirror`/
+/// `generations`/`mesh_meta`) -- naga's WGSL front end validates a module's
+/// function bodies too, so parsing `CULL_WGSL` in isolation fails with
+/// "undefined identifier". This mirrors `CullPass::new`'s own
+/// `format!("{SCENE_BINDINGS_WGSL}\n{CULL_WGSL}")` concatenation exactly
+/// (the ACTUAL source the cull pipeline compiles), not an approximation.
+fn cull_wgsl_combined() -> String {
+    format!("{SCENE_BINDINGS_WGSL}\n{CULL_WGSL}")
+}
+
+/// M3-b T5: host [`DrawCommand`] (Helio-owned, no `pulsar_scenedb` twin --
+/// C0: SceneDB never touches draw commands) vs naga reflection of
+/// `CULL_WGSL`'s standalone `DrawCommand` struct -- the spec S14.1
+/// indexed-indirect wire format, byte-exact.
+#[test]
+fn draw_command_struct_is_byte_exact() {
+    let src = cull_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "DrawCommand");
+    assert_eq!(size, 20, "WGSL DrawCommand size == size_of::<DrawCommand>() (spec S14.1)");
+    assert_eq!(size as usize, std::mem::size_of::<DrawCommand>());
+    assert_eq!(
+        members,
+        vec![
+            ("index_count".to_string(), 0),
+            ("instance_count".to_string(), 4),
+            ("first_index".to_string(), 8),
+            ("base_vertex".to_string(), 12),
+            ("first_instance".to_string(), 16),
+        ]
+    );
+}
+
+/// M3-b T5: host [`CullRecord`] vs naga reflection of `CULL_WGSL`'s
+/// `CullRecord` -- the combined per-command-slot output record
+/// (`wgsl::CULL_WGSL`'s module doc has the group(2) storage-budget
+/// rationale for why DrawCommand's 5 fields, `row`, and `flags` all live in
+/// ONE record type). First 5 offsets identical to `DrawCommand`'s own test
+/// above -- asserted again here directly against `CullRecord`'s OWN
+/// reflection (not inferred), so a future edit that broke that field-for-
+/// field promise would fail HERE, not just look consistent by construction.
+#[test]
+fn cull_record_struct_is_byte_exact() {
+    let src = cull_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "CullRecord");
+    assert_eq!(size, 32, "WGSL CullRecord size == size_of::<CullRecord>()");
+    assert_eq!(size as usize, std::mem::size_of::<CullRecord>());
+    assert_eq!(
+        members,
+        vec![
+            ("index_count".to_string(), 0),
+            ("instance_count".to_string(), 4),
+            ("first_index".to_string(), 8),
+            ("base_vertex".to_string(), 12),
+            ("first_instance".to_string(), 16),
+            ("row".to_string(), 20),
+            ("flags".to_string(), 24),
+            ("reserved".to_string(), 28),
+        ]
+    );
+}
+
+/// M3-b T5: host [`CullUniforms`] vs naga reflection of `CULL_WGSL`'s
+/// `CullUniforms` -- the cull pass's per-dispatch uniform block (view-proj
+/// matrix, 6 frustum planes, and the three scalar guards).
+#[test]
+fn cull_uniforms_struct_is_byte_exact() {
+    let src = cull_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "CullUniforms");
+    assert_eq!(size, 176, "WGSL CullUniforms size == size_of::<CullUniforms>()");
+    assert_eq!(size as usize, std::mem::size_of::<CullUniforms>());
+    assert_eq!(
+        members,
+        vec![
+            ("view_proj".to_string(), 0),
+            ("planes".to_string(), 64),
+            ("count".to_string(), 160),
+            ("mesh_count".to_string(), 164),
+            ("capacity".to_string(), 168),
+            ("reserved".to_string(), 172),
+        ]
+    );
+}
+
+/// M3-b T5: `CullOutput`'s header offsets (the 16-byte atomics header --
+/// `visible_count`/`stale_drops`/`oob_drops`/`frustum_drops` -- followed by
+/// `records` at offset 16). naga's `Layouter` reports the STRUCT's overall
+/// `size` as 48, not 16, for a trailing runtime array: its "minimum binding
+/// size" convention counts the fixed header PLUS exactly one array-element
+/// stride (16 + `CullRecord`'s own 32-byte stride,
+/// `cull_record_struct_is_byte_exact` above) -- not the true fixed-header
+/// size alone. Asserted here as 48 (not 16) so this test documents naga's
+/// real behavior rather than the WGSL-source-level intuition; the MEMBER
+/// OFFSETS (0/4/8/12/16) are what this test actually pins, and they are
+/// unaffected by the trailing-array size quirk.
+#[test]
+fn cull_output_header_is_byte_exact() {
+    let src = cull_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "CullOutput");
+    assert_eq!(
+        size, 48,
+        "naga Layouter size for a struct with a trailing runtime array == fixed header (16) + ONE array-element stride (32, CullRecord) -- not the header alone"
+    );
+    assert_eq!(
+        members,
+        vec![
+            ("visible_count".to_string(), 0),
+            ("stale_drops".to_string(), 4),
+            ("oob_drops".to_string(), 8),
+            ("frustum_drops".to_string(), 12),
+            ("records".to_string(), 16),
+        ]
+    );
+}
+
+/// M3-b T7: [`DRAW_WGSL`]'s struct declarations reference `SCENE_BINDINGS_
+/// WGSL`'s group(0) globals (`instances`/`instance_info`) from `vs_main`'s
+/// body -- same reason `cull_wgsl_combined` above exists, mirroring
+/// `DrawExecutor::new`'s ACTUAL `format!("{SCENE_BINDINGS_WGSL}\n{DRAW_
+/// WGSL}")` concatenation.
+fn draw_wgsl_combined() -> String {
+    format!("{SCENE_BINDINGS_WGSL}\n{DRAW_WGSL}")
+}
+
+/// M3-b T7: host [`DrawUniforms`] vs naga reflection of `DRAW_WGSL`'s
+/// `DrawUniforms` -- the draw pass's per-dispatch uniform block (just the
+/// view-proj matrix; no frustum planes or bounds, those are cull-only).
+#[test]
+fn draw_uniforms_struct_is_byte_exact() {
+    let src = draw_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "DrawUniforms");
+    assert_eq!(size, 64, "WGSL DrawUniforms size == size_of::<DrawUniforms>()");
+    assert_eq!(size as usize, std::mem::size_of::<DrawUniforms>());
+    assert_eq!(members, vec![("view_proj".to_string(), 0)]);
+}
+
+/// M3-b T7: [`DRAW_WGSL`]'s `DrawRecord` MUST stay byte-identical to
+/// `CULL_WGSL`'s `CullRecord` (`crate::wgsl::DRAW_WGSL`'s module doc has the
+/// full rationale for why this is a second, independently-declared WGSL
+/// struct rather than a reused type: `VERTEX_WRITABLE_STORAGE` is a
+/// non-default feature, so the draw pass's `@group(2)` binding must be
+/// `read`-only, which rules out reusing `CullOutput`'s atomic-bearing
+/// declaration). Asserted directly against `DrawRecord`'s OWN reflection
+/// (not inferred from `CullRecord`'s), so a future edit that broke the
+/// field-for-field promise fails HERE.
+#[test]
+fn draw_record_struct_is_byte_exact() {
+    let src = draw_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "DrawRecord");
+    assert_eq!(size, 32, "WGSL DrawRecord size == CullRecord's size (32 bytes) -- must stay byte-identical");
+    assert_eq!(size as usize, std::mem::size_of::<CullRecord>());
+    assert_eq!(
+        members,
+        vec![
+            ("index_count".to_string(), 0),
+            ("instance_count".to_string(), 4),
+            ("first_index".to_string(), 8),
+            ("base_vertex".to_string(), 12),
+            ("first_instance".to_string(), 16),
+            ("row".to_string(), 20),
+            ("flags".to_string(), 24),
+            ("reserved".to_string(), 28),
+        ]
+    );
+}
+
+/// M3-b T7: `DrawCullOutput`'s header offsets MUST stay byte-identical to
+/// `CULL_WGSL`'s `CullOutput` (same 16-byte header, same `records` offset)
+/// -- both are WGSL views of the SAME `CullOutputBuffers` buffer bytes (see
+/// `DRAW_WGSL`'s module doc). Mirrors `cull_output_header_is_byte_exact`'s
+/// own naga trailing-runtime-array size quirk (48 = 16-byte header + ONE
+/// `DrawRecord` stride, not the header alone).
+#[test]
+fn draw_cull_output_header_is_byte_exact() {
+    let src = draw_wgsl_combined();
+    let (size, members) = wgsl_struct_layout(&src, "DrawCullOutput");
+    assert_eq!(
+        size, 48,
+        "naga Layouter size for a struct with a trailing runtime array == fixed header (16) + ONE array-element stride (32, DrawRecord) -- not the header alone"
+    );
+    assert_eq!(
+        members,
+        vec![
+            ("visible_count".to_string(), 0),
+            ("stale_drops".to_string(), 4),
+            ("oob_drops".to_string(), 8),
+            ("frustum_drops".to_string(), 12),
+            ("records".to_string(), 16),
+        ]
+    );
+}

--- a/crates/helio-scenedb/tests/cull_equality.rs
+++ b/crates/helio-scenedb/tests/cull_equality.rs
@@ -1,0 +1,531 @@
+//! M3-b T6 deliverable 3: GPU-vs-CPU cull equality. `support::cpu_cull_all`
+//! (an INDEPENDENT Rust port of the design §4 β term list, written from the
+//! spec prose — see `support/mod.rs`'s module doc for why it is not a
+//! transliteration of `CULL_WGSL`) is run over the SAME token/gen/buffer
+//! state the real `CullPass` GPU dispatch consumes, across >= 3 seeded
+//! randomized fixtures mixing visible / frustum-culled / near-clip / stale
+//! / out-of-range rows. The visible ROW SETS must match exactly; on
+//! mismatch the differing rows and both sides' decisions are printed,
+//! along with the failing seed.
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms, NEAR_CLIP_FLAG};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, EngineGpuContext, FrameDriver, HarvestPipeline, HarvestStaging,
+    MaterialRegistry, MeshClass, MeshMetadata, MeshRegistry, MeshletBuffer, SceneGpuStore, View,
+    ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+use std::collections::HashSet;
+
+use support::{
+    cpu_cull_all, flatten_column_major, frustum_planes_90deg, mat3_mul, mat3_rot_x, mat3_rot_z,
+    mesh, readback, scene_cfg, test_context, translation, view_proj_90deg, CpuCullInputs,
+    CpuDecision, Rng,
+};
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum RowCategory {
+    Visible,
+    FrustumCulled,
+    NearClip,
+    Stale,
+    Oob,
+}
+
+#[allow(dead_code)] // `category` documents intent at construction time; the actual decision is re-derived by the CPU/GPU cull logic, not read back off this field
+struct RowSpec {
+    transform: [f32; 16],
+    mesh_index: u32,
+    corrupt_gen: bool,
+    category: RowCategory,
+}
+
+/// A position/mesh/optional-rotation choice safely inside the frustum at
+/// every category that reuses it (`Visible`, `Stale`, `Oob` all start from
+/// this — staleness/OOB-ness is layered on top of an otherwise-visible
+/// row, deliberately, so the equality check exercises TERM ORDER: the
+/// shader must drop these BEFORE ever reaching the frustum test).
+fn visible_like(rng: &mut Rng) -> ([f32; 16], u32) {
+    let x = rng.range_f32(-3.0, 3.0);
+    let y = rng.range_f32(-3.0, 3.0);
+    let z = rng.range_f32(-60.0, -8.0);
+    let mesh_index = if rng.chance(0.5) { 0 } else { 2 };
+    let transform = if rng.chance(0.25) {
+        let rz = rng.range_f32(-50.0, 50.0);
+        let rx = rng.range_f32(-50.0, 50.0);
+        let r = mat3_mul(mat3_rot_z(rz), mat3_rot_x(rx));
+        flatten_column_major(r, [x, y, z])
+    } else {
+        translation([x, y, z])
+    };
+    (transform, mesh_index)
+}
+
+fn gen_row(rng: &mut Rng, category: RowCategory) -> RowSpec {
+    match category {
+        RowCategory::Visible => {
+            let (transform, mesh_index) = visible_like(rng);
+            RowSpec { transform, mesh_index, corrupt_gen: false, category }
+        }
+        RowCategory::Stale => {
+            let (transform, mesh_index) = visible_like(rng);
+            RowSpec { transform, mesh_index, corrupt_gen: true, category }
+        }
+        RowCategory::Oob => {
+            let (transform, _valid_mesh_index) = visible_like(rng);
+            // mesh_count is always 3 in this fixture (see `register_
+            // meshes`) — deliberately out of range by 1..=3.
+            let mesh_index = 3 + rng.next_u32(3);
+            RowSpec { transform, mesh_index, corrupt_gen: false, category }
+        }
+        RowCategory::FrustumCulled => {
+            let sign = if rng.chance(0.5) { 1.0 } else { -1.0 };
+            let x = sign * rng.range_f32(500.0, 1500.0);
+            let y = rng.range_f32(-3.0, 3.0);
+            let z = rng.range_f32(-60.0, -8.0);
+            let mesh_index = if rng.chance(0.5) { 0 } else { 2 };
+            RowSpec { transform: translation([x, y, z]), mesh_index, corrupt_gen: false, category }
+        }
+        RowCategory::NearClip => {
+            let x = rng.range_f32(-0.3, 0.3);
+            let y = rng.range_f32(-0.3, 0.3);
+            let z = rng.range_f32(-0.6, -0.1);
+            // mesh 1 ("mesh_b") is the tall (extents.z = 2.0) mesh — its
+            // far corners always cross world z=0 (behind the camera) in
+            // this shallow z range, guaranteeing the near-clip trigger
+            // regardless of the random x/y jitter above.
+            RowSpec { transform: translation([x, y, z]), mesh_index: 1, corrupt_gen: false, category }
+        }
+    }
+}
+
+fn register_meshes(ctx: &EngineGpuContext) -> (MeshRegistry, Vec<MeshMetadata>) {
+    let mut meshes = MeshRegistry::new(ctx, 4);
+    let mesh_a = mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], 6, 0, 0);
+    let mesh_b = mesh([0.0, 0.0, 0.0], [0.5, 0.5, 2.0], 12, 6, 4);
+    let mesh_c = mesh([0.1, -0.1, 0.05], [0.8, 0.3, 0.6], 9, 18, 10);
+    assert_eq!(meshes.register(ctx.queue(), mesh_a).unwrap(), 0);
+    assert_eq!(meshes.register(ctx.queue(), mesh_b).unwrap(), 1);
+    assert_eq!(meshes.register(ctx.queue(), mesh_c).unwrap(), 2);
+    (meshes, vec![mesh_a, mesh_b, mesh_c])
+}
+
+fn parse_u32_column(bytes: &[u8], count: usize) -> Vec<u32> {
+    (0..count).map(|i| u32::from_le_bytes(bytes[i * 4..i * 4 + 4].try_into().unwrap())).collect()
+}
+
+/// Builds one randomized fixture (seeded), dispatches the real `CullPass`,
+/// runs the independent CPU reference over the identical logical input, and
+/// asserts the visible row sets (plus per-row near-clip flags and telemetry
+/// counters) match exactly. Every assertion message embeds `seed` so a
+/// failure prints it without needing a panic hook.
+fn run_equality_check(seed: u64) {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let mut rng = Rng::new(seed);
+
+    // 5 deterministic anchors (guarantee every category fires at least
+    // once, independent of the RNG stream) + 40 randomized filler rows.
+    let anchors = [
+        RowCategory::Visible,
+        RowCategory::FrustumCulled,
+        RowCategory::NearClip,
+        RowCategory::Stale,
+        RowCategory::Oob,
+    ];
+    let filler_count = 40usize;
+    let mut categories: Vec<RowCategory> = anchors.to_vec();
+    for _ in 0..filler_count {
+        let roll = rng.next_u32(100);
+        categories.push(match roll {
+            0..=34 => RowCategory::Visible,
+            35..=54 => RowCategory::FrustumCulled,
+            55..=69 => RowCategory::NearClip,
+            70..=84 => RowCategory::Stale,
+            _ => RowCategory::Oob,
+        });
+    }
+    let n = categories.len() as u32;
+
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(128).unwrap();
+
+    let mut specs: Vec<RowSpec> = Vec::with_capacity(categories.len());
+    let mut handles = Vec::with_capacity(categories.len());
+    for (i, &cat) in categories.iter().enumerate() {
+        let spec = gen_row(&mut rng, cat);
+        let t = &spec.transform;
+        let (x, y, z) = (t[12], t[13], t[14]);
+        let h = cell
+            .alloc(Aabb { min: [x - 1.0, y - 1.0, z - 1.0], max: [x + 1.0, y + 1.0, z + 1.0] })
+            .unwrap();
+        assert_eq!(
+            cell.row_of(h),
+            Some(i as u32),
+            "seed={seed}: fresh-alloc row-assignment assumption broken at row {i} — the equality \
+             test relies on sequential row assignment for a churn-free cell"
+        );
+        handles.push(h);
+        specs.push(spec);
+    }
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "seed={seed}: single cell, class-0 region base 0");
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (i, h) in handles.iter().enumerate() {
+        assert!(store.write_transform(id, cell.storage_mut(), *h, &specs[i].transform, &sim));
+        assert!(store.write_instance_info(
+            id,
+            cell.storage_mut(),
+            *h,
+            InstanceInfo { mesh_index: specs[i].mesh_index, flags: 0 },
+            &sim
+        ));
+    }
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    // Gigantic view — this is a pure CPU-side broad-phase query, unrelated
+    // to the GPU frustum under test, so it must catch even the
+    // deliberately-far-away FrustumCulled rows (x up to +-1500).
+    let view = View::Aabb(Aabb { min: [-5000.0, -5000.0, -5000.0], max: [5000.0, 5000.0, 5000.0] });
+    let harvested = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(harvested, n, "seed={seed}: broad harvest view must catch every row");
+    assert_eq!(staging.traditional, (0..n).collect::<Vec<_>>(), "seed={seed}: plain-path 100%-hit harvest preserves row order (base=0)");
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    // Corrupt the Stale rows' expected-gen snapshot directly — every live
+    // row's REAL generation is 1 (fresh alloc, no churn anywhere in this
+    // fixture), so any value != 1 is a guaranteed, deliberate mismatch.
+    // This tests the CULL SHADER's stale-vs-live comparison in isolation
+    // (Test 2, tests/cull_stale_and_oob.rs, is what proves harvest's OWN
+    // gens column is correct under real free/boundary churn).
+    for (i, spec) in specs.iter().enumerate() {
+        if spec.corrupt_gen {
+            staging.traditional_gens[i] = 2;
+        }
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "cull-equality-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), n);
+
+    let (meshes, mesh_table) = register_meshes(&ctx);
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "cull-equality-output", n + 8);
+    output.clear_counters(ctx.queue());
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(ctx.queue(), &uniforms);
+
+    let mut encoder = device.create_command_encoder(&Default::default());
+    cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+    ctx.queue().submit([encoder.finish()]);
+
+    // -- Read back real GPU state for the CPU reference's slot_mirror /
+    // generations inputs (rather than assuming — this is real SSBO
+    // content, post-boundary). --
+    let gen_buf = store.generation_buffer();
+    let slot_buf = store.slot_mirror_buffer();
+    let gen_bytes = readback(&ctx, gen_buf, gen_buf.size());
+    let slot_bytes = readback(&ctx, slot_buf, slot_buf.size());
+    let generations = parse_u32_column(&gen_bytes, (gen_buf.size() / 4) as usize);
+    let slot_mirror = parse_u32_column(&slot_bytes, (slot_buf.size() / 4) as usize);
+
+    let tokens: Vec<u32> = staging.traditional.clone();
+    let expected_gens: Vec<u32> = staging.traditional_gens.clone();
+    let instances: Vec<[f32; 16]> = specs.iter().map(|s| s.transform).collect();
+    let instance_info: Vec<InstanceInfo> = specs.iter().map(|s| InstanceInfo { mesh_index: s.mesh_index, flags: 0 }).collect();
+
+    let inputs = CpuCullInputs {
+        tokens: &tokens,
+        expected_gens: &expected_gens,
+        slot_mirror: &slot_mirror,
+        generations: &generations,
+        instance_info: &instance_info,
+        instances: &instances,
+        mesh_table: &mesh_table,
+        mesh_count: meshes.len(),
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+    };
+    let cpu_results = cpu_cull_all(&inputs);
+
+    // -- House-law guard: every category this fixture is DESIGNED to
+    // exercise must have actually fired, per the CPU reference's OWN tally
+    // (not a hand-prediction of which random row lands where). --
+    let cpu_stale = cpu_results.iter().filter(|(_, d)| *d == CpuDecision::Stale).count();
+    let cpu_oob = cpu_results.iter().filter(|(_, d)| *d == CpuDecision::Oob).count();
+    let cpu_frustum = cpu_results.iter().filter(|(_, d)| *d == CpuDecision::FrustumCulled).count();
+    let cpu_near_clip = cpu_results.iter().filter(|(_, d)| matches!(d, CpuDecision::Visible { near_clip: true })).count();
+    let cpu_visible_total = cpu_results.iter().filter(|(_, d)| matches!(d, CpuDecision::Visible { .. })).count();
+    assert!(cpu_stale > 0, "seed={seed}: guard — fixture must produce >=1 Stale row");
+    assert!(cpu_oob > 0, "seed={seed}: guard — fixture must produce >=1 Oob row");
+    assert!(cpu_frustum > 0, "seed={seed}: guard — fixture must produce >=1 FrustumCulled row");
+    assert!(cpu_near_clip > 0, "seed={seed}: guard — fixture must produce >=1 near-clip Visible row");
+    assert!(cpu_visible_total > cpu_near_clip, "seed={seed}: guard — fixture must produce >=1 normal (non-near-clip) Visible row");
+
+    // -- GPU readback. --
+    let out_bytes = readback(&ctx, output.buffer(), output.byte_size());
+    let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+    let gpu_visible_count = u32_at(0);
+    let gpu_stale = u32_at(4);
+    let gpu_oob = u32_at(8);
+    let gpu_frustum = u32_at(12);
+    assert!(gpu_visible_count <= output.capacity(), "seed={seed}: fixture must not overflow the output capacity (would need Test 5's clamp, out of scope here)");
+
+    struct GpuRecord {
+        index_count: u32,
+        first_index: u32,
+        base_vertex: i32,
+        near_clip: bool,
+    }
+    let mut gpu_by_row: std::collections::HashMap<u32, GpuRecord> = std::collections::HashMap::new();
+    for slot in 0..gpu_visible_count {
+        let off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+        let index_count = u32_at(off);
+        let first_index = u32_at(off + 8);
+        let base_vertex = i32::from_le_bytes(out_bytes[off + 12..off + 16].try_into().unwrap());
+        let row = u32_at(off + 20);
+        let flags = u32_at(off + 24);
+        gpu_by_row.insert(row, GpuRecord { index_count, first_index, base_vertex, near_clip: flags & NEAR_CLIP_FLAG != 0 });
+    }
+
+    // -- Counter equality. --
+    assert_eq!(gpu_stale, cpu_stale as u32, "seed={seed}: stale_drops mismatch (GPU {gpu_stale} vs CPU {cpu_stale})");
+    assert_eq!(gpu_oob, cpu_oob as u32, "seed={seed}: oob_drops mismatch (GPU {gpu_oob} vs CPU {cpu_oob})");
+    assert_eq!(gpu_frustum, cpu_frustum as u32, "seed={seed}: frustum_drops mismatch (GPU {gpu_frustum} vs CPU {cpu_frustum})");
+    assert_eq!(gpu_visible_count, cpu_visible_total as u32, "seed={seed}: visible_count mismatch (GPU {gpu_visible_count} vs CPU {cpu_visible_total})");
+
+    // -- THE equality assertion: visible row SETS must match exactly.
+    // Order is NOT compared (see command_slot_order_is_empirically_stable_
+    // within_one_dispatch below for the determinism finding this is based
+    // on — command-slot allocation is a GPU atomic, not contractually
+    // ordered, so this test compares as sets on principle regardless of
+    // what was empirically observed on this run's hardware). --
+    let cpu_visible_rows: HashSet<u32> = cpu_results
+        .iter()
+        .filter_map(|(row, d)| if matches!(d, CpuDecision::Visible { .. }) { Some(*row) } else { None })
+        .collect();
+    let gpu_visible_rows: HashSet<u32> = gpu_by_row.keys().copied().collect();
+
+    if cpu_visible_rows != gpu_visible_rows {
+        let only_cpu: Vec<u32> = cpu_visible_rows.difference(&gpu_visible_rows).copied().collect();
+        let only_gpu: Vec<u32> = gpu_visible_rows.difference(&cpu_visible_rows).copied().collect();
+        let cpu_decision_of = |row: u32| cpu_results.iter().find(|(r, _)| *r == row).map(|(_, d)| *d);
+        eprintln!("seed={seed}: VISIBLE SET MISMATCH");
+        for row in &only_cpu {
+            eprintln!("  row {row}: CPU says {:?}, GPU has NO command", cpu_decision_of(*row));
+        }
+        for row in &only_gpu {
+            eprintln!("  row {row}: GPU emitted a command, CPU says {:?}", cpu_decision_of(*row));
+        }
+        panic!("seed={seed}: visible row sets differ — {} CPU-only, {} GPU-only (see stderr for the row list)", only_cpu.len(), only_gpu.len());
+    }
+
+    // -- Per-row cross-checks over the agreed-upon visible set: near-clip
+    // flag parity + DrawCommand fields resolved from the SAME mesh table. --
+    for (row, decision) in &cpu_results {
+        let CpuDecision::Visible { near_clip: cpu_near } = decision else { continue };
+        let gpu_rec = &gpu_by_row[row];
+        assert_eq!(
+            gpu_rec.near_clip, *cpu_near,
+            "seed={seed}: row {row} near-clip flag mismatch (CPU {cpu_near} vs GPU {})",
+            gpu_rec.near_clip
+        );
+        let mesh_index = instance_info[*row as usize].mesh_index;
+        let expected_mesh = &mesh_table[mesh_index as usize];
+        assert_eq!(gpu_rec.index_count, expected_mesh.index_count, "seed={seed}: row {row} index_count mismatch");
+        assert_eq!(gpu_rec.first_index, expected_mesh.index_offset, "seed={seed}: row {row} first_index mismatch");
+        assert_eq!(gpu_rec.base_vertex, expected_mesh.base_vertex, "seed={seed}: row {row} base_vertex mismatch");
+    }
+}
+
+/// M3-b T6 deliverable 3: >= 3 seeded randomized fixtures. Seeds are
+/// arbitrary fixed constants (not re-rolled per run) so a failure is
+/// reproducible from the printed seed alone without needing to capture
+/// process-random state.
+#[test]
+fn gpu_vs_cpu_cull_equality_matches_across_randomized_seeds() {
+    for seed in [0xC0FFEE_u64, 0xDEAD_BEEF_u64, 0x1234_5678_9ABC_DEF0_u64] {
+        run_equality_check(seed);
+    }
+}
+
+/// M3-b T6 deliverable 3's explicit instruction: "check whether the
+/// atomic-alloc makes order nondeterministic ... document that." Builds
+/// ONE fixture, dispatches `CullPass` TWICE against fresh output buffers
+/// with IDENTICAL input, and compares the row->slot assignment between the
+/// two runs. This is an empirical probe on the actual adapter/driver this
+/// suite runs on, not a portability claim — `run_equality_check` above
+/// compares visible sets, never slot order, regardless of what this test
+/// finds.
+#[test]
+fn command_slot_order_determinism_probe() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let mut rng = Rng::new(0x5EED_5EED);
+
+    let categories: Vec<RowCategory> = (0..64)
+        .map(|_| match rng.next_u32(100) {
+            0..=59 => RowCategory::Visible,
+            60..=79 => RowCategory::FrustumCulled,
+            _ => RowCategory::NearClip,
+        })
+        .collect();
+    let n = categories.len() as u32;
+
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(128).unwrap();
+    let mut specs = Vec::new();
+    for cat in &categories {
+        specs.push(gen_row(&mut rng, *cat));
+    }
+    let mut handles = Vec::with_capacity(specs.len());
+    for (i, spec) in specs.iter().enumerate() {
+        let t = &spec.transform;
+        let h = cell
+            .alloc(Aabb {
+                min: [t[12] - 1.0, t[13] - 1.0, t[14] - 1.0],
+                max: [t[12] + 1.0, t[13] + 1.0, t[14] + 1.0],
+            })
+            .unwrap();
+        assert_eq!(cell.row_of(h), Some(i as u32), "fresh-alloc row-assignment assumption broken at row {i}");
+        handles.push(h);
+    }
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (h, spec) in handles.iter().zip(specs.iter()) {
+        assert!(store.write_transform(id, cell.storage_mut(), *h, &spec.transform, &sim));
+        assert!(store.write_instance_info(id, cell.storage_mut(), *h, InstanceInfo { mesh_index: spec.mesh_index, flags: 0 }, &sim));
+    }
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-5000.0, -5000.0, -5000.0], max: [5000.0, 5000.0, 5000.0] });
+    let harvested = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(harvested, n);
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "determinism-probe-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+
+    let (meshes, _mesh_table) = register_meshes(&ctx);
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: view_tokens.count() + 8,
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(ctx.queue(), &uniforms);
+
+    let dispatch_once = || -> Vec<(u32, u32)> {
+        let output = CullOutputBuffers::new(device, "determinism-probe-output", view_tokens.count() + 8);
+        output.clear_counters(ctx.queue());
+        let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+        ctx.queue().submit([encoder.finish()]);
+        let out_bytes = readback(&ctx, output.buffer(), output.byte_size());
+        let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+        let visible_count = u32_at(0);
+        (0..visible_count.min(output.capacity()))
+            .map(|slot| {
+                let off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+                (slot, u32_at(off + 20)) // (slot, row)
+            })
+            .collect()
+    };
+
+    let run_a = dispatch_once();
+    let run_b = dispatch_once();
+
+    let order_identical = run_a == run_b;
+    // RESOLVED (M3-b T6 review follow-up): slot assignment is genuinely
+    // NONDETERMINISTIC on this adapter — back-to-back dispatches of a
+    // byte-identical input hand out different slot ranges, because the
+    // §14.2 bounded `atomicAdd` hands slots out in workgroup-completion
+    // order and that order is a scheduling detail, not a guarantee. An
+    // earlier revision of this probe ASSERTED order stability on the
+    // strength of a lucky observation; that assert was flaky by
+    // construction and has been removed. What is asserted below is what
+    // the contract actually promises.
+    println!(
+        "[cull order probe] slot assignment {} between two identical dispatches \
+         (informational — order is NOT a contract; §14.2 promises only a valid bijection)",
+        if order_identical { "was stable" } else { "DIFFERED" }
+    );
+
+    // The real invariants, order notwithstanding: both runs must emit the
+    // same SET of rows, and each run's slots must be a duplicate-free
+    // allocation within capacity (an atomic that handed the same slot to
+    // two threads, or a slot past capacity, would corrupt the command
+    // buffer — that IS a contract, and it is what this probe now pins).
+    let rows_of = |run: &Vec<(u32, u32)>| {
+        let mut v: Vec<u32> = run.iter().map(|&(_, row)| row).collect();
+        v.sort_unstable();
+        v
+    };
+    assert_eq!(
+        rows_of(&run_a),
+        rows_of(&run_b),
+        "the same input must yield the same visible ROW set regardless of slot order"
+    );
+    for (label, run) in [("a", &run_a), ("b", &run_b)] {
+        let mut slots: Vec<u32> = run.iter().map(|&(slot, _)| slot).collect();
+        slots.sort_unstable();
+        let before = slots.len();
+        slots.dedup();
+        assert_eq!(before, slots.len(), "run {label}: a command slot was allocated twice");
+        // Same capacity the closure above constructs its output with.
+        let capacity = view_tokens.count() + 8;
+        assert!(
+            slots.iter().all(|&s| s < capacity),
+            "run {label}: a command slot landed outside the capacity bound ({capacity})"
+        );
+    }
+}

--- a/crates/helio-scenedb/tests/cull_pass.rs
+++ b/crates/helio-scenedb/tests/cull_pass.rs
@@ -1,0 +1,304 @@
+//! `CullPass` end-to-end proof (M3-b T5, design S4): build a real scene
+//! through SceneDB's public write/harvest API (mirrors `seam_smoke.rs`'s
+//! `test_context`/boundary-driving pattern and `gpu_harvest.rs`'s harvest
+//! pattern), upload the harvested tokens via `ViewTokenBuffers` (M3-b T1),
+//! dispatch `CullPass`, and read back the command buffer + visible ids +
+//! telemetry counters. Every expected value below is HAND-COMPUTED from the
+//! fixture's own geometry, not re-derived by re-running the shader's logic
+//! in Rust (that CPU-reference equality check is M3-b T6's job,
+//! `tests/cull_equality.rs`).
+//!
+//! ## The fixture (house law: self-verifying guards -- every category
+//! non-empty before trusting the aggregate assertion)
+//!
+//! Camera at the world origin, looking down -Z, with an identity view
+//! matrix (world space IS view space here) and a symmetric fovy=90/aspect=1
+//! perspective projection (near=1, far=100 -- `support::view_proj_90deg`).
+//! Four instances, one cell, fresh allocations (slot == row == index,
+//! generation 1 for all -- no stale/oob category exercised here, that is
+//! Task 6's dedicated `tests/cull_stale_and_oob.rs`).
+//!
+//! | row | translation      | mesh (local extents)     | category      |
+//! |-----|-------------------|---------------------------|---------------|
+//! | 0   | (0, 0, -10)       | mesh0, (0.5,0.5,0.5)      | VISIBLE       |
+//! | 1   | (100, 0, -10)     | mesh0, (0.5,0.5,0.5)      | FRUSTUM-CULLED|
+//! | 2   | (0, 0, -0.5)      | mesh1, (0.5,0.5,2.0)      | NEAR-CLIP     |
+//! | 3   | rotated, see below | mesh2, (0.5,0.5,2.0)     | VISIBLE (rotation regression pin, M3-b T6 fold-in) |
+//!
+//! Row 0's box (world z in [-10.5,-9.5], all W = -z_view in [9.5,10.5] > 0,
+//! well inside the fovy=90 side planes at that depth) is unambiguously
+//! visible with no near-clip. Row 1 is the identical box translated far off
+//! to the side (x=100 at z=-10; the fovy=90 side plane only admits |x| <=
+//! 10 at that depth) -- entirely outside the right frustum plane, cannot
+//! trigger near-clip (same z range as row 0). Row 2's box is deliberately
+//! LARGE in z (extents.z=2.0) and centered just in front of the camera
+//! (translation z=-0.5), so its far corners reach world z=+1.5 -- BEHIND
+//! the camera eye (z_view >= 0), giving W = -z_view <= 0 on those corners,
+//! which per spec S12 bypasses culling entirely (marked visible
+//! unconditionally, near-clip flag set) rather than being frustum-tested.
+//!
+//! ## Row 3 -- the rotation regression pin (M3-b T6 fold-in, T5 review)
+//!
+//! `page.rs`'s `Pod for [f32; 16]` doc comment pins the instance-transform
+//! flattening convention as COLUMN-MAJOR (`array[4*col+row] = M[row][col]`,
+//! i.e. `to_cols_array()`, no transpose) and records the exact landmine a
+//! transposed (naively "row-major") reading produces: `|M_3x3|` computed
+//! from `R^T` instead of `R` silently changes the world-space AABB extents
+//! for ANY non-symmetric rotation matrix, with NO scale needed to trigger
+//! it (element-wise `abs` does not commute with transpose unless the matrix
+//! is symmetric). Every fixture row above this one uses either a pure
+//! translation (rotation-free, transpose-invariant in this flat layout) or
+//! never exercised in a way that discriminates. Row 3 closes that gap: a
+//! genuine two-axis rotation `Rz(30 deg) * Rx(40 deg)` (matrix product,
+//! applied to a column vector as `Rz * (Rx * v)`), positioned at the exact
+//! `x` translation where the CORRECTLY-read world AABB is (barely) inside
+//! the right frustum plane and the WRONGLY-transposed-read world AABB is
+//! (barely) outside it -- see the self-verifying guard below, which
+//! computes both extents independently (via `support::mat3_abs_mul_vec3`
+//! on `R` and on `R^T`) and asserts they straddle the frustum's visibility
+//! threshold with a real margin BEFORE trusting the main dispatch assertion
+//! that row 3 is visible. If `abs_mat3`/the buffer's column-major reading
+//! ever regresses to a transposed interpretation, row 3 flips to
+//! frustum-culled and `by_row.get(&3)` panics.
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms, NEAR_CLIP_FLAG};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, FrameDriver, HarvestPipeline, HarvestStaging, MaterialRegistry,
+    MeshClass, MeshRegistry, MeshletBuffer, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+use std::collections::HashMap;
+
+use support::{
+    frustum_planes_90deg, mat3_abs_mul_vec3, mat3_mul, mat3_rot_x, mat3_rot_z, mat3_transpose,
+    mesh, readback, scene_cfg, test_context, translation, view_proj_90deg, flatten_column_major,
+};
+
+#[test]
+fn cull_pass_produces_exact_hand_computed_visible_set() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+
+    // --- Build the scene: one cell, 4 fresh instances (rows 0..3, slot ==
+    // row, generation 1 for all — no stale/oob category in this fixture,
+    // that lives in tests/cull_stale_and_oob.rs). ---
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+    // Harvest (broad-phase) AABBs: generous unit boxes around each
+    // translation so ONE big harvest query AABB catches all four — the
+    // cull SHADER computes its own precise world AABB from mesh_meta +
+    // transform independently (S11), this is only the CPU-side coarse
+    // query bound.
+    let h0 = cell.alloc(Aabb { min: [-1.0, -1.0, -11.0], max: [1.0, 1.0, -9.0] }).unwrap();
+    let h1 = cell.alloc(Aabb { min: [99.0, -1.0, -11.0], max: [101.0, 1.0, -9.0] }).unwrap();
+    let h2 = cell.alloc(Aabb { min: [-1.0, -1.0, -1.5], max: [1.0, 1.0, 0.5] }).unwrap();
+
+    // --- Row 3's rotation regression pin: Rz(30deg) * Rx(40deg), local
+    // extents (0.5, 0.5, 2.0) (same shape as mesh1, row 2), local center
+    // at the origin (so world_center == the translation, no extra offset
+    // math needed). The self-verifying guard below independently computes
+    // BOTH the correct (R) and the transposed-bug (R^T) world extents and
+    // derives the x-translation that straddles the right frustum plane's
+    // visibility threshold for exactly this rotation/extents pair — this
+    // is NOT a hand-copied magic number, it is computed fresh at test time
+    // from `support`'s matrix helpers, independently of `abs_mat3` in
+    // CULL_WGSL. ---
+    let rz30 = mat3_rot_z(30.0);
+    let rx40 = mat3_rot_x(40.0);
+    let r3 = mat3_mul(rz30, rx40); // Rz * Rx, applied to a column vector as Rz*(Rx*v)
+    let r3_wrong = mat3_transpose(r3);
+    let row3_local_extents = [0.5_f32, 0.5, 2.0];
+    let correct_extents = mat3_abs_mul_vec3(r3, row3_local_extents);
+    let wrong_extents = mat3_abs_mul_vec3(r3_wrong, row3_local_extents);
+    // Right frustum plane: normal (-1, 0, -1), w=0 (`frustum_planes_90deg`
+    // index 1) -- r = extents.x + extents.z (|nx|=|nz|=1, |ny|=0, so
+    // extents.y never enters this particular plane's test, which is why
+    // this specific plane cleanly isolates the x/z components of the
+    // transpose bug for this rotation). Visible requires
+    // `x_c + z_c <= r` (derived from `d = -x_c - z_c >= -r`).
+    let row3_z = -10.0_f32;
+    let thresh_correct = (correct_extents[0] + correct_extents[2]) - row3_z; // r_correct + 10
+    let thresh_wrong = (wrong_extents[0] + wrong_extents[2]) - row3_z; // r_wrong + 10
+    // Self-verifying guard (house law): the two thresholds must be
+    // meaningfully separated (not coincidentally equal) BEFORE trusting a
+    // midpoint x_c to discriminate between them — a future change to the
+    // rotation/extents pair that collapsed this gap would silently turn
+    // row 3 into a non-discriminating fixture.
+    assert!(
+        (thresh_correct - thresh_wrong).abs() > 0.05,
+        "guard: the correct-vs-transposed visibility thresholds must differ by a real margin \
+         (correct={thresh_correct}, wrong={thresh_wrong}) — otherwise row 3 cannot pin the \
+         row/col-major landmine"
+    );
+    let row3_x = (thresh_correct + thresh_wrong) / 2.0;
+    assert!(
+        row3_x < thresh_correct && row3_x > thresh_wrong,
+        "guard: chosen x_c ({row3_x}) must sit strictly between the wrong threshold \
+         ({thresh_wrong}, would already cull) and the correct one ({thresh_correct}, still visible) \
+         — i.e. this fixture instance IS visible under the pinned column-major convention and \
+         WOULD be frustum-culled under a transposed (row-major) reading"
+    );
+    let row3_transform = flatten_column_major(r3, [row3_x, 0.0, row3_z]);
+    let h3 = cell
+        .alloc(Aabb {
+            min: [row3_x - 2.0, -2.0, row3_z - 2.0],
+            max: [row3_x + 2.0, 2.0, row3_z + 2.0],
+        })
+        .unwrap();
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0 — rows below are global rows verbatim");
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    assert!(store.write_transform(id, cell.storage_mut(), h0, &translation([0.0, 0.0, -10.0]), &sim));
+    assert!(store.write_transform(id, cell.storage_mut(), h1, &translation([100.0, 0.0, -10.0]), &sim));
+    assert!(store.write_transform(id, cell.storage_mut(), h2, &translation([0.0, 0.0, -0.5]), &sim));
+    assert!(store.write_transform(id, cell.storage_mut(), h3, &row3_transform, &sim));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h0, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h1, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h2, InstanceInfo { mesh_index: 1, flags: 0 }, &sim));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h3, InstanceInfo { mesh_index: 2, flags: 0 }, &sim));
+
+    // --- Harvest: one big AABB view over the whole cell (S3.1's expected-
+    // generation column comes along for free — HarvestPipeline::harvest_cell
+    // always emits it positionally aligned with the token). ---
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-200.0, -200.0, -200.0], max: [200.0, 200.0, 200.0] });
+    let n = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(n, 4, "sanity: the broad harvest view catches all four rows");
+    assert_eq!(staging.traditional.len(), 4);
+
+    // --- Boundary: retire/compact/sync pushes the transform/instance_info
+    // writes above onto the GPU buffers the cull shader will read. ---
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    // --- Per-view token upload (M3-b T1). ---
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "cull-pass-test-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), 4);
+
+    // --- Asset-side stores SceneDbBinding also binds (mesh registry carries
+    // the three real meshes this fixture's hand-computed expectations use;
+    // cluster/meshlet/material registries are unused by cull, empty is
+    // fine — mirrors seam_smoke.rs). ---
+    let mut meshes = MeshRegistry::new(&ctx, 4);
+    let mesh0 = meshes.register(ctx.queue(), mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], 6, 0, 0)).unwrap();
+    let mesh1 = meshes.register(ctx.queue(), mesh([0.0, 0.0, 0.0], [0.5, 0.5, 2.0], 12, 6, 4)).unwrap();
+    let mesh2 = meshes.register(ctx.queue(), mesh([0.0, 0.0, 0.0], row3_local_extents, 18, 18, 8)).unwrap();
+    assert_eq!((mesh0, mesh1, mesh2), (0, 1, 2), "sanity: mesh_index values the fixture's InstanceInfo rows used above");
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+
+    // --- The cull pass itself. ---
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "cull-pass-test-output", 8);
+    output.clear_counters(ctx.queue());
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(ctx.queue(), &uniforms);
+
+    let mut encoder = device.create_command_encoder(&Default::default());
+    cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+    ctx.queue().submit([encoder.finish()]);
+
+    // --- Readback: 16-byte counters header + up to `capacity` 32-byte
+    // records. ---
+    let out_bytes = readback(&ctx, output.buffer(), output.byte_size());
+    let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+    let i32_at = |off: usize| i32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+
+    let visible_count = u32_at(0);
+    let stale_drops = u32_at(4);
+    let oob_drops = u32_at(8);
+    let frustum_drops = u32_at(12);
+
+    // --- Self-verifying fixture guards (house law): every category the
+    // fixture is DESIGNED to exercise must be non-empty before the main
+    // assertion is trusted, and every category it deliberately does NOT
+    // exercise (stale/oob — tests/cull_stale_and_oob.rs's job) must read
+    // exactly zero. ---
+    assert_eq!(stale_drops, 0, "fixture has no stale-generation row (tests/cull_stale_and_oob.rs's job)");
+    assert_eq!(oob_drops, 0, "fixture has no out-of-range mesh_index row (tests/cull_stale_and_oob.rs's job)");
+    assert_eq!(frustum_drops, 1, "guard: exactly one frustum-culled row (row 1) — must be non-zero");
+    assert_eq!(visible_count, 3, "guard: exactly three visible rows (row 0 + row 2 near-clip + row 3 rotation) — must be non-zero");
+
+    // --- Parse the `visible_count` (== 3, within `capacity` == 8, so all
+    // slots were written) records, keyed by `row` — command-slot ORDER
+    // between concurrently-executing GPU threads is not guaranteed, so this
+    // assertion is written to be robust to any row landing in any slot,
+    // while still being fully hand-computed per row. ---
+    let mut by_row: HashMap<u32, (u32, u32, u32, i32, u32, u32)> = HashMap::new(); // row -> (index_count, instance_count, first_index, base_vertex, first_instance, flags)
+    for slot in 0..visible_count.min(output.capacity()) {
+        let base_off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+        let index_count = u32_at(base_off);
+        let instance_count = u32_at(base_off + 4);
+        let first_index = u32_at(base_off + 8);
+        let base_vertex = i32_at(base_off + 12);
+        let first_instance = u32_at(base_off + 16);
+        let row = u32_at(base_off + 20);
+        let flags = u32_at(base_off + 24);
+        assert_eq!(first_instance, slot, "S14.1: first_instance == command slot (C5)");
+        assert_eq!(instance_count, 1, "S14.1: instance_count always 1 — no instance merging");
+        by_row.insert(row, (index_count, instance_count, first_index, base_vertex, first_instance, flags));
+    }
+    assert_eq!(by_row.len(), 3, "three distinct rows, no duplicate/lost slot");
+
+    // Row 0 (VISIBLE, mesh0, no near-clip): hand-computed from mesh0's
+    // registered fields (index_count=6, index_offset=0, base_vertex=0).
+    let row0 = by_row.get(&0).expect("row 0 (VISIBLE) must have a command");
+    assert_eq!(row0.0, 6, "row 0 index_count == mesh0.index_count");
+    assert_eq!(row0.2, 0, "row 0 first_index == mesh0.index_offset");
+    assert_eq!(row0.3, 0, "row 0 base_vertex == mesh0.base_vertex");
+    assert_eq!(row0.5 & NEAR_CLIP_FLAG, 0, "row 0 is NOT near-clip — flag bit 0 clear");
+
+    // Row 2 (NEAR-CLIP bypass, mesh1): hand-computed from mesh1's registered
+    // fields (index_count=12, index_offset=6, base_vertex=4).
+    let row2 = by_row.get(&2).expect("row 2 (NEAR-CLIP) must have a command");
+    assert_eq!(row2.0, 12, "row 2 index_count == mesh1.index_count");
+    assert_eq!(row2.2, 6, "row 2 first_index == mesh1.index_offset");
+    assert_eq!(row2.3, 4, "row 2 base_vertex == mesh1.base_vertex");
+    assert_eq!(row2.5 & NEAR_CLIP_FLAG, NEAR_CLIP_FLAG, "row 2 near-clip flag bit 0 MUST be set — its far corners are behind the camera (W<=0)");
+
+    // Row 3 (VISIBLE, mesh2, the rotation regression pin): hand-computed
+    // from mesh2's registered fields (index_count=18, index_offset=18,
+    // base_vertex=8). THE assertion that matters most here is simply that
+    // this entry EXISTS — under a transposed-matrix read, row 3 would be
+    // frustum-culled instead (see the guard above), and `by_row.get(&3)`
+    // would panic.
+    let row3 = by_row.get(&3).expect(
+        "row 3 (rotation regression pin) must have a command — if this fails, the buffer's \
+         instance-transform column is being read transposed (row-major) instead of the pinned \
+         column-major convention (page.rs's Pod for [f32; 16] doc comment)",
+    );
+    assert_eq!(row3.0, 18, "row 3 index_count == mesh2.index_count");
+    assert_eq!(row3.2, 18, "row 3 first_index == mesh2.index_offset");
+    assert_eq!(row3.3, 8, "row 3 base_vertex == mesh2.base_vertex");
+    assert_eq!(row3.5 & NEAR_CLIP_FLAG, 0, "row 3 is NOT near-clip — flag bit 0 clear (z=-10, well clear of the camera)");
+
+    // Row 1 (FRUSTUM-CULLED) must have no command at all.
+    assert!(!by_row.contains_key(&1), "row 1 was frustum-culled — no command, no visible id");
+}

--- a/crates/helio-scenedb/tests/cull_stale_and_oob.rs
+++ b/crates/helio-scenedb/tests/cull_stale_and_oob.rs
@@ -1,0 +1,358 @@
+//! M3-b T6: Test 2 (stale-token drop, design §3.1/§20.2/C6) + the
+//! mesh_index out-of-range twin (closing the coverage gap the M3-b T5
+//! review found — T5's own suite never disables the bounds check and
+//! notice, since it never injects an out-of-range `mesh_index`).
+//!
+//! Both tests build a real scene through SceneDB's public write/harvest
+//! API (same headless pattern as `cull_pass.rs`/`gpu_harvest.rs`), upload
+//! via `ViewTokenBuffers`, dispatch the real `CullPass`, and read back the
+//! telemetry counters + command records — never re-deriving expectations
+//! by re-running the shader's own logic (that is `cull_equality.rs`'s job).
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, FrameDriver, HarvestPipeline, HarvestStaging, MaterialRegistry,
+    MeshClass, MeshRegistry, MeshletBuffer, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, Handle, InstanceInfo, Scratchpad, SpatialCell};
+use std::collections::{HashMap, HashSet};
+
+use support::{frustum_planes_90deg, mesh, readback, scene_cfg, test_context, translation, view_proj_90deg};
+
+type DrawRecord = (u32, u32, i32, u32);
+type CullReadback = (u32, u32, u32, u32, HashMap<u32, DrawRecord>);
+
+fn box_at(x: f32) -> Aabb {
+    Aabb { min: [x - 0.5, -0.5, -10.5], max: [x + 0.5, 0.5, -9.5] }
+}
+
+/// Reads back `CullOutputBuffers`' 16-byte atomics header + up to
+/// `capacity` 32-byte records, returning `(visible_count, stale_drops,
+/// oob_drops, frustum_drops, by_row)` — `by_row` maps `row ->
+/// (index_count, first_index, base_vertex, first_instance)`, the same
+/// shape `cull_pass.rs` parses, factored out here since both tests below
+/// need it.
+fn read_cull_output(
+    ctx: &pulsar_scenedb::gpu::EngineGpuContext,
+    output: &CullOutputBuffers,
+) -> CullReadback {
+    let out_bytes = readback(ctx, output.buffer(), output.byte_size());
+    let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+    let i32_at = |off: usize| i32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+
+    let visible_count = u32_at(0);
+    let stale_drops = u32_at(4);
+    let oob_drops = u32_at(8);
+    let frustum_drops = u32_at(12);
+
+    let mut by_row = HashMap::new();
+    for slot in 0..visible_count.min(output.capacity()) {
+        let base_off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+        let index_count = u32_at(base_off);
+        let first_index = u32_at(base_off + 8);
+        let base_vertex = i32_at(base_off + 12);
+        let first_instance = u32_at(base_off + 16);
+        let row = u32_at(base_off + 20);
+        assert_eq!(first_instance, slot, "S14.1: first_instance == command slot (C5)");
+        by_row.insert(row, (index_count, first_index, base_vertex, first_instance));
+    }
+    (visible_count, stale_drops, oob_drops, frustum_drops, by_row)
+}
+
+/// Test 2 (design §3.1/§20.2/C6): a harvested run's `expected_gens`
+/// snapshot goes stale the moment its row's occupant is freed and a
+/// boundary bumps that slot's live generation — WITHOUT re-harvesting, the
+/// cull shader must drop exactly the stale rows, increment `stale_drops`
+/// by exactly that count, and leave every OTHER row's command untouched.
+///
+/// ## Fixture shape (M3-α T8 house law: gen-diverse KEPT set + a
+/// self-verifying non-uniformity guard, PLUS two dedicated victim rows)
+///
+/// Six live rows, one cell: a KEPT set of four (`h0`, `h2`, `h3`, `h1b`)
+/// built via the T8 free+compact+realloc churn recipe (frees `h1`,
+/// compacts — the then-last live row swaps into `h1`'s slot, permanently
+/// breaking row/slot identity — then reallocs `h1b` at the new tail,
+/// recycling the freed slot at generation 2) so the kept set genuinely
+/// carries non-uniform generations (guarded below, non-vacuously); and two
+/// VICTIM rows (`hv1`, `hv2`) allocated LAST, after the churn, so freeing
+/// them later requires no compaction swap into the kept set's rows — a
+/// self-verifying guard re-checks every kept handle's row is UNCHANGED
+/// across the second boundary, so this test does not silently mis-assert
+/// if that assumption ever stops holding.
+#[test]
+fn test2_stale_token_drop_leaves_only_the_injected_rows_dropped() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+
+    // -- Kept-set churn (T8 recipe): h0, h1(freed), h2, h3 allocated, h1
+    // freed + compacted, h1b reallocated at the new tail. --
+    let h0 = cell.alloc(box_at(0.0)).unwrap();
+    let h1 = cell.alloc(box_at(1.5)).unwrap();
+    let h2 = cell.alloc(box_at(3.0)).unwrap();
+    let h3 = cell.alloc(box_at(4.5)).unwrap();
+    cell.free(h1);
+    cell.compact();
+    let h1b = cell.alloc(box_at(6.0)).unwrap();
+    let kept: Vec<(Handle, f32)> = vec![(h0, 0.0), (h2, 3.0), (h3, 4.5), (h1b, 6.0)];
+
+    // -- Victim rows, allocated LAST (tail — no swap needed when freed). --
+    let hv1 = cell.alloc(box_at(7.5)).unwrap();
+    let hv2 = cell.alloc(box_at(9.0)).unwrap();
+    let victims = [hv1, hv2];
+    let victims_with_x: Vec<(Handle, f32)> = vec![(hv1, 7.5), (hv2, 9.0)];
+
+    // Self-verifying guard 1 (house law): the kept set must carry genuinely
+    // non-uniform generations, or the stale-check below is not actually
+    // exercising generation diversity.
+    let distinct_kept_gens: HashSet<u32> = kept.iter().map(|(h, _)| h.generation()).collect();
+    assert!(
+        distinct_kept_gens.len() > 1,
+        "guard: the kept set must carry genuinely different generations (T8 churn) — got {distinct_kept_gens:?}"
+    );
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0");
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (h, x) in kept.iter().copied().chain(victims_with_x.iter().copied()) {
+        assert!(store.write_transform(id, cell.storage_mut(), h, &translation([x, 0.0, -10.0]), &sim));
+        assert!(store.write_instance_info(id, cell.storage_mut(), h, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+    }
+
+    // -- Harvest all six live rows in one broad query. --
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-1.0, -1.0, -11.0], max: [10.0, 1.0, -9.0] });
+    let n = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(n, 6, "sanity: all six live rows (4 kept + 2 victims) harvested");
+
+    // Capture every kept handle's row BEFORE the second boundary, so the
+    // guard after it can prove no collateral row-shuffle happened.
+    let kept_rows_pre: HashMap<Handle, u32> = kept.iter().map(|&(h, _)| (h, cell.row_of(h).unwrap())).collect();
+
+    // -- Boundary #1: push the initial (all-fresh) state to GPU — the
+    // uploaded tokens/gens below snapshot exactly this state. --
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "test2-stale-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), 6);
+
+    let mut meshes = MeshRegistry::new(&ctx, 2);
+    let mesh0 = meshes.register(ctx.queue(), mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], 6, 0, 0)).unwrap();
+    assert_eq!(mesh0, 0);
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "test2-stale-output", 8);
+
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(ctx.queue(), &uniforms);
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+
+    // -- Dispatch #1 (pre-free baseline): every row is fresh, nothing
+    // stale yet — proves the fixture is genuinely all-visible BEFORE
+    // staleness is injected (a non-vacuity guard on the fixture itself). --
+    output.clear_counters(ctx.queue());
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+        ctx.queue().submit([encoder.finish()]);
+    }
+    let (visible0, stale0, oob0, frustum0, by_row0) = read_cull_output(&ctx, &output);
+    assert_eq!(stale0, 0, "baseline: nothing stale yet");
+    assert_eq!(oob0, 0, "baseline: no OOB row in this fixture");
+    assert_eq!(frustum0, 0, "baseline: every row is comfortably inside the frustum");
+    assert_eq!(visible0, 6, "baseline: all six rows visible before staleness is injected");
+    assert_eq!(by_row0.len(), 6);
+
+    // -- Make hv1 + hv2 stale: free_deferred -> force_complete -> a SECOND
+    // boundary (no re-harvest, no re-upload — the SAME view_tokens buffer
+    // from before is reused for dispatch #2 below). --
+    let sim2 = frames.begin();
+    let serial1 = store.tracker().next_serial();
+    assert!(store.free_deferred(id, cell.storage_mut(), hv1, serial1, &sim2));
+    let serial2 = store.tracker().next_serial();
+    assert!(store.free_deferred(id, cell.storage_mut(), hv2, serial2, &sim2));
+    store.tracker().force_complete(serial1);
+    store.tracker().force_complete(serial2);
+    let harvest2 = sim2.end().end();
+    let boundary2 = harvest2.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary2.run(&mut store, &mut slots);
+    }
+
+    // Self-verifying guard 2 (house law): the kept set's rows must be
+    // UNCHANGED by the second boundary (victims were tail rows, so no
+    // compaction swap should have touched anything else) — if this ever
+    // stops holding, the "every OTHER row still emits normally" assertion
+    // below would be checking the wrong physical rows, so fail loudly here
+    // instead.
+    for (h, x) in &kept {
+        let post_row = cell.row_of(*h).expect("kept handle must still be live");
+        assert_eq!(
+            kept_rows_pre[h], post_row,
+            "guard: kept handle at x={x} must keep its pre-free row (victims were tail rows — no swap expected)"
+        );
+    }
+    let expected_visible_rows: HashSet<u32> = kept.iter().map(|(h, _)| cell.row_of(*h).unwrap()).collect();
+    assert_eq!(expected_visible_rows.len(), 4);
+
+    // -- Dispatch #2: SAME view_tokens (uploaded before the free) against
+    // the NOW-BUMPED live generations for hv1/hv2's slots. --
+    output.clear_counters(ctx.queue());
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+        ctx.queue().submit([encoder.finish()]);
+    }
+    let (visible1, stale1, oob1, frustum1, by_row1) = read_cull_output(&ctx, &output);
+
+    // THE assertions (design §3.1/Test 2): exactly the injected count
+    // dropped as stale, nothing else touched.
+    assert_eq!(stale1, 2, "stale_drops must equal exactly the 2 injected stale rows");
+    assert_eq!(oob1, 0, "no OOB row in this fixture");
+    assert_eq!(frustum1, 0, "no row moved out of the frustum — only staleness changed");
+    // Non-vacuity guard: a shader that dropped EVERYTHING would also
+    // "pass" a naive assert_eq!(visible1, 0) style check — assert the
+    // KEPT rows are still exactly, individually, present instead.
+    assert_eq!(visible1, 4, "exactly the 4 kept (non-stale) rows must still emit a command");
+    let by_row1_keys: HashSet<u32> = by_row1.keys().copied().collect();
+    assert_eq!(
+        by_row1_keys, expected_visible_rows,
+        "the visible set after staleness injection must equal EXACTLY the kept (non-stale) rows"
+    );
+    for (row, (index_count, first_index, base_vertex, _first_instance)) in &by_row1 {
+        assert_eq!(*index_count, 6, "row {row}: index_count == mesh0.index_count");
+        assert_eq!(*first_index, 0, "row {row}: first_index == mesh0.index_offset");
+        assert_eq!(*base_vertex, 0, "row {row}: base_vertex == mesh0.base_vertex");
+    }
+    // The stale rows' old physical positions must have no command at all.
+    let stale_rows_now: HashSet<u32> = victims.iter().filter_map(|h| cell.row_of(*h)).collect();
+    // (victims are dead — `row_of` returns None for both; this is asserted
+    // for documentation, not as a load-bearing check.)
+    assert!(stale_rows_now.is_empty(), "victims are dead — row_of returns None for both");
+}
+
+/// The mesh_index out-of-range twin (M3-b T5 review coverage gap): a row
+/// whose `InstanceInfo.mesh_index` is written, via the NORMAL
+/// `write_instance_info` path, as `>= meshes.len()` (the mesh-table
+/// bounds-check ceiling `CullUniforms::mesh_count` carries) must be dropped
+/// with `oob_drops` incremented, and must not disturb a sibling VALID row
+/// (the non-vacuity guard). Mutation-kill evidence (WGSL bounds check
+/// temporarily disabled, this test observed to fail, then reverted) is
+/// recorded in the M3-b T6 report, not in this file.
+#[test]
+fn mesh_index_out_of_range_is_dropped_with_oob_telemetry() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+
+    let h_ok = cell.alloc(box_at(0.0)).unwrap();
+    let h_oob = cell.alloc(box_at(2.0)).unwrap();
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    assert!(store.write_transform(id, cell.storage_mut(), h_ok, &translation([0.0, 0.0, -10.0]), &sim));
+    assert!(store.write_transform(id, cell.storage_mut(), h_oob, &translation([2.0, 0.0, -10.0]), &sim));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h_ok, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+    // Written via the NORMAL write_instance_info path (per plan: "travels
+    // the real pipeline") — mesh_index == meshes.len() exactly (the
+    // boundary the `>=` bounds check must catch).
+    assert!(store.write_instance_info(id, cell.storage_mut(), h_oob, InstanceInfo { mesh_index: 1, flags: 0 }, &sim));
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-1.0, -1.0, -11.0], max: [3.0, 1.0, -9.0] });
+    let n = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(n, 2, "sanity: both rows harvested");
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "oob-twin-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), 2);
+
+    // Exactly ONE mesh registered (index 0) — h_oob's mesh_index (1) is
+    // exactly `meshes.len()`, the `>=` boundary the bounds check must trip.
+    let mut meshes = MeshRegistry::new(&ctx, 2);
+    let mesh0 = meshes.register(ctx.queue(), mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], 6, 0, 0)).unwrap();
+    assert_eq!(mesh0, 0);
+    assert_eq!(meshes.len(), 1, "sanity: h_oob's mesh_index (1) is out of range against this table");
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "oob-twin-output", 8);
+    output.clear_counters(ctx.queue());
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(ctx.queue(), &uniforms);
+
+    let mut encoder = device.create_command_encoder(&Default::default());
+    cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+    ctx.queue().submit([encoder.finish()]);
+
+    let (visible, stale, oob, frustum, by_row) = read_cull_output(&ctx, &output);
+
+    assert_eq!(stale, 0, "no stale row in this fixture");
+    assert_eq!(frustum, 0, "no frustum-culled row in this fixture");
+    // Non-vacuity guard: prove the OOB row's drop is specific to it, not a
+    // shader that dropped everything.
+    assert_eq!(visible, 1, "exactly h_ok must be visible");
+    assert_eq!(oob, 1, "oob_drops must equal exactly the 1 injected out-of-range row");
+
+    let ok_row = cell.row_of(h_ok).unwrap();
+    let oob_row = cell.row_of(h_oob).unwrap();
+    assert!(by_row.contains_key(&ok_row), "h_ok's row must have a command");
+    assert!(!by_row.contains_key(&oob_row), "h_oob's row must have NO command — dropped by the bounds check");
+    let (index_count, first_index, base_vertex, _) = by_row[&ok_row];
+    assert_eq!(index_count, 6, "h_ok's command uses mesh0.index_count");
+    assert_eq!(first_index, 0, "h_ok's command uses mesh0.index_offset");
+    assert_eq!(base_vertex, 0, "h_ok's command uses mesh0.base_vertex");
+}

--- a/crates/helio-scenedb/tests/draw_multi_indirect_equivalence.rs
+++ b/crates/helio-scenedb/tests/draw_multi_indirect_equivalence.rs
@@ -1,0 +1,335 @@
+//! M3-b T9-followup, deliverables 2/3: the PERMANENT equivalence pin the T9
+//! review's throwaway probe never left behind. T9 proved
+//! `DrawExecutor::record_multi_indirect` (strategy (b'): one
+//! `multi_draw_indexed_indirect` call over a repacked, tightly-packed
+//! 20-byte args buffer) renders byte-identical output to
+//! `DrawExecutor::record` (strategy (a): a CPU-side loop of
+//! `draw_indexed_indirect` calls reading the cull pass's own 32-byte-
+//! strided `CullRecord` buffer directly) -- then deleted the probe. That
+//! coverage does not persist across future edits to either draw path OR to
+//! the repack pass this file's sibling module (`src/repack.rs`) now ships.
+//! This test file is the replacement: it stays in the tree.
+//!
+//! ## The fixture (house law: self-verifying guards)
+//!
+//! Reuses the T9 reviewer's fixture SHAPE, chosen specifically to catch a
+//! SCRAMBLED slot->row mapping: >= 20 tokens (24 here, one cell), several
+//! (5) visible at DISTINCT x-positions -- reusing `draw_transform_sweep.
+//! rs`'s own five already-verified sweep positions (x = -8.75/-3.75/1.25/
+//! 6.25/8.75 at z=-10, landing in screen columns 0/2/4/6/7 of an 8-wide
+//! coarse grid, `support::view_proj_90deg`'s fovy=90 symmetric projection)
+//! -- alternating `mesh_index` 0/1/0/1/0 so the row lookup must resolve
+//! PER INSTANCE, not just "some row". If a repack (or `record_multi_
+//! indirect` itself) ever scrambled which packed record's `first_instance`
+//! maps to which cull slot, a visible instance would either vanish, paint
+//! the wrong column, or paint the wrong color -- any of which fails this
+//! file's per-color pixel-set assertions or the byte-identical target
+//! comparison below. The remaining 19 of 24 tokens sit at x=1000 (the same
+//! frustum-culled position `benches/pass_timing.rs`'s fixture and `cull_
+//! pass.rs`'s row 1 both use) -- a genuine culled MAJORITY, so both the
+//! visible and the culled path are exercised, not just the trivial
+//! all-visible case.
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullRecord, CullUniforms};
+use helio_scenedb::draw::{mesh_color_rgba8, DrawExecutor, DrawUniforms, OffscreenTarget};
+use helio_scenedb::repack::{packed_indirect_buffer, RepackPass};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, FrameDriver, GeometryArena, HarvestPipeline, HarvestStaging, MaterialRegistry,
+    MeshClass, MeshRegistry, MeshletBuffer, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+
+use support::{mesh, readback, scene_cfg, test_context_indirect_first_instance, translation, view_proj_90deg};
+
+const QUAD_VERTICES: [[f32; 3]; 4] = [
+    [-0.5, -0.5, 0.0],
+    [0.5, -0.5, 0.0],
+    [0.5, 0.5, 0.0],
+    [-0.5, 0.5, 0.0],
+];
+const QUAD_INDICES: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+/// Five visible x-positions, DISTINCT enough to land in 5 distinct 8-wide
+/// screen columns (verified against `draw_transform_sweep.rs`'s identical
+/// values -- see that file's own comment for the u/column arithmetic) --
+/// reused verbatim rather than re-derived, since that file already proves
+/// these five discriminate. `z = -10.0` for all (same depth as `cull_pass.
+/// rs`'s row 0 / `benches/pass_timing.rs`'s visible position).
+const VISIBLE_X: [f32; 5] = [-8.75, -3.75, 1.25, 6.25, 8.75];
+const Z: f32 = -10.0;
+/// The frustum-culled position -- `benches/pass_timing.rs`'s fixture and
+/// `cull_pass.rs`'s row 1 both use x=100/x=1000 as "comfortably outside the
+/// fovy=90 side planes at z=-10" (|x| <= 10 is the visibility bound there);
+/// 1000 keeps a wide margin.
+const CULLED_X: f32 = 1000.0;
+const N: u32 = 24;
+const VISIBLE_COUNT: u32 = VISIBLE_X.len() as u32; // 5
+
+#[test]
+fn record_and_record_multi_indirect_render_byte_identical_targets() {
+    let ctx = test_context_indirect_first_instance();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue = ctx.queue();
+
+    // --- Scene: one cell, N=24 rows. Rows 0..VISIBLE_COUNT sit at the
+    // five distinct visible x-positions (alternating mesh_index 0/1);
+    // rows VISIBLE_COUNT..N sit at the culled position. ---
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(32).unwrap();
+    let mut handles = Vec::with_capacity(N as usize);
+    for row in 0..N {
+        let x = if row < VISIBLE_COUNT { VISIBLE_X[row as usize] } else { CULLED_X };
+        let h = cell.alloc(Aabb { min: [x - 1.0, -1.0, Z - 1.0], max: [x + 1.0, 1.0, Z + 1.0] }).unwrap();
+        handles.push(h);
+    }
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0");
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (row, &h) in handles.iter().enumerate() {
+        let row = row as u32;
+        let x = if row < VISIBLE_COUNT { VISIBLE_X[row as usize] } else { CULLED_X };
+        let mesh_index = if row < VISIBLE_COUNT { row % 2 } else { 0 };
+        assert!(store.write_transform(id, cell.storage_mut(), h, &translation([x, 0.0, Z]), &sim));
+        assert!(store.write_instance_info(id, cell.storage_mut(), h, InstanceInfo { mesh_index, flags: 0 }, &sim));
+    }
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-2000.0, -2000.0, -2000.0], max: [2000.0, 2000.0, 2000.0] });
+    let harvested = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(harvested, N, "sanity: harvest must catch every synthetic row");
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "multi-indirect-equiv-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), N);
+
+    // --- Geometry: one quad, registered twice (mesh_index 0 and 1) over
+    // the SAME vertex/index range -- the two instances used above differ
+    // only by InstanceInfo.mesh_index (mirrors `draw_transform_sweep.rs`'s
+    // fixture idiom, so a per-color pixel-set assertion below actually
+    // proves the row->instance_info->color lookup, not just "some pixel is
+    // some color"). ---
+    let mut arena = GeometryArena::new(&ctx, 4096, 4096);
+    let vbytes: &[u8] = bytemuck::cast_slice(&QUAD_VERTICES);
+    let ibytes: &[u8] = bytemuck::cast_slice(&QUAD_INDICES);
+    let voff = arena.upload_vertices(queue, vbytes).unwrap();
+    let ioff = arena.upload_indices(queue, ibytes).unwrap();
+    let base_vertex = (voff / 12) as i32;
+    let first_index = ioff / 4;
+
+    let mut meshes = MeshRegistry::new(&ctx, 4);
+    let mesh0 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    let mesh1 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    assert_eq!((mesh0, mesh1), (0, 1), "sanity: mesh_index values the fixture's InstanceInfo rows used above");
+
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+
+    // --- Cull pass: ONE real dispatch, output capacity == N == 24 (so
+    // "the last slot at capacity", slot 23, is a real, addressable, never-
+    // written-by-cull slot -- deliverable 3's spot-pin target). ---
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "multi-indirect-equiv-cull-output", N);
+    output.clear_counters(queue);
+    let cull_output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: support::frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(queue, &uniforms);
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &cull_output_bind_group, view_tokens.count());
+        queue.submit([encoder.finish()]);
+    }
+
+    let cull_bytes = readback(&ctx, output.buffer(), output.byte_size());
+    let u32_at = |bytes: &[u8], off: usize| u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+    let visible_count = u32_at(&cull_bytes, 0);
+    let stale_drops = u32_at(&cull_bytes, 4);
+    let oob_drops = u32_at(&cull_bytes, 8);
+    let frustum_drops = u32_at(&cull_bytes, 12);
+    assert_eq!(stale_drops, 0, "fixture has no stale row");
+    assert_eq!(oob_drops, 0, "fixture has no OOB mesh_index row");
+    assert_eq!(frustum_drops, N - VISIBLE_COUNT, "guard: every non-visible row must be frustum-culled");
+    assert_eq!(visible_count, VISIBLE_COUNT, "guard: exactly the 5 fixture rows placed at visible x-positions must be visible");
+    // House-law guard (deliverable 2's explicit requirement): visible count
+    // must be strictly between 1 and the token count -- proves BOTH the
+    // visible and the culled path are genuinely exercised, not a
+    // degenerate all-visible or all-culled fixture.
+    assert!(visible_count > 1 && visible_count < N, "guard: 1 < visible_count ({visible_count}) < token_count ({N})");
+
+    // ==================================================================
+    // Deliverable 3: repack spot-pin -- compare a few repacked
+    // `PackedArgs` records against their source `CullRecord`s FIELD FOR
+    // FIELD, at three slots chosen to catch a repack that's plausible but
+    // shifted: the first visible slot (0), the first zero-instance/culled
+    // slot (== visible_count, the first slot the bounded-atomic cull pass
+    // never wrote), and the last slot at capacity (N-1 == 23).
+    // ==================================================================
+    let repack_pass = RepackPass::new(device);
+    repack_pass.write_capacity(queue, output.capacity());
+    let packed_buf = packed_indirect_buffer(device, output.capacity());
+    let repack_bind_group = repack_pass.build_bind_group(device, &output, &packed_buf);
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        repack_pass.record(&mut encoder, &repack_bind_group, output.capacity());
+        queue.submit([encoder.finish()]);
+    }
+    let packed_bytes = readback(&ctx, &packed_buf, output.capacity() as u64 * 20);
+
+    let cull_record_at = |slot: u32| -> CullRecord {
+        let off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+        CullRecord {
+            index_count: u32_at(&cull_bytes, off),
+            instance_count: u32_at(&cull_bytes, off + 4),
+            first_index: u32_at(&cull_bytes, off + 8),
+            base_vertex: i32::from_le_bytes(cull_bytes[off + 12..off + 16].try_into().unwrap()),
+            first_instance: u32_at(&cull_bytes, off + 16),
+            row: u32_at(&cull_bytes, off + 20),
+            flags: u32_at(&cull_bytes, off + 24),
+            reserved: u32_at(&cull_bytes, off + 28),
+        }
+    };
+    // `(index_count, instance_count, first_index, base_vertex, first_instance)`
+    // -- the packed buffer's own 20-byte shape.
+    let packed_args_at = |slot: u32| -> (u32, u32, u32, i32, u32) {
+        let off = slot as usize * 20;
+        (
+            u32_at(&packed_bytes, off),
+            u32_at(&packed_bytes, off + 4),
+            u32_at(&packed_bytes, off + 8),
+            i32::from_le_bytes(packed_bytes[off + 12..off + 16].try_into().unwrap()),
+            u32_at(&packed_bytes, off + 16),
+        )
+    };
+    let assert_repack_matches = |slot: u32, label: &str| {
+        let src = cull_record_at(slot);
+        let packed = packed_args_at(slot);
+        assert_eq!(
+            packed,
+            (src.index_count, src.instance_count, src.first_index, src.base_vertex, src.first_instance),
+            "repack spot-pin FAILED at slot {slot} ({label}): packed args {packed:?} must equal source \
+             CullRecord's first 20 bytes {src:?} field-for-field (index_count, instance_count, \
+             first_index, base_vertex, first_instance) -- first_instance especially, the §14.1 \
+             command-slot bindless key"
+        );
+    };
+    assert_repack_matches(0, "first visible slot");
+    assert_repack_matches(VISIBLE_COUNT, "first zero-instance/culled slot (never written by the bounded-atomic cull pass)");
+    assert_repack_matches(N - 1, "last slot at capacity");
+    // Self-verifying guard: the "zero-instance" slot must ACTUALLY be
+    // zero-instance (i.e. this fixture's capacity genuinely exceeds
+    // visible_count, so the spot-pin above exercises a real never-written
+    // slot, not an accidental second visible one).
+    assert_eq!(
+        cull_record_at(VISIBLE_COUNT).instance_count,
+        0,
+        "guard: slot {VISIBLE_COUNT} must be a genuine zero-instance/never-written slot"
+    );
+
+    // ==================================================================
+    // Deliverables 1/2: render the SAME scene twice -- strategy (a) via
+    // `DrawExecutor::record` (reads `CullRecord`s directly), strategy (b')
+    // via `DrawExecutor::record_multi_indirect` + the just-verified
+    // repacked buffer -- into two SEPARATE offscreen targets, then compare
+    // bytes. Both issue `output.capacity()` (24) draw "slots": the tail
+    // (zero-instance) slots are harmless no-op draws on EITHER path
+    // (`instance_count == 0`), so this also exercises the repack's
+    // handling of the culled majority, not just the 5 visible rows.
+    // ==================================================================
+    let draw_executor = DrawExecutor::new(device, &scene_binding.cull_layout);
+    let draw_output_bind_group = draw_executor.build_output_bind_group(device, &output);
+    draw_executor.write_uniforms(queue, &DrawUniforms { view_proj: view_proj_90deg() });
+
+    let target_a = OffscreenTarget::new(device, "multi-indirect-equiv-target-a");
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        draw_executor.record(
+            &mut encoder,
+            target_a.view(),
+            &scene_binding.cull_bind_group,
+            &draw_output_bind_group,
+            &output,
+            arena.vertex_buffer(),
+            arena.index_buffer(),
+            output.capacity(),
+        );
+        queue.submit([encoder.finish()]);
+    }
+    let pixels_a = target_a.read_pixels(device, queue);
+
+    let target_b = OffscreenTarget::new(device, "multi-indirect-equiv-target-b");
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        draw_executor.record_multi_indirect(
+            &mut encoder,
+            target_b.view(),
+            &scene_binding.cull_bind_group,
+            &draw_output_bind_group,
+            &packed_buf,
+            0,
+            output.capacity(),
+            arena.vertex_buffer(),
+            arena.index_buffer(),
+        );
+        queue.submit([encoder.finish()]);
+    }
+    let pixels_b = target_b.read_pixels(device, queue);
+
+    // --- Self-verifying guards (house law): non-empty targets -- two
+    // blank targets would match vacuously and defeat the whole point of
+    // this comparison. "Painted" == any pixel with alpha == 255 (the
+    // clear color is transparent black, alpha 0; `mesh_color`'s alpha is
+    // always 1.0). ---
+    let painted_count = |pixels: &[u8]| pixels.chunks_exact(4).filter(|px| px[3] == 255).count();
+    let painted_a = painted_count(&pixels_a);
+    let painted_b = painted_count(&pixels_b);
+    assert!(painted_a > 0, "guard: strategy (a)'s target must be non-empty (painted {painted_a} pixels)");
+    assert!(painted_b > 0, "guard: strategy (b')'s target must be non-empty (painted {painted_b} pixels)");
+
+    // --- Self-verifying guard: at least two distinct mesh colors present
+    // -- proves the row lookup resolved PER INSTANCE (mesh_index 0 vs 1),
+    // not one instance repeated across every visible slot. ---
+    let color0 = mesh_color_rgba8(0);
+    let color1 = mesh_color_rgba8(1);
+    assert_ne!(color0, color1, "guard: mesh_index 0/1 colors must differ");
+    let has_color = |pixels: &[u8], c: [u8; 4]| pixels.chunks_exact(4).any(|px| px == c);
+    assert!(has_color(&pixels_a, color0) && has_color(&pixels_a, color1), "guard: strategy (a) must paint BOTH mesh colors");
+    assert!(has_color(&pixels_b, color0) && has_color(&pixels_b, color1), "guard: strategy (b') must paint BOTH mesh colors");
+
+    // --- THE deliverable-gate assertion: byte-identical targets. ---
+    let diff_count = pixels_a.iter().zip(pixels_b.iter()).filter(|(a, b)| a != b).count();
+    assert_eq!(
+        diff_count, 0,
+        "strategy (a) [record] and strategy (b') [record_multi_indirect + repack] must render \
+         byte-identical targets ({diff_count}/{} bytes differ)",
+        pixels_a.len()
+    );
+    assert_eq!(pixels_a, pixels_b, "byte-identical target check (redundant with diff_count above, kept for a precise Vec diff on failure)");
+}

--- a/crates/helio-scenedb/tests/draw_transform_sweep.rs
+++ b/crates/helio-scenedb/tests/draw_transform_sweep.rs
@@ -1,0 +1,425 @@
+//! Test 4 (design S5/S14, M3-b T7): the transform sweep. Sweeps ONE
+//! instance's transform across six frames (>= 5 positions, INCLUDING a
+//! rotated pose -- the column-major transform convention is pinned
+//! (`page.rs`'s `Pod for [f32; 16]` doc comment) and the T5/T6 review's
+//! rotation regression pin lives cull-side (`cull_pass.rs` row 3). SCOPE,
+//! corrected per the M3-b T7 review: this test's rotated pose proves a
+//! NON-IDENTITY rotation reached the vertex shader's
+//! `instances[row].transform` read (asserted on painted-footprint size,
+//! after the sweep loop) -- it does NOT catch a transposed-matrix read,
+//! because R(45deg) and R(-45deg) map this centered symmetric quad to the
+//! identical point set. Transpose detection lives cull-side, where row 3
+//! uses a deliberately non-symmetric two-axis rotation. A draw-side
+//! transpose pin would need an off-center or asymmetric quad so rotation
+//! DIRECTION moves the centroid -- known gap, recorded not overclaimed):
+//! each frame
+//! `write_transform` -> boundary -> a REAL `CullPass` dispatch -> a REAL
+//! `DrawExecutor` indirect draw over that dispatch's own command buffer ->
+//! offscreen-target readback. Every frame re-derives its own expected
+//! screen column from the SAME symmetric fovy=90/aspect=1 projection
+//! `support::view_proj_90deg` already establishes, independently of the
+//! shader (the projection math is `x_ndc = x_world / (-z_world)`, derived
+//! by hand from that matrix's own coefficients, not by re-running WGSL in
+//! Rust).
+//!
+//! ## The real cull->draw handoff (report honesty note, restated here)
+//!
+//! Nothing here is shortcut: `CullPass::record` runs a real compute
+//! dispatch each frame against the JUST-boundary-synced transform,
+//! `CullOutputBuffers` is read back for its own `visible_count` (the S14.2
+//! CPU clamp), and `DrawExecutor::record` issues `draw_indexed_indirect`
+//! calls that read their `DrawIndexedIndirectArgs` prefix directly out of
+//! THAT SAME buffer the cull dispatch just wrote -- the vertex shader's
+//! `draw_cull_output.records[iid].row` lookup resolves through the actual
+//! per-frame cull output, not a precomputed/faked row index. The ONE
+//! CPU-side value the draw call consumes (`command_count`) comes from a
+//! real `map_async` readback of the cull pass's own atomic counter, exactly
+//! mirroring the S14.2 clamp-after-readback design (T9 is the dedicated
+//! task for measuring this readback's latency; this test pays it once per
+//! frame without trying to hide or amortize it).
+//!
+//! ## Two instances per frame -- proving row indirection, not just presence
+//!
+//! A lone moving instance would let `first_instance == 0` always resolve to
+//! row 0 even if the shader ignored `draw_cull_output.records[iid].row`
+//! entirely and just used `iid` as the row directly (row == slot == 0 in
+//! that degenerate one-instance case). A SECOND, static "decoy" instance
+//! (different row, different `mesh_index`, positioned far off in Y so its
+//! screen footprint never spatially overlaps the mover's, regardless of the
+//! cull pass's nondeterministic slot-allocation order across its two
+//! concurrent GPU threads) forces the shader to genuinely resolve
+//! `slot -> row` per draw call: whichever of the two rows lands in which
+//! slot, both must still end up in their OWN correct screen position with
+//! their OWN correct color, or this test's per-color pixel-set assertions
+//! fail.
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms};
+use helio_scenedb::draw::{mesh_color_rgba8, DrawExecutor, DrawUniforms, OffscreenTarget};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, FrameDriver, GeometryArena, HarvestPipeline, HarvestStaging, MaterialRegistry,
+    MeshClass, MeshRegistry, MeshletBuffer, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+
+use support::{
+    flatten_column_major, mat3_rot_z, mesh, readback, scene_cfg, test_context_indirect_first_instance, translation,
+    view_proj_90deg,
+};
+
+/// Local-space unit quad (two triangles), `vec3<f32>` positions -- the
+/// trivial mesh `DrawExecutor::new`'s vertex layout expects (`array_stride:
+/// 12`). Half-extent 0.5, matching this suite's other fixtures' object
+/// scale (`cull_pass.rs`'s mesh0).
+const QUAD_VERTICES: [[f32; 3]; 4] = [
+    [-0.5, -0.5, 0.0],
+    [0.5, -0.5, 0.0],
+    [0.5, 0.5, 0.0],
+    [-0.5, 0.5, 0.0],
+];
+const QUAD_INDICES: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+/// Screen-space 8x8 coarse grid (design plan T7: "coarse grid assert...
+/// pixel-exact rasterization comparison is explicitly NOT the goal").
+const GRID: u32 = 8;
+
+/// `x_ndc = x_world / (-z_world)` -- hand-derived from `view_proj_90deg`'s
+/// own coefficients (`support` module doc / `cull_pass.rs`'s own comments):
+/// that matrix's clip.x is untouched world x, clip.w is `-z_world`, and
+/// fovy=90/aspect=1 gives a slope of exactly 1, so NDC x IS `x/(-z)` with no
+/// extra scale factor. Maps to a column index in `0..GRID`.
+fn expected_column(x_world: f32, z_world: f32) -> u32 {
+    let ndc_x = x_world / -z_world;
+    let u = (ndc_x * 0.5 + 0.5) * OffscreenTarget::WIDTH as f32;
+    ((u / (OffscreenTarget::WIDTH as f32 / GRID as f32)) as u32).min(GRID - 1)
+}
+
+/// Pixel coordinates (row-major, `OffscreenTarget::WIDTH`-wide) whose RGBA8
+/// value matches `expected` within `tol` per channel (Rgba8Unorm round-trip
+/// tolerance -- the fragment shader computes `f32(byte)/255.0`, the
+/// rasterizer quantizes back to u8; this is designed to round-trip exactly
+/// for byte-valued inputs, but a tolerance of 1 absorbs any FP rounding
+/// without weakening the "which mesh painted this" identification, since
+/// `mesh_color_rgba8(0)` and `mesh_color_rgba8(1)` differ by far more than 2
+/// in every channel).
+fn pixels_matching(rgba: &[u8], expected: [u8; 4], tol: i32) -> Vec<(u32, u32)> {
+    let mut hits = Vec::new();
+    for y in 0..OffscreenTarget::HEIGHT {
+        for x in 0..OffscreenTarget::WIDTH {
+            let i = ((y * OffscreenTarget::WIDTH + x) * 4) as usize;
+            let px = [rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3]];
+            let close = px.iter().zip(expected.iter()).all(|(&a, &b)| (a as i32 - b as i32).abs() <= tol);
+            if close {
+                hits.push((x, y));
+            }
+        }
+    }
+    hits
+}
+
+fn centroid(pixels: &[(u32, u32)]) -> (f32, f32) {
+    let n = pixels.len() as f32;
+    let sx: f32 = pixels.iter().map(|&(x, _)| x as f32).sum();
+    let sy: f32 = pixels.iter().map(|&(_, y)| y as f32).sum();
+    (sx / n, sy / n)
+}
+
+fn column_of(px: f32) -> u32 {
+    ((px / (OffscreenTarget::WIDTH as f32 / GRID as f32)) as u32).min(GRID - 1)
+}
+
+#[test]
+fn transform_sweep_tracks_projected_position_across_frames() {
+    let ctx = test_context_indirect_first_instance();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue = ctx.queue();
+
+    // --- Scene: one moving instance (mesh_index 0) + one static decoy
+    // (mesh_index 1, parked at y=8 so its screen row never overlaps the
+    // mover's y=0 row regardless of the sweep's x). ---
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+    let h_move = cell.alloc(Aabb { min: [-9.0, -1.0, -11.0], max: [9.0, 1.0, -9.0] }).unwrap();
+    let h_decoy = cell.alloc(Aabb { min: [-1.0, 7.0, -11.0], max: [1.0, 9.0, -9.0] }).unwrap();
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0");
+
+    // --- The sweep: six frames, x in [-8, 8] at fixed z=-10, plus a
+    // rotated pose (row3-style Rz(45deg)) at a FRESH x not otherwise used
+    // (self-verifying guard below proves every column is distinct enough
+    // to discriminate). ---
+    let z = -10.0_f32;
+    struct Step {
+        x: f32,
+        rot: Option<[[f32; 3]; 3]>,
+    }
+    // x values chosen to land near the CENTER of their predicted 8-pixel
+    // grid cell (u = x*3.2 + 32, cell width 8px -- picking u == 4 mod 8
+    // maximizes margin from any cell boundary), not at a boundary: the
+    // quad's own screen footprint is a few pixels wide, so a sweep point
+    // placed exactly ON a cell boundary (e.g. x=0.0, which projects to
+    // u=32.0 exactly, the col3/col4 boundary) makes the observed centroid
+    // vs. predicted-column comparison a coin flip on rasterization
+    // rounding -- not a real bug, just a bad fixture choice. Every value
+    // below sits solidly inside its column instead.
+    let steps = [
+        Step { x: -8.75, rot: None },  // u=4   -> column 0
+        Step { x: -3.75, rot: None },  // u=20  -> column 2
+        Step { x: 1.25, rot: None },   // u=36  -> column 4
+        Step { x: 6.25, rot: None },   // u=52  -> column 6
+        Step { x: 8.75, rot: None },   // u=60  -> column 7
+        Step { x: -6.25, rot: Some(mat3_rot_z(45.0)) }, // u=12 -> column 1, rotation regression pin, draw side
+    ];
+
+    // Self-verifying guard (house law): the sweep's own predicted columns
+    // must be genuinely non-uniform BEFORE trusting "footprint moves"
+    // below -- a degenerate sweep that collapsed to one column would let a
+    // static-image shader pass by accident.
+    let predicted_columns: Vec<u32> = steps.iter().map(|s| expected_column(s.x, z)).collect();
+    assert!(
+        predicted_columns.iter().collect::<std::collections::HashSet<_>>().len() >= 4,
+        "guard: the sweep must predict at least 4 distinct columns, got {predicted_columns:?}"
+    );
+
+    let mut frames = FrameDriver::new();
+    let sim0 = frames.begin();
+    let first = flatten_column_major([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], [steps[0].x, 0.0, z]);
+    assert!(store.write_transform(id, cell.storage_mut(), h_move, &first, &sim0));
+    assert!(store.write_transform(id, cell.storage_mut(), h_decoy, &translation([0.0, 8.0, z]), &sim0));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h_move, InstanceInfo { mesh_index: 0, flags: 0 }, &sim0));
+    assert!(store.write_instance_info(id, cell.storage_mut(), h_decoy, InstanceInfo { mesh_index: 1, flags: 0 }, &sim0));
+
+    // --- Harvest once (broad view; no free/realloc happens across the
+    // whole sweep, so rows/generations never go stale and the SAME
+    // ViewTokenBuffers upload stays valid for every frame -- the T6
+    // `sim.end().end()`-without-reharvest pattern below relies on this). ---
+    let harvest_phase = sim0.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-200.0, -200.0, -200.0], max: [200.0, 200.0, 200.0] });
+    let n = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(n, 2, "sanity: both rows harvested");
+
+    let boundary0 = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary0.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "draw-sweep-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), 2);
+
+    // --- Geometry: ONE quad uploaded through SceneDB's real GeometryArena +
+    // MeshRegistry public API (design's explicit requirement: the draw
+    // genuinely pulls SceneDB-owned vertex/index data, not a test-local
+    // buffer) -- registered TWICE (mesh_index 0 and 1) over the SAME
+    // vertex/index range, so the two instances differ only by
+    // InstanceInfo.mesh_index (and therefore only by fragment color), never
+    // by geometry. ---
+    let mut arena = GeometryArena::new(&ctx, 4096, 4096);
+    let vbytes: &[u8] = bytemuck::cast_slice(&QUAD_VERTICES);
+    let ibytes: &[u8] = bytemuck::cast_slice(&QUAD_INDICES);
+    let voff = arena.upload_vertices(queue, vbytes).unwrap();
+    let ioff = arena.upload_indices(queue, ibytes).unwrap();
+    assert_eq!(voff, 0, "sanity: first vertex alloc in an empty arena lands at byte 0");
+    assert_eq!(ioff, 0, "sanity: first index alloc in an empty arena lands at byte 0");
+    let base_vertex = (voff / 12) as i32; // vec3<f32> stride
+    let first_index = ioff / 4; // u32 index stride
+
+    let mut meshes = MeshRegistry::new(&ctx, 4);
+    let mesh0 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.05], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    let mesh1 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.05], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    assert_eq!((mesh0, mesh1), (0, 1), "sanity: mesh_index values the fixture's InstanceInfo rows used above");
+
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+
+    // --- Cull + draw passes, built ONCE (mirrors CullPass/DrawExecutor's
+    // "rebuilt at renderer construction" idiom -- nothing here is rebuilt
+    // per sweep frame, only re-dispatched/re-recorded). ---
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "draw-sweep-cull-output", 8);
+    let cull_output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: support::frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        capacity: output.capacity(),
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(queue, &uniforms);
+
+    let draw_executor = DrawExecutor::new(device, &scene_binding.cull_layout);
+    let draw_output_bind_group = draw_executor.build_output_bind_group(device, &output);
+    draw_executor.write_uniforms(queue, &DrawUniforms { view_proj: view_proj_90deg() });
+    let target = OffscreenTarget::new(device, "draw-sweep-target");
+
+    let move_color = mesh_color_rgba8(0);
+    let decoy_color = mesh_color_rgba8(1);
+    // Self-verifying guard: the two meshes' derived colors must actually
+    // differ, or the pixel-classification-by-color below cannot
+    // discriminate the mover from the decoy.
+    assert_ne!(move_color, decoy_color, "guard: mesh_index 0/1 colors must differ");
+
+    let mut observed_columns = Vec::new();
+    // `(was_rotated, painted_pixel_count)` per frame — feeds the
+    // rotation-reached-the-shader assertion after the loop.
+    let mut mover_footprints: Vec<(bool, usize)> = Vec::new();
+
+    for (step_i, step) in steps.iter().enumerate() {
+        // --- Per-frame transform write + boundary (no re-harvest, matching
+        // T6's `sim.end().end()` pattern -- rows/gens are stable). ---
+        if step_i > 0 {
+            let sim = frames.begin();
+            let xf = match step.rot {
+                None => translation([step.x, 0.0, z]),
+                Some(r) => flatten_column_major(r, [step.x, 0.0, z]),
+            };
+            assert!(store.write_transform(id, cell.storage_mut(), h_move, &xf, &sim));
+            let harvest = sim.end().end();
+            let boundary = harvest.end();
+            let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+            boundary.run(&mut store, &mut slots);
+        }
+
+        // --- Real cull dispatch against the just-synced transform. ---
+        output.clear_counters(queue);
+        {
+            let mut encoder = device.create_command_encoder(&Default::default());
+            cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &cull_output_bind_group, view_tokens.count());
+            queue.submit([encoder.finish()]);
+        }
+        let out_bytes = readback(&ctx, output.buffer(), output.byte_size());
+        let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+        let visible_count = u32_at(0);
+        let stale_drops = u32_at(4);
+        let oob_drops = u32_at(8);
+        let frustum_drops = u32_at(12);
+        // Self-verifying non-vacuity guard: both instances must be visible,
+        // every frame -- a cull regression that dropped one would silently
+        // turn this into a one-instance test (defeating the row-indirection
+        // proof, see this file's module doc).
+        assert_eq!(stale_drops, 0, "step {step_i}: no stale row in this fixture");
+        assert_eq!(oob_drops, 0, "step {step_i}: no OOB row in this fixture");
+        assert_eq!(frustum_drops, 0, "step {step_i}: both rows must stay inside the frustum across the whole sweep");
+        assert_eq!(visible_count, 2, "step {step_i}: both mover and decoy must be visible");
+        let command_count = visible_count.min(output.capacity());
+
+        // --- Real indirect draw over the SAME cull output the dispatch
+        // above just wrote. ---
+        {
+            let mut encoder = device.create_command_encoder(&Default::default());
+            draw_executor.record(
+                &mut encoder,
+                target.view(),
+                &scene_binding.cull_bind_group,
+                &draw_output_bind_group,
+                &output,
+                arena.vertex_buffer(),
+                arena.index_buffer(),
+                command_count,
+            );
+            queue.submit([encoder.finish()]);
+        }
+
+        let pixels = target.read_pixels(device, queue);
+        let mover_px = pixels_matching(&pixels, move_color, 1);
+        let decoy_px = pixels_matching(&pixels, decoy_color, 1);
+
+        // --- Self-verifying guards (house law): non-empty target (a shader
+        // that draws nothing must fail this), AND the color-classified
+        // pixel sets must be non-empty for BOTH instances (proves the
+        // row->instance_info->color lookup for both concurrently-drawn
+        // rows, not just "some pixel is some color"). ---
+        assert!(!mover_px.is_empty(), "step {step_i}: mover must paint at least one pixel of its mesh_index-0 color");
+        assert!(!decoy_px.is_empty(), "step {step_i}: decoy must paint at least one pixel of its mesh_index-1 color");
+
+        let (cx, cy) = centroid(&mover_px);
+        let (_dcx, dcy) = centroid(&decoy_px);
+        // The decoy's row (y=8 world) and the mover's row (y=0 world) must
+        // land in different screen rows regardless of NDC-y sign
+        // convention -- proves the two instances are not simply painting
+        // the same location (which would defeat the row-indirection proof
+        // even if both color checks above happened to pass via overlap).
+        assert!(
+            (cy - dcy).abs() > (OffscreenTarget::HEIGHT as f32 / GRID as f32),
+            "step {step_i}: mover row {cy} and decoy row {dcy} must be clearly separated"
+        );
+
+        let observed_col = column_of(cx);
+        let expected_col = expected_column(step.x, z);
+        assert_eq!(
+            observed_col, expected_col,
+            "step {step_i} (x={}, rot={:?}): observed column {observed_col} (centroid px={cx}) \
+             must match the CPU-projected column {expected_col}",
+            step.x,
+            step.rot.is_some()
+        );
+        observed_columns.push(observed_col);
+        mover_footprints.push((step.rot.is_some(), mover_px.len()));
+    }
+
+    // The rotated pose must actually CHANGE the rendered footprint (M3-β T7
+    // review, defect 1). A centered square quad's centroid is invariant
+    // under rotation, so the column assertions above cannot see a rotation
+    // at all; without this, the rotated frame would be pure decoration.
+    // Comparing painted-pixel COUNT against the unrotated frames' does see
+    // it: the same quad rotated 45° covers a different pixel set.
+    //
+    // Scope, stated honestly: this proves a NON-IDENTITY rotation reached
+    // the vertex shader's `instances[row]` read — it does NOT discriminate
+    // M from Mᵀ, because R(45°) and R(-45°) map a symmetric square to the
+    // same point set (reviewer verified numerically). The column-major
+    // convention itself is pinned cull-side by `cull_pass.rs` row 3, which
+    // uses a deliberately non-symmetric two-axis rotation for exactly that
+    // reason. Pinning a *vertex-shader* transpose specifically would need
+    // an off-center or asymmetric quad so rotation direction moves the
+    // centroid — recorded as a known gap rather than overclaimed here.
+    let unrotated: Vec<usize> =
+        mover_footprints.iter().filter(|(r, _)| !r).map(|&(_, n)| n).collect();
+    let rotated: Vec<usize> =
+        mover_footprints.iter().filter(|(r, _)| *r).map(|&(_, n)| n).collect();
+    assert!(!rotated.is_empty(), "guard: the sweep must contain a rotated pose");
+    let baseline = unrotated[0];
+    assert!(
+        unrotated.iter().all(|&n| n == baseline),
+        "guard: the unrotated poses must all paint the same footprint size (got {unrotated:?}) — \
+         otherwise the rotated-vs-unrotated comparison below is meaningless"
+    );
+    for &n in &rotated {
+        assert_ne!(
+            n, baseline,
+            "the rotated pose painted the same {n}-pixel footprint as the unrotated baseline — \
+             the rotation did not reach the vertex shader's transform read"
+        );
+    }
+
+    // --- The deliverable-gate assertion (house law): the footprint must
+    // actually MOVE between at least two sweep positions -- a static image
+    // would otherwise have passed every per-frame assertion above by
+    // accident (each frame's centroid checked independently). ---
+    let distinct: std::collections::HashSet<u32> = observed_columns.iter().copied().collect();
+    assert!(
+        distinct.len() >= 2,
+        "guard: the sweep's observed columns must include at least 2 distinct values, got {observed_columns:?}"
+    );
+    assert_ne!(
+        observed_columns.first(),
+        observed_columns.last(),
+        "guard: the FIRST and LAST sweep frame must land in different columns"
+    );
+}

--- a/crates/helio-scenedb/tests/overflow_clamp.rs
+++ b/crates/helio-scenedb/tests/overflow_clamp.rs
@@ -1,0 +1,323 @@
+//! Test 5 (design §14.2, M3-b T8): the overflow clamp. Oversubscribes the
+//! cull pass's command buffer -- more visible instances than the shader is
+//! TOLD it may write (`CullUniforms.capacity`) -- and proves the whole
+//! §14.2 safety story end to end: the atomic keeps counting true demand
+//! past the bound, the shader never writes past it, the CPU-side
+//! `min(count, capacity)` clamp is what makes the subsequent indirect draw
+//! safe, and the silent-drop count is derivable and reportable.
+//!
+//! ## The logical/physical capacity split (the mechanism this test hinges on)
+//!
+//! [`CullOutputBuffers::new`] sizes the underlying `wgpu::Buffer` for
+//! whatever `capacity` it is given -- call this the buffer's PHYSICAL
+//! capacity. Separately, `CullUniforms.capacity` (written independently via
+//! `CullPass::write_uniforms`) is the LOGICAL bound the shader actually
+//! enforces (`wgsl.rs`'s `cull_main`: `if (out_slot < cull_uniforms.
+//! capacity) { cull_output.records[out_slot] = ... }`). Nothing requires
+//! these two numbers to match -- `records` is declared `array<CullRecord>`
+//! (WGSL runtime-sized, its length implied by whatever buffer region is
+//! bound), so the shader's only real bound is the uniform value.
+//!
+//! This test deliberately allocates a PHYSICAL buffer (`PHYSICAL_CAPACITY`)
+//! LARGER than the LOGICAL bound it tells the shader (`LOGICAL_CAPACITY`),
+//! specifically so there is real, GPU-addressable, in-bounds space past the
+//! logical bound to plant canary bytes into. This is what makes the canary
+//! check meaningful: a shader that ignored `cull_uniforms.capacity` and
+//! instead wrote up to the buffer's actual physical extent (a real class of
+//! bug -- reading the wrong bound, or comparing against `arrayLength`
+//! instead of the uniform) would corrupt the canary region without ever
+//! triggering a wgpu OOB validation error, because that region genuinely IS
+//! inside the bound buffer. A canary planted in memory that was ALSO out of
+//! the physical buffer's bounds would prove nothing new (wgpu's own
+//! validation already forbids that unconditionally) -- the interesting,
+//! test-worthy failure mode is exactly the in-bounds-but-past-the-logical-
+//! limit one this split creates room for.
+//!
+//! `DEMAND` (the fixture's instance count, all mutually visible -- no
+//! stale/oob/frustum-cull category exercised here, that is `cull_stale_and_
+//! oob.rs`'s and `cull_pass.rs`'s job) sits strictly between `LOGICAL_
+//! CAPACITY` (so the buffer really is oversubscribed) and `PHYSICAL_
+//! CAPACITY` (so the canary region is never itself a plausible target row
+//! -- the fixture simply does not have enough rows to fill it even if the
+//! bound were ignored, keeping the corruption check unambiguous either
+//! way).
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms};
+use helio_scenedb::draw::{mesh_color_rgba8, DrawExecutor, DrawUniforms, OffscreenTarget};
+use helio_scenedb::SceneDbBinding;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, FrameDriver, GeometryArena, HarvestPipeline, HarvestStaging, MaterialRegistry,
+    MeshClass, MeshRegistry, MeshletBuffer, SceneGpuStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+use std::collections::HashSet;
+
+use support::{frustum_planes_90deg, mesh, readback, scene_cfg, test_context_indirect_first_instance, translation, view_proj_90deg};
+
+/// Local-space unit quad (two triangles), `vec3<f32>` positions -- identical
+/// to `draw_transform_sweep.rs`'s fixture geometry (the trivial mesh
+/// `DrawExecutor::new`'s vertex layout expects, `array_stride: 12`).
+const QUAD_VERTICES: [[f32; 3]; 4] = [
+    [-0.5, -0.5, 0.0],
+    [0.5, -0.5, 0.0],
+    [0.5, 0.5, 0.0],
+    [-0.5, 0.5, 0.0],
+];
+const QUAD_INDICES: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+/// The fixture's total mutually-visible instance count -- the "true demand"
+/// the shader's atomic must keep counting past the logical bound.
+const DEMAND: u32 = 10;
+/// The bound the shader is TOLD (`CullUniforms.capacity`) -- deliberately
+/// smaller than `DEMAND` (this test's entire point) and smaller than
+/// `PHYSICAL_CAPACITY` (see module doc for why).
+const LOGICAL_CAPACITY: u32 = 4;
+/// The buffer's actual allocated size, in records -- deliberately larger
+/// than both `LOGICAL_CAPACITY` (leaves real, addressable canary room) and
+/// `DEMAND` (the fixture cannot accidentally fill the canary region even if
+/// the logical bound were ignored).
+const PHYSICAL_CAPACITY: u32 = 20;
+const _SHAPE_GUARD: () = assert!(LOGICAL_CAPACITY < DEMAND && DEMAND < PHYSICAL_CAPACITY);
+
+#[test]
+fn overflow_clamp_counts_demand_writes_exactly_capacity_and_leaves_the_tail_untouched() {
+    let ctx = test_context_indirect_first_instance();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue = ctx.queue();
+
+    // --- Scene: DEMAND instances, evenly spaced in x at a fixed z=-10, all
+    // comfortably inside the fovy=90/aspect=1 frustum's side planes (which
+    // admit |x| far beyond 9 at this depth, per `cull_pass.rs`'s own plane
+    // arithmetic) and with no near-clip (z well clear of the camera). One
+    // shared mesh (mesh_index 0) for all rows -- this test is about the
+    // command-buffer accounting, not per-row visual identity. ---
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+    let mut handles = Vec::with_capacity(DEMAND as usize);
+    for i in 0..DEMAND {
+        let x = -9.0 + i as f32 * 2.0;
+        let h = cell.alloc(Aabb { min: [x - 1.0, -1.0, -11.0], max: [x + 1.0, 1.0, -9.0] }).unwrap();
+        handles.push(h);
+    }
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0");
+
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    for (i, &h) in handles.iter().enumerate() {
+        let x = -9.0 + i as f32 * 2.0;
+        assert!(store.write_transform(id, cell.storage_mut(), h, &translation([x, 0.0, -10.0]), &sim));
+        assert!(store.write_instance_info(id, cell.storage_mut(), h, InstanceInfo { mesh_index: 0, flags: 0 }, &sim));
+    }
+
+    let harvest_phase = sim.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb { min: [-200.0, -200.0, -200.0], max: [200.0, 200.0, 200.0] });
+    let n = pipeline.harvest_cell(&cell, base, MeshClass::Traditional, &view, &mut pad, &mut staging, &harvest_phase);
+    assert_eq!(n, DEMAND, "sanity: the broad harvest view catches every row");
+
+    let boundary = harvest_phase.end();
+    {
+        let mut slots = [CellSlot { id, cell: cell.storage_mut() }];
+        boundary.run(&mut store, &mut slots);
+    }
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "overflow-clamp-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), DEMAND);
+
+    // --- Geometry + mesh registration (real SceneDB residency, mirroring
+    // `draw_transform_sweep.rs`). ---
+    let mut arena = GeometryArena::new(&ctx, 4096, 4096);
+    let vbytes: &[u8] = bytemuck::cast_slice(&QUAD_VERTICES);
+    let ibytes: &[u8] = bytemuck::cast_slice(&QUAD_INDICES);
+    let voff = arena.upload_vertices(queue, vbytes).unwrap();
+    let ioff = arena.upload_indices(queue, ibytes).unwrap();
+    let base_vertex = (voff / 12) as i32;
+    let first_index = ioff / 4;
+
+    let mut meshes = MeshRegistry::new(&ctx, 2);
+    let mesh0 = meshes
+        .register(queue, mesh([0.0, 0.0, 0.0], [0.5, 0.5, 0.5], QUAD_INDICES.len() as u32, first_index, base_vertex))
+        .unwrap();
+    assert_eq!(mesh0, 0, "sanity: mesh_index 0, matching the fixture's InstanceInfo rows above");
+
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+    let scene_binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+
+    // --- The cull pass, output allocated at PHYSICAL_CAPACITY (see module
+    // doc). ---
+    let cull_pass = CullPass::new(device, &scene_binding.cull_layout);
+    let output = CullOutputBuffers::new(device, "overflow-clamp-output", PHYSICAL_CAPACITY);
+    output.clear_counters(queue);
+
+    // --- Plant the canary: a distinctive, non-zero, non-plausible-draw-
+    // command 32-bit pattern (0xCAFEBABE repeated) across the ENTIRE tail
+    // region -- every record slot from LOGICAL_CAPACITY..PHYSICAL_CAPACITY
+    // -- BEFORE dispatch. `clear_counters` above only zeroes the 16-byte
+    // atomics header (offsets 0..16), a disjoint byte range from this
+    // write, so ordering between the two calls does not matter. ---
+    let tail_offset = CullOutputBuffers::HEADER_BYTES + LOGICAL_CAPACITY as u64 * CullOutputBuffers::RECORD_BYTES;
+    let tail_len = (PHYSICAL_CAPACITY - LOGICAL_CAPACITY) as u64 * CullOutputBuffers::RECORD_BYTES;
+    const CANARY_PATTERN: u32 = 0xCAFE_BABE;
+    let canary_bytes: Vec<u8> =
+        std::iter::repeat_n(CANARY_PATTERN.to_le_bytes(), (tail_len / 4) as usize).flatten().collect();
+    assert_eq!(canary_bytes.len() as u64, tail_len, "sanity: canary fills the whole tail exactly");
+    queue.write_buffer(output.buffer(), tail_offset, &canary_bytes);
+
+    let output_bind_group = cull_pass.build_output_bind_group(device, &view_tokens, &output);
+    let uniforms = CullUniforms {
+        view_proj: view_proj_90deg(),
+        planes: frustum_planes_90deg(),
+        count: view_tokens.count(),
+        mesh_count: meshes.len(),
+        // THE decoupling this test exists to exercise: the shader is told a
+        // bound smaller than both the fixture's demand AND the buffer's
+        // real physical size.
+        capacity: LOGICAL_CAPACITY,
+        reserved: 0,
+    };
+    cull_pass.write_uniforms(queue, &uniforms);
+
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull_pass.record(&mut encoder, &scene_binding.cull_bind_group, &output_bind_group, view_tokens.count());
+        queue.submit([encoder.finish()]);
+    }
+
+    let out_bytes = readback(&ctx, output.buffer(), output.byte_size());
+    let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+    let i32_at = |off: usize| i32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+
+    let visible_count = u32_at(0);
+    let stale_drops = u32_at(4);
+    let oob_drops = u32_at(8);
+    let frustum_drops = u32_at(12);
+
+    // --- Self-verifying guards (house law): this fixture is designed to
+    // exercise ONLY the overflow category -- everything else must read
+    // exactly zero, or the demand/capacity arithmetic below is not testing
+    // what it claims to. ---
+    assert_eq!(stale_drops, 0, "fixture has no stale-generation row");
+    assert_eq!(oob_drops, 0, "fixture has no out-of-range mesh_index row");
+    assert_eq!(frustum_drops, 0, "fixture has no frustum-culled row -- every instance sits well inside the frustum");
+
+    // (1) The atomic counter reads back GREATER than capacity: the shader
+    // keeps counting true demand even past the bound.
+    assert_eq!(visible_count, DEMAND, "the atomic must count the FULL true demand, not just what fit");
+    assert!(
+        visible_count > LOGICAL_CAPACITY,
+        "guard: this fixture must genuinely oversubscribe the command buffer (visible_count={visible_count} \
+         must exceed LOGICAL_CAPACITY={LOGICAL_CAPACITY})"
+    );
+
+    // (2) Exactly `capacity` command records were written -- collect the
+    // LOGICAL_CAPACITY slots and verify each is a real, distinct, valid
+    // draw command (S14.1 shape) rather than assuming which of the 10 rows
+    // won the atomic race (GPU thread scheduling order is not guaranteed).
+    let mut written_rows: HashSet<u32> = HashSet::new();
+    for slot in 0..LOGICAL_CAPACITY {
+        let off = CullOutputBuffers::HEADER_BYTES as usize + slot as usize * CullOutputBuffers::RECORD_BYTES as usize;
+        let index_count = u32_at(off);
+        let instance_count = u32_at(off + 4);
+        let rec_first_index = u32_at(off + 8);
+        let rec_base_vertex = i32_at(off + 12);
+        let rec_first_instance = u32_at(off + 16);
+        let row = u32_at(off + 20);
+        assert_eq!(instance_count, 1, "slot {slot}: S14.1 instance_count always 1");
+        assert_eq!(rec_first_instance, slot, "slot {slot}: S14.1 first_instance == command slot (C5)");
+        assert_eq!(index_count, QUAD_INDICES.len() as u32, "slot {slot}: valid command, mesh0's index_count");
+        assert_eq!(rec_first_index, first_index, "slot {slot}: valid command, mesh0's index_offset");
+        assert_eq!(rec_base_vertex, base_vertex, "slot {slot}: valid command, mesh0's base_vertex");
+        assert!(row < DEMAND, "slot {slot}: row {row} must be one of the fixture's real rows (0..{DEMAND})");
+        assert!(written_rows.insert(row), "slot {slot}: duplicate row {row} across command slots -- lost a slot");
+    }
+    assert_eq!(
+        written_rows.len() as u32,
+        LOGICAL_CAPACITY,
+        "exactly LOGICAL_CAPACITY distinct rows must have received a command"
+    );
+
+    // (3) The region beyond capacity is untouched: the canary planted above
+    // must survive byte-for-byte. A shader that wrote past the logical
+    // bound (e.g. comparing against the buffer's physical extent instead of
+    // `cull_uniforms.capacity`) would corrupt this.
+    let tail_after = &out_bytes[tail_offset as usize..(tail_offset + tail_len) as usize];
+    assert_eq!(
+        tail_after,
+        canary_bytes.as_slice(),
+        "canary corrupted -- the shader wrote past the LOGICAL capacity bound into buffer space \
+         only the PHYSICAL allocation made addressable"
+    );
+
+    // (4) The CPU-side clamp path: `min(count, capacity)` against the SAME
+    // logical bound the shader enforced (NOT `output.capacity()`, which is
+    // the physical size -- a driver that clamped against the physical size
+    // here would issue draw calls reading slots the shader never wrote).
+    let command_count = visible_count.min(LOGICAL_CAPACITY);
+    assert_eq!(command_count, LOGICAL_CAPACITY, "the clamp must yield a usable, in-bounds draw count");
+
+    // (5) Report the silent-drop count.
+    let silent_drops = visible_count - command_count;
+    assert_eq!(silent_drops, DEMAND - LOGICAL_CAPACITY, "silent_drops == true demand minus what the clamp kept");
+    println!(
+        "Test 5 overflow clamp: demand={DEMAND} logical_capacity={LOGICAL_CAPACITY} \
+         physical_capacity={PHYSICAL_CAPACITY} silent_drops={silent_drops}"
+    );
+
+    // --- Then DRAW with the clamped count: this is what actually proves
+    // the clamp makes overflow SAFE, not merely counted. Wrap the encode +
+    // submit in a validation error scope -- a real wgpu OOB/validation
+    // failure would otherwise either panic (uncaptured-error default
+    // handler) or, worse, pass silently on a backend that tolerates it; the
+    // error scope makes the absence of an error an explicit, checked
+    // assertion instead of "the test process didn't crash". ---
+    let draw_executor = DrawExecutor::new(device, &scene_binding.cull_layout);
+    let draw_output_bind_group = draw_executor.build_output_bind_group(device, &output);
+    draw_executor.write_uniforms(queue, &DrawUniforms { view_proj: view_proj_90deg() });
+    let target = OffscreenTarget::new(device, "overflow-clamp-target");
+
+    let error_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        draw_executor.record(
+            &mut encoder,
+            target.view(),
+            &scene_binding.cull_bind_group,
+            &draw_output_bind_group,
+            &output,
+            arena.vertex_buffer(),
+            arena.index_buffer(),
+            command_count,
+        );
+        queue.submit([encoder.finish()]);
+    }
+    device.poll(wgpu::PollType::wait_indefinitely()).expect("poll");
+    let validation_error = pollster::block_on(error_scope.pop());
+    assert!(
+        validation_error.is_none(),
+        "the clamped draw ({command_count} commands, out of a {PHYSICAL_CAPACITY}-record physical buffer) \
+         must not raise a validation error -- that is what 'the clamp makes overflow safe' means \
+         concretely; got: {validation_error:?}"
+    );
+
+    // Self-verifying non-vacuity guard (house law): the clamped draw must
+    // actually paint pixels -- an empty/no-op frame would satisfy the
+    // no-validation-error assertion above vacuously.
+    let pixels = target.read_pixels(device, queue);
+    let mesh0_color = mesh_color_rgba8(0);
+    let painted = pixels
+        .chunks_exact(4)
+        .filter(|px| px[0] == mesh0_color[0] && px[1] == mesh0_color[1] && px[2] == mesh0_color[2])
+        .count();
+    assert!(painted > 0, "guard: the clamped draw must paint at least one pixel of mesh0's color");
+}

--- a/crates/helio-scenedb/tests/renderer_teardown.rs
+++ b/crates/helio-scenedb/tests/renderer_teardown.rs
@@ -1,0 +1,962 @@
+//! Test 13 (design §5's exact assertion set, CONTRACTS.md C0's binding
+//! acceptance criterion, M3-b T8 -- THE MILESTONE GATE): stateless renderer
+//! teardown. This is the test that turns the Ownership Law from a sentence
+//! in CONTRACTS.md into an executable assertion: build a scene through
+//! SceneDB, construct renderer-side objects (`SceneDbBinding` + `CullPass` +
+//! `DrawExecutor`, plus the Helio-owned derived scratch that goes with them
+//! -- `CullOutputBuffers`/`OffscreenTarget`) as instance A, render N frames,
+//! **drop A entirely**, construct a fresh instance B against the SAME
+//! `SceneGpuStore` and asset registries, render N more frames, and prove:
+//! zero scene-data re-upload happened anywhere in that whole window, every
+//! scene SSBO and the device survived, and the two renderer instances
+//! produce byte-identical output despite being genuinely different GPU
+//! objects.
+//!
+//! ## Assertion-by-assertion mapping to design §5's exact list
+//!
+//! | # | Design §5 wording | This test's mechanism |
+//! |---|---|---|
+//! | a | Σ`SyncStats.bytes` == 0 across the window | every frame in the window runs a REAL `BoundaryPhase::run` (retire/compact/sync) with NO writes queued; each call's `SyncStats.bytes` is summed and the total asserted zero at the end -- not "we skipped calling it" |
+//! | b | Δ`generation_write_count` == 0 | captured before the window, asserted equal after. SCOPE (M3-b T8 review, defect 1 -- what this assertion does NOT prove): `write_generation` is shadow-gated (`scene_store.rs`), so once a row's tenant is stable it is STRUCTURALLY impossible for ordinary mirrored writes to move this counter at all -- only slot retirement/reuse can. Δ==0 is true and is sufficient for THIS test's claim (a teardown must not re-stamp generations), but it is a narrower statement than "zero generation writes of any kind occurred". The before-window nonzero guard below exists precisely because of this: it needs a throwaway allocate-then-retire instance to make the counter move at all. |
+//! | c | ALL six asset-store upload counters unchanged | `MeshRegistry`/`ClusterBuffer`/`MeshletBuffer`/`MaterialRegistry`/`TextureStore`/`GeometryArena`.`upload_count()`, each captured before the window and asserted equal at 3 checkpoints (after A's frames, after A drops + B constructs, after B's frames) |
+//! | d | streaming frozen (or counted separately) | `StreamingGrid::write_cell_metadata` is never called anywhere in this test -- frozen, not counted; see the module-level note below |
+//! | e | G-buffer hash byte-identical, jitter/TAA caveat stated | A's final frame and B's converged frame are compared BYTE-FOR-BYTE (strictly stronger than a hash: no collision risk) with an FNV-1a hash also computed and printed for the report; this harness has no TAA/jitter/Halton-phase state at all, so the comparison is trivially stable -- stated honestly below, not oversold as jitter-proof |
+//! | f | device + every scene SSBO alive, buffer IDs unchanged | `wgpu::Buffer`/`wgpu::Device` implement `PartialEq`/`Clone` in wgpu 30 proxied to the underlying resource id (confirmed: no `.global_id()` in this wgpu version, `cmp::impl_eq_ord_hash_proxy!` on `Buffer`/`Device` is the sanctioned mechanism) -- every SceneDB-owned buffer accessor's handle is cloned before the window and compared equal after |
+//!
+//! ## The `write_cell_metadata` decision (honesty note, design §5's stated trap)
+//!
+//! `StreamingGrid::write_cell_metadata` is, by design, an unconditional full
+//! rewrite on every call (`grid.rs`'s own doc: "Simple full rewrite of every
+//! materialized entry's 8 bytes on every call") with its own upload counter
+//! that increments unconditionally, no dirty-gating. This test does not
+//! construct a `StreamingGrid` at all and never calls it -- streaming is
+//! FROZEN for the window, the simpler of the two options design §5 offers
+//! ("freeze streaming for the window, or count it separately"). This is a
+//! sound scope choice for M3 (design's own carve-out: "M3 scopes to
+//! non-voxel, non-streaming scenes" is the spirit of the gate at this
+//! milestone), not a claim that streaming-driven cell-metadata churn is
+//! compatible with the zero-reupload story -- that is out of scope here and
+//! recorded as such.
+//!
+//! ## Scope note: which objects are "A"/"B" vs. which persist
+//!
+//! Per CONTRACTS C0, `SceneGpuStore`, `MeshRegistry`, `ClusterBuffer`,
+//! `MeshletBuffer`, `MaterialRegistry`, `TextureStore`, `GeometryArena`, and
+//! `ViewTokenBuffers` are all SceneDB-owned (scene object data / its
+//! per-view harvest products) -- they are built ONCE, before the window,
+//! and never touched again until the test's own final assertions. Only the
+//! Helio-owned derived data -- `SceneDbBinding` (the read-only bind groups
+//! over those SceneDB buffers), `CullPass`/`DrawExecutor` (pipelines),
+//! `CullOutputBuffers` (draw-command scratch), and `OffscreenTarget`
+//! (framebuffer) -- is torn down and rebuilt across the A/B boundary. This
+//! matches the design's own framing precisely (`lib.rs`'s module doc: "Helio
+//! owns no scene state... pipelines, shaders, Hi-Z, framebuffers,
+//! draw-command and payload scratch").
+
+#[path = "support/mod.rs"]
+mod support;
+
+use helio_scenedb::cull::{CullOutputBuffers, CullPass, CullUniforms};
+use helio_scenedb::draw::{mesh_color_rgba8, DrawExecutor, DrawUniforms, OffscreenTarget};
+use helio_scenedb::SceneDbRenderSource;
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, EngineGpuContext, FrameDriver, GeometryArena, HarvestPipeline,
+    HarvestStaging, MaterialRegistry, MaterialRow, MeshClass, MeshRegistry, MeshletBuffer,
+    MeshletEntry, SceneGpuStore, TextureStore, View, ViewTokenBuffers,
+};
+use pulsar_scenedb::{Aabb, InstanceInfo, Scratchpad, SpatialCell};
+
+use support::{
+    frustum_planes_90deg, mesh, readback, scene_cfg, test_context_indirect_first_instance,
+    translation, view_proj_90deg,
+};
+
+/// Local-space unit quad -- identical fixture geometry to `draw_transform_
+/// sweep.rs`/`overflow_clamp.rs`.
+const QUAD_VERTICES: [[f32; 3]; 4] = [
+    [-0.5, -0.5, 0.0],
+    [0.5, -0.5, 0.0],
+    [0.5, 0.5, 0.0],
+    [-0.5, 0.5, 0.0],
+];
+const QUAD_INDICES: [u32; 6] = [0, 1, 2, 0, 2, 3];
+
+/// Frames rendered by EACH of executor A and executor B (design: "N ≥ 3").
+const N_FRAMES: u32 = 4;
+/// Cull-output physical capacity -- generous headroom over this fixture's 2
+/// instances; overflow is `overflow_clamp.rs`'s job, not this test's.
+const CULL_CAPACITY: u32 = 8;
+
+/// Non-cryptographic FNV-1a over the raw pixel bytes -- used ONLY to print a
+/// compact, comparable value for the report table. The actual pass/fail
+/// assertion below compares the full byte buffers directly (strictly
+/// stronger than any hash: zero collision risk), so this hash is reporting
+/// sugar, not the proof.
+fn fnv1a_hash(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01B3);
+    }
+    h
+}
+
+/// One frame's worth of cull-dispatch + indirect-draw + readback, run
+/// against whichever renderer instance (A or B) owns the passed-in
+/// pipelines/bind-groups/scratch buffers. Returns the cull telemetry
+/// (visible/stale/oob/frustum) and the rendered target's raw RGBA8 bytes.
+/// Shared by both the A-loop and the B-loop below -- the SAME function,
+/// proving neither loop gets any special-cased behavior.
+#[allow(clippy::too_many_arguments)]
+fn render_one_frame(
+    ctx: &EngineGpuContext,
+    cull: &CullPass,
+    cull_bind_group: &wgpu::BindGroup,
+    cull_output_bg: &wgpu::BindGroup,
+    output: &CullOutputBuffers,
+    draw: &DrawExecutor,
+    draw_output_bg: &wgpu::BindGroup,
+    target: &OffscreenTarget,
+    vertex_buffer: &wgpu::Buffer,
+    index_buffer: &wgpu::Buffer,
+    dispatch_count: u32,
+) -> (u32, u32, u32, u32, Vec<u8>) {
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue: &wgpu::Queue = ctx.queue().as_ref();
+
+    output.clear_counters(queue);
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        cull.record(
+            &mut encoder,
+            cull_bind_group,
+            cull_output_bg,
+            dispatch_count,
+        );
+        queue.submit([encoder.finish()]);
+    }
+    let out_bytes = readback(ctx, output.buffer(), output.byte_size());
+    let u32_at = |off: usize| u32::from_le_bytes(out_bytes[off..off + 4].try_into().unwrap());
+    let visible = u32_at(0);
+    let stale = u32_at(4);
+    let oob = u32_at(8);
+    let frustum = u32_at(12);
+    let command_count = visible.min(output.capacity());
+
+    {
+        let mut encoder = device.create_command_encoder(&Default::default());
+        draw.record(
+            &mut encoder,
+            target.view(),
+            cull_bind_group,
+            draw_output_bg,
+            output,
+            vertex_buffer,
+            index_buffer,
+            command_count,
+        );
+        queue.submit([encoder.finish()]);
+    }
+    let pixels = target.read_pixels(device, queue);
+    (visible, stale, oob, frustum, pixels)
+}
+
+#[test]
+fn stateless_renderer_teardown_zero_reupload_identical_hash_ssbos_alive() {
+    let ctx = test_context_indirect_first_instance();
+    let device: &wgpu::Device = ctx.device().as_ref();
+    let queue: &wgpu::Queue = ctx.queue().as_ref();
+
+    // =====================================================================
+    // Scene build (BEFORE the window): two static instances, different
+    // meshes/colors so the "did it really render" guard can look for both.
+    // Every SceneDB-owned store used below is constructed exactly once and
+    // never rebuilt -- this whole block is the "one real upload" the
+    // post-window zero-reupload assertions get to be meaningful against.
+    // =====================================================================
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = SpatialCell::with_transform(64).unwrap();
+    let h_a = cell
+        .alloc(Aabb {
+            min: [-1.0, -1.0, -11.0],
+            max: [1.0, 1.0, -9.0],
+        })
+        .unwrap();
+    let h_b = cell
+        .alloc(Aabb {
+            min: [2.0, -1.0, -11.0],
+            max: [4.0, 1.0, -9.0],
+        })
+        .unwrap();
+
+    let id = store.register_cell(cell.storage(), 0).unwrap();
+    let base = store.row_region_base(id);
+    assert_eq!(base, 0, "single cell, class-0 region base 0");
+
+    let mut frames = FrameDriver::new();
+    let sim0 = frames.begin();
+    assert!(store.write_transform(
+        id,
+        cell.storage_mut(),
+        h_a,
+        &translation([0.0, 0.0, -10.0]),
+        &sim0
+    ));
+    assert!(store.write_transform(
+        id,
+        cell.storage_mut(),
+        h_b,
+        &translation([3.0, 0.0, -10.0]),
+        &sim0
+    ));
+    assert!(store.write_instance_info(
+        id,
+        cell.storage_mut(),
+        h_a,
+        InstanceInfo {
+            mesh_index: 0,
+            flags: 0
+        },
+        &sim0
+    ));
+    assert!(store.write_instance_info(
+        id,
+        cell.storage_mut(),
+        h_b,
+        InstanceInfo {
+            mesh_index: 1,
+            flags: 0
+        },
+        &sim0
+    ));
+
+    let harvest_phase = sim0.end().end();
+    let pipeline = HarvestPipeline::new();
+    let mut pad = Scratchpad::new();
+    let mut staging = HarvestStaging::new();
+    let view = View::Aabb(Aabb {
+        min: [-200.0, -200.0, -200.0],
+        max: [200.0, 200.0, 200.0],
+    });
+    let n = pipeline.harvest_cell(
+        &cell,
+        base,
+        MeshClass::Traditional,
+        &view,
+        &mut pad,
+        &mut staging,
+        &harvest_phase,
+    );
+    assert_eq!(n, 2, "sanity: both rows harvested");
+
+    let boundary0 = harvest_phase.end();
+    let initial_sync = {
+        let mut slots = [CellSlot {
+            id,
+            cell: cell.storage_mut(),
+        }];
+        boundary0.run(&mut store, &mut slots)
+    };
+    assert!(
+        initial_sync.bytes > 0,
+        "sanity: the one real scene upload must actually move bytes"
+    );
+
+    // --- A THIRD, throwaway instance: allocated as the cell's LAST row,
+    // freed via the deferred-retire path, and drained by a second
+    // pre-window boundary. This is the ONLY way `generation_write_count`
+    // becomes genuinely non-zero: `register_cell`'s bulk generation upload
+    // (the write at `scene_store.rs`'s `rebuild_region` call) seeds
+    // `gen_shadow` from the freshly-registered rows' OWN generations, so
+    // `write_transform`'s shadow-gated stamp is a no-op for h_a/h_b (their
+    // very first write already agrees with what registration already
+    // shadowed) -- confirmed empirically: without this block, `generation_
+    // write_count()` reads 0 even after the real writes above, which would
+    // make the "counters must be non-zero before the window" house-law
+    // guard below vacuous for this one counter. Retirement is documented as
+    // the OTHER trigger (`write_transform`'s own doc: "a generation reaches
+    // VRAM on the first write after alloc and on retirement"), so freeing a
+    // fresh handle exercises it directly. Allocated as the LAST row and
+    // freed before ever being harvested/uploaded -- swap-and-pop
+    // compaction of the last row is a no-op, so this cannot renumber h_a's
+    // or h_b's rows out from under the harvest/ViewTokenBuffers state
+    // captured below. ---
+    let sim_throwaway = frames.begin();
+    let h_throwaway = cell
+        .alloc(Aabb {
+            min: [50.0, 50.0, 50.0],
+            max: [51.0, 51.0, 51.0],
+        })
+        .unwrap();
+    let throwaway_serial = store.tracker().next_serial();
+    assert!(store.free_deferred(
+        id,
+        cell.storage_mut(),
+        h_throwaway,
+        throwaway_serial,
+        &sim_throwaway
+    ));
+    store.tracker().force_complete(throwaway_serial);
+    let boundary_throwaway = sim_throwaway.end().end().end();
+    {
+        let mut slots = [CellSlot {
+            id,
+            cell: cell.storage_mut(),
+        }];
+        boundary_throwaway.run(&mut store, &mut slots);
+    }
+    assert!(
+        store.generation_write_count() > 0,
+        "sanity: retiring the throwaway handle must stamp its bumped generation to VRAM"
+    );
+
+    let mut view_tokens = ViewTokenBuffers::new(&ctx, "teardown-view", 0);
+    view_tokens.upload(&ctx, &staging, MeshClass::Traditional);
+    assert_eq!(view_tokens.count(), 2);
+
+    let mut arena = GeometryArena::new(&ctx, 4096, 4096);
+    let vbytes: &[u8] = bytemuck::cast_slice(&QUAD_VERTICES);
+    let ibytes: &[u8] = bytemuck::cast_slice(&QUAD_INDICES);
+    let voff = arena.upload_vertices(queue, vbytes).unwrap();
+    let ioff = arena.upload_indices(queue, ibytes).unwrap();
+    let base_vertex = (voff / 12) as i32;
+    let first_index = ioff / 4;
+
+    let mut meshes = MeshRegistry::new(&ctx, 4);
+    let mesh0 = meshes
+        .register(
+            queue,
+            mesh(
+                [0.0, 0.0, 0.0],
+                [0.5, 0.5, 0.05],
+                QUAD_INDICES.len() as u32,
+                first_index,
+                base_vertex,
+            ),
+        )
+        .unwrap();
+    let mesh1 = meshes
+        .register(
+            queue,
+            mesh(
+                [0.0, 0.0, 0.0],
+                [0.5, 0.5, 0.05],
+                QUAD_INDICES.len() as u32,
+                first_index,
+                base_vertex,
+            ),
+        )
+        .unwrap();
+    assert_eq!(
+        (mesh0, mesh1),
+        (0, 1),
+        "sanity: mesh_index values match the InstanceInfo rows above"
+    );
+
+    // ClusterBuffer's constructor already performs one real upload (the
+    // reserved sentinel node, `assets.rs`'s own doc) -- no `append` call
+    // needed for its baseline to be non-zero.
+    let clusters = ClusterBuffer::new(&ctx, 2);
+
+    // MeshletBuffer's constructor does NOT write anything (module doc: entry
+    // 0 is an ordinary allocatable record, no sentinel) -- append exactly
+    // one valid entry so its baseline is genuinely non-zero, matching the
+    // "counters must be non-zero BEFORE the window" house-law guard below.
+    let mut meshlets = MeshletBuffer::new(&ctx, 4);
+    meshlets
+        .append(
+            queue,
+            &[MeshletEntry {
+                sphere_x: 0.0,
+                sphere_y: 0.0,
+                sphere_z: 0.0,
+                sphere_radius: 1.0,
+                cone_packed: 0,
+                data_offset: 0,
+                counts_packed: (1u32 << 8) | 1u32, // vertex_count=1, triangle_count=1
+                reserved: 0,
+            }],
+        )
+        .unwrap();
+
+    let mut materials = MaterialRegistry::new(&ctx, 2);
+    materials
+        .register(
+            queue,
+            MaterialRow {
+                base_color: 0xFFFF_FFFF,
+                metallic: 0.5,
+                roughness: 0.5,
+                normal_scale: 1.0,
+                emissive_r: 0.0,
+                emissive_g: 0.0,
+                emissive_b: 0.0,
+                emissive_intensity: 0.0,
+                tex_albedo: 0xFFFF_FFFF,
+                tex_normal: 0xFFFF_FFFF,
+                tex_metallic_roughness: 0xFFFF_FFFF,
+                tex_emissive: 0xFFFF_FFFF,
+                radiant_graph_index: 0xFFFF_FFFF,
+                flags: 0,
+                alpha_cutoff: 1.0,
+                reserved: 0,
+            },
+        )
+        .unwrap();
+
+    let mut textures = TextureStore::new(4);
+    textures
+        .register(
+            device,
+            queue,
+            &wgpu::TextureDescriptor {
+                label: Some("teardown-texture"),
+                size: wgpu::Extent3d {
+                    width: 1,
+                    height: 1,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format: wgpu::TextureFormat::Rgba8Unorm,
+                usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+                view_formats: &[],
+            },
+            &[255u8, 255, 255, 255],
+        )
+        .unwrap();
+
+    // --- House-law guard: every counter this test claims stays flat across
+    // the window must actually be NON-ZERO right now -- otherwise "unchanged"
+    // would be a vacuous truth (a counter that starts and stays at 0 proves
+    // nothing about re-upload avoidance). ---
+    let gen_writes_baseline = store.generation_write_count();
+    let mesh_uploads_baseline = meshes.upload_count();
+    let cluster_uploads_baseline = clusters.upload_count();
+    let meshlet_uploads_baseline = meshlets.upload_count();
+    let material_uploads_baseline = materials.upload_count();
+    let texture_uploads_baseline = textures.upload_count();
+    let geometry_uploads_baseline = arena.upload_count();
+    assert!(
+        gen_writes_baseline > 0,
+        "guard: generation_write_count must be non-zero before the window"
+    );
+    assert!(
+        mesh_uploads_baseline > 0,
+        "guard: MeshRegistry.upload_count must be non-zero before the window"
+    );
+    assert!(
+        cluster_uploads_baseline > 0,
+        "guard: ClusterBuffer.upload_count must be non-zero before the window"
+    );
+    assert!(
+        meshlet_uploads_baseline > 0,
+        "guard: MeshletBuffer.upload_count must be non-zero before the window"
+    );
+    assert!(
+        material_uploads_baseline > 0,
+        "guard: MaterialRegistry.upload_count must be non-zero before the window"
+    );
+    assert!(
+        texture_uploads_baseline > 0,
+        "guard: TextureStore.upload_count must be non-zero before the window"
+    );
+    assert!(
+        geometry_uploads_baseline > 0,
+        "guard: GeometryArena.upload_count must be non-zero before the window"
+    );
+
+    // Scene SSBO + device identity, captured before the window (assertion f).
+    let device_ptr_before = std::sync::Arc::as_ptr(ctx.device());
+    let transform_buf_before = store.transform_buffer().clone();
+    let instance_info_buf_before = store.instance_info_buffer().clone();
+    let slot_mirror_buf_before = store.slot_mirror_buffer().clone();
+    let generation_buf_before = store.generation_buffer().clone();
+    let cell_meta_buf_before = store.cell_metadata_buffer().clone();
+    let mesh_buf_before = meshes.buffer().clone();
+    let cluster_buf_before = clusters.buffer().clone();
+    let meshlet_buf_before = meshlets.buffer().clone();
+    let material_buf_before = materials.buffer().clone();
+    let vertex_buf_before = arena.vertex_buffer().clone();
+    let index_buf_before = arena.index_buffer().clone();
+
+    let mesh0_color = mesh_color_rgba8(0);
+    let mesh1_color = mesh_color_rgba8(1);
+    assert_ne!(
+        mesh0_color, mesh1_color,
+        "guard: the two meshes' derived colors must differ"
+    );
+
+    // =====================================================================
+    // THE WINDOW starts here: everything from this point until B's last
+    // frame must move zero scene-data bytes.
+    // =====================================================================
+    let mut total_sync_bytes: u64 = 0;
+
+    // --- Construct executor A: SceneDbRenderSource + CullPass + DrawExecutor,
+    // plus the Helio-owned derived scratch that goes with a renderer
+    // instance (CullOutputBuffers, OffscreenTarget). ---
+    let a_source = SceneDbRenderSource::new(
+        device, &store, &meshes, &clusters, &meshlets, &materials, &arena,
+    );
+    let a_cull = CullPass::new(device, &a_source.binding().cull_layout);
+    let a_output = CullOutputBuffers::new(device, "teardown-a-output", CULL_CAPACITY);
+    let a_cull_bg = a_cull.build_output_bind_group(device, &view_tokens, &a_output);
+    a_cull.write_uniforms(
+        queue,
+        &CullUniforms {
+            view_proj: view_proj_90deg(),
+            planes: frustum_planes_90deg(),
+            count: view_tokens.count(),
+            mesh_count: meshes.len(),
+            capacity: a_output.capacity(),
+            reserved: 0,
+        },
+    );
+    let a_draw = DrawExecutor::new(device, &a_source.binding().cull_layout);
+    let a_draw_bg = a_draw.build_output_bind_group(device, &a_output);
+    a_draw.write_uniforms(
+        queue,
+        &DrawUniforms {
+            view_proj: view_proj_90deg(),
+        },
+    );
+    let a_target = OffscreenTarget::new(device, "teardown-a-target");
+
+    // Identity snapshots of A's Helio-owned derived objects -- held ONLY for
+    // the "A and B are genuinely distinct" guard below, captured before A is
+    // dropped (cloning a wgpu handle bumps its own internal refcount but
+    // does not keep the SCENE buffers alive -- those were never part of A).
+    let a_cull_bind_group_id = a_source.binding().cull_bind_group.clone();
+    let a_draw_bind_group_id = a_source.binding().draw_bind_group.clone();
+    let a_output_buffer_id = a_output.buffer().clone();
+    let a_target_view_id = a_target.view().clone();
+
+    let mut a_final_pixels: Vec<u8> = Vec::new();
+    for frame_i in 0..N_FRAMES {
+        // Zero-write frame boundary: a REAL BoundaryPhase::run, no
+        // write_transform/write_instance_info/free_deferred queued at all
+        // this frame -- proves the mechanism itself is a no-op when nothing
+        // changed, rather than the test simply never calling it.
+        let sim = frames.begin();
+        let harvest = sim.end().end();
+        let boundary = harvest.end();
+        let stats = {
+            let mut slots = [CellSlot {
+                id,
+                cell: cell.storage_mut(),
+            }];
+            boundary.run(&mut store, &mut slots)
+        };
+        assert_eq!(
+            stats.bytes, 0,
+            "A frame {frame_i}: zero-write boundary must sync zero bytes"
+        );
+        assert_eq!(
+            stats.ranges, 0,
+            "A frame {frame_i}: zero-write boundary must touch zero ranges"
+        );
+        total_sync_bytes += stats.bytes;
+
+        let mut frame_resources = libhelio::FrameResources::empty();
+        frame_resources
+            .scene_db
+            .write(a_source.frame_resources(), "Renderer");
+        let published = frame_resources
+            .scene_db
+            .get()
+            .expect("attached SceneDB source must be published");
+        let (visible, stale, oob, frustum, pixels) = render_one_frame(
+            &ctx,
+            &a_cull,
+            published.cull_bind_group,
+            &a_cull_bg,
+            &a_output,
+            &a_draw,
+            &a_draw_bg,
+            &a_target,
+            published.vertex_buffer,
+            published.index_buffer,
+            view_tokens.count(),
+        );
+        assert_eq!(stale, 0, "A frame {frame_i}: no stale row in this fixture");
+        assert_eq!(oob, 0, "A frame {frame_i}: no OOB row in this fixture");
+        assert_eq!(
+            frustum, 0,
+            "A frame {frame_i}: both rows stay inside the frustum"
+        );
+        assert_eq!(
+            visible, 2,
+            "A frame {frame_i}: both instances visible every frame"
+        );
+        a_final_pixels = pixels;
+    }
+
+    // --- Checkpoint 1: after A's N frames, before dropping anything. ---
+    assert_eq!(
+        store.generation_write_count(),
+        gen_writes_baseline,
+        "after A's frames: generation_write_count moved"
+    );
+    assert_eq!(
+        meshes.upload_count(),
+        mesh_uploads_baseline,
+        "after A's frames: MeshRegistry re-uploaded"
+    );
+    assert_eq!(
+        clusters.upload_count(),
+        cluster_uploads_baseline,
+        "after A's frames: ClusterBuffer re-uploaded"
+    );
+    assert_eq!(
+        meshlets.upload_count(),
+        meshlet_uploads_baseline,
+        "after A's frames: MeshletBuffer re-uploaded"
+    );
+    assert_eq!(
+        materials.upload_count(),
+        material_uploads_baseline,
+        "after A's frames: MaterialRegistry re-uploaded"
+    );
+    assert_eq!(
+        textures.upload_count(),
+        texture_uploads_baseline,
+        "after A's frames: TextureStore re-uploaded"
+    );
+    assert_eq!(
+        arena.upload_count(),
+        geometry_uploads_baseline,
+        "after A's frames: GeometryArena re-uploaded"
+    );
+
+    // =====================================================================
+    // DROP A ENTIRELY -- explicit, one object at a time, so the compiler
+    // (not just a scope-exit convention) is the proof: any later reference
+    // to these bindings is a compile error, not just "went out of scope".
+    // =====================================================================
+    drop(a_cull_bg);
+    drop(a_draw_bg);
+    drop(a_output);
+    drop(a_target);
+    drop(a_cull);
+    drop(a_draw);
+    drop(a_source);
+
+    // --- Construct executor B: fresh SceneDbRenderSource + CullPass +
+    // DrawExecutor + derived scratch, against the SAME store/meshes/
+    // clusters/meshlets/materials/view_tokens/arena -- none of which were
+    // touched by the drop above. ---
+    let b_source = SceneDbRenderSource::new(
+        device, &store, &meshes, &clusters, &meshlets, &materials, &arena,
+    );
+    let b_cull = CullPass::new(device, &b_source.binding().cull_layout);
+    let b_output = CullOutputBuffers::new(device, "teardown-b-output", CULL_CAPACITY);
+    let b_cull_bg = b_cull.build_output_bind_group(device, &view_tokens, &b_output);
+    b_cull.write_uniforms(
+        queue,
+        &CullUniforms {
+            view_proj: view_proj_90deg(),
+            planes: frustum_planes_90deg(),
+            count: view_tokens.count(),
+            mesh_count: meshes.len(),
+            capacity: b_output.capacity(),
+            reserved: 0,
+        },
+    );
+    let b_draw = DrawExecutor::new(device, &b_source.binding().cull_layout);
+    let b_draw_bg = b_draw.build_output_bind_group(device, &b_output);
+    b_draw.write_uniforms(
+        queue,
+        &DrawUniforms {
+            view_proj: view_proj_90deg(),
+        },
+    );
+    let b_target = OffscreenTarget::new(device, "teardown-b-target");
+
+    // --- Guard (e): A and B must be genuinely distinct objects. Every
+    // Helio-owned derived object B just built is a FRESH wgpu allocation
+    // (SceneDbBinding::new/CullOutputBuffers::new/OffscreenTarget::new never
+    // cache or reuse) -- wgpu::BindGroup/Buffer/TextureView all proxy
+    // PartialEq to the underlying resource id (wgpu 30's `cmp::impl_eq_
+    // ord_hash_proxy!`), so this is a real identity check, not a
+    // by-construction tautology. ---
+    assert_ne!(
+        a_cull_bind_group_id,
+        b_source.binding().cull_bind_group,
+        "guard: B's cull bind group must differ from A's"
+    );
+    assert_ne!(
+        a_draw_bind_group_id,
+        b_source.binding().draw_bind_group,
+        "guard: B's draw bind group must differ from A's"
+    );
+    assert_ne!(
+        &a_output_buffer_id,
+        b_output.buffer(),
+        "guard: B's cull-output buffer must differ from A's"
+    );
+    assert_ne!(
+        &a_target_view_id,
+        b_target.view(),
+        "guard: B's offscreen target view must differ from A's"
+    );
+
+    // --- Checkpoint 2: immediately after drop(A) + construct(B), before B
+    // renders a single frame. ---
+    assert_eq!(
+        store.generation_write_count(),
+        gen_writes_baseline,
+        "after drop(A)+construct(B): generation_write_count moved"
+    );
+    assert_eq!(
+        meshes.upload_count(),
+        mesh_uploads_baseline,
+        "after drop(A)+construct(B): MeshRegistry re-uploaded"
+    );
+    assert_eq!(
+        clusters.upload_count(),
+        cluster_uploads_baseline,
+        "after drop(A)+construct(B): ClusterBuffer re-uploaded"
+    );
+    assert_eq!(
+        meshlets.upload_count(),
+        meshlet_uploads_baseline,
+        "after drop(A)+construct(B): MeshletBuffer re-uploaded"
+    );
+    assert_eq!(
+        materials.upload_count(),
+        material_uploads_baseline,
+        "after drop(A)+construct(B): MaterialRegistry re-uploaded"
+    );
+    assert_eq!(
+        textures.upload_count(),
+        texture_uploads_baseline,
+        "after drop(A)+construct(B): TextureStore re-uploaded"
+    );
+    assert_eq!(
+        arena.upload_count(),
+        geometry_uploads_baseline,
+        "after drop(A)+construct(B): GeometryArena re-uploaded"
+    );
+
+    let mut b_converged_pixels: Vec<u8> = Vec::new();
+    for frame_i in 0..N_FRAMES {
+        let sim = frames.begin();
+        let harvest = sim.end().end();
+        let boundary = harvest.end();
+        let stats = {
+            let mut slots = [CellSlot {
+                id,
+                cell: cell.storage_mut(),
+            }];
+            boundary.run(&mut store, &mut slots)
+        };
+        assert_eq!(
+            stats.bytes, 0,
+            "B frame {frame_i}: zero-write boundary must sync zero bytes"
+        );
+        assert_eq!(
+            stats.ranges, 0,
+            "B frame {frame_i}: zero-write boundary must touch zero ranges"
+        );
+        total_sync_bytes += stats.bytes;
+
+        let mut frame_resources = libhelio::FrameResources::empty();
+        frame_resources
+            .scene_db
+            .write(b_source.frame_resources(), "Renderer");
+        let published = frame_resources
+            .scene_db
+            .get()
+            .expect("attached SceneDB source must be published");
+        let (visible, stale, oob, frustum, pixels) = render_one_frame(
+            &ctx,
+            &b_cull,
+            published.cull_bind_group,
+            &b_cull_bg,
+            &b_output,
+            &b_draw,
+            &b_draw_bg,
+            &b_target,
+            published.vertex_buffer,
+            published.index_buffer,
+            view_tokens.count(),
+        );
+        assert_eq!(stale, 0, "B frame {frame_i}: no stale row in this fixture");
+        assert_eq!(oob, 0, "B frame {frame_i}: no OOB row in this fixture");
+        assert_eq!(
+            frustum, 0,
+            "B frame {frame_i}: both rows stay inside the frustum"
+        );
+        assert_eq!(
+            visible, 2,
+            "B frame {frame_i}: both instances visible every frame"
+        );
+        b_converged_pixels = pixels;
+    }
+
+    // =====================================================================
+    // THE WINDOW ends here (after B's last frame). Final assertions:
+    // =====================================================================
+
+    // (a) Σ SyncStats.bytes == 0 across the ENTIRE window (A's frames + B's
+    // frames combined, one running total, never reset).
+    assert_eq!(
+        total_sync_bytes, 0,
+        "assertion (a): total SyncStats.bytes across the whole window must be zero"
+    );
+
+    // (b) Δ generation_write_count == 0.
+    let gen_writes_after = store.generation_write_count();
+    assert_eq!(
+        gen_writes_after, gen_writes_baseline,
+        "assertion (b): generation_write_count moved across the window"
+    );
+
+    // (c) ALL SIX asset-store upload counters unchanged.
+    assert_eq!(
+        meshes.upload_count(),
+        mesh_uploads_baseline,
+        "assertion (c): MeshRegistry re-uploaded across the window"
+    );
+    assert_eq!(
+        clusters.upload_count(),
+        cluster_uploads_baseline,
+        "assertion (c): ClusterBuffer re-uploaded across the window"
+    );
+    assert_eq!(
+        meshlets.upload_count(),
+        meshlet_uploads_baseline,
+        "assertion (c): MeshletBuffer re-uploaded across the window"
+    );
+    assert_eq!(
+        materials.upload_count(),
+        material_uploads_baseline,
+        "assertion (c): MaterialRegistry re-uploaded across the window"
+    );
+    assert_eq!(
+        textures.upload_count(),
+        texture_uploads_baseline,
+        "assertion (c): TextureStore re-uploaded across the window"
+    );
+    assert_eq!(
+        arena.upload_count(),
+        geometry_uploads_baseline,
+        "assertion (c): GeometryArena re-uploaded across the window"
+    );
+
+    // (d) streaming: StreamingGrid::write_cell_metadata was never called in
+    // this test at all -- frozen for the window, per the module doc's
+    // decision. Nothing to assert beyond "it was never invoked", which is
+    // true by inspection of this file (no `StreamingGrid` import exists
+    // here at all).
+
+    // Self-verifying non-vacuity guard (house law): the window must
+    // actually have RENDERED something in both halves -- a pair of blank
+    // frames would satisfy a byte-identity comparison vacuously.
+    let a_has_mesh0 = a_final_pixels
+        .chunks_exact(4)
+        .any(|px| px[0] == mesh0_color[0] && px[1] == mesh0_color[1] && px[2] == mesh0_color[2]);
+    let a_has_mesh1 = a_final_pixels
+        .chunks_exact(4)
+        .any(|px| px[0] == mesh1_color[0] && px[1] == mesh1_color[1] && px[2] == mesh1_color[2]);
+    let b_has_mesh0 = b_converged_pixels
+        .chunks_exact(4)
+        .any(|px| px[0] == mesh0_color[0] && px[1] == mesh0_color[1] && px[2] == mesh0_color[2]);
+    let b_has_mesh1 = b_converged_pixels
+        .chunks_exact(4)
+        .any(|px| px[0] == mesh1_color[0] && px[1] == mesh1_color[1] && px[2] == mesh1_color[2]);
+    assert!(a_has_mesh0 && a_has_mesh1, "guard: A's final frame must paint BOTH mesh colors -- a blank frame would pass byte-identity vacuously");
+    assert!(b_has_mesh0 && b_has_mesh1, "guard: B's converged frame must paint BOTH mesh colors -- a blank frame would pass byte-identity vacuously");
+
+    // (e) A-final and B-converged target hashes byte-identical. This
+    // harness has NO TAA, NO jitter, NO Halton-phase/frame_count-driven
+    // state anywhere in the cull/draw path -- so this comparison is
+    // trivially stable (the design's own stated caveat: a jitter-driven
+    // renderer would need frame_count/jitter-phase reset accounted for,
+    // which does not exist here to get wrong). Compared byte-for-byte
+    // (strictly stronger than a hash), with the hash also computed and
+    // printed for the report.
+    let a_hash = fnv1a_hash(&a_final_pixels);
+    let b_hash = fnv1a_hash(&b_converged_pixels);
+    println!("Test 13: A-final target hash = {a_hash:#018x}, B-converged target hash = {b_hash:#018x} (no TAA/jitter in this harness)");
+    assert_eq!(
+        a_final_pixels.len(),
+        b_converged_pixels.len(),
+        "assertion (e): A/B target byte-length mismatch"
+    );
+    assert_eq!(
+        a_final_pixels, b_converged_pixels,
+        "assertion (e): A-final and B-converged frames must be byte-identical"
+    );
+    assert_eq!(
+        a_hash, b_hash,
+        "assertion (e): A/B hashes must agree (implied by the byte-identity check above)"
+    );
+
+    // (f) Device + every scene SSBO alive throughout, buffer IDs unchanged.
+    // `wgpu::Buffer`/`wgpu::Device` have no `.global_id()` in wgpu 30; their
+    // `PartialEq`/`Clone` impls (proxied to the underlying resource id) are
+    // the sanctioned identity-comparison mechanism instead.
+    assert_eq!(
+        std::sync::Arc::as_ptr(ctx.device()),
+        device_ptr_before,
+        "assertion (f): device pointer changed across the window"
+    );
+    assert_eq!(
+        store.transform_buffer(),
+        &transform_buf_before,
+        "assertion (f): transform buffer identity changed"
+    );
+    assert_eq!(
+        store.instance_info_buffer(),
+        &instance_info_buf_before,
+        "assertion (f): instance_info buffer identity changed"
+    );
+    assert_eq!(
+        store.slot_mirror_buffer(),
+        &slot_mirror_buf_before,
+        "assertion (f): slot_mirror buffer identity changed"
+    );
+    assert_eq!(
+        store.generation_buffer(),
+        &generation_buf_before,
+        "assertion (f): generation buffer identity changed"
+    );
+    assert_eq!(
+        store.cell_metadata_buffer(),
+        &cell_meta_buf_before,
+        "assertion (f): cell_metadata buffer identity changed"
+    );
+    assert_eq!(
+        meshes.buffer(),
+        &mesh_buf_before,
+        "assertion (f): MeshRegistry buffer identity changed"
+    );
+    assert_eq!(
+        clusters.buffer(),
+        &cluster_buf_before,
+        "assertion (f): ClusterBuffer buffer identity changed"
+    );
+    assert_eq!(
+        meshlets.buffer(),
+        &meshlet_buf_before,
+        "assertion (f): MeshletBuffer buffer identity changed"
+    );
+    assert_eq!(
+        materials.buffer(),
+        &material_buf_before,
+        "assertion (f): MaterialRegistry buffer identity changed"
+    );
+    assert_eq!(
+        arena.vertex_buffer(),
+        &vertex_buf_before,
+        "assertion (f): GeometryArena vertex buffer identity changed"
+    );
+    assert_eq!(
+        arena.index_buffer(),
+        &index_buf_before,
+        "assertion (f): GeometryArena index buffer identity changed"
+    );
+}

--- a/crates/helio-scenedb/tests/seam_smoke.rs
+++ b/crates/helio-scenedb/tests/seam_smoke.rs
@@ -1,0 +1,306 @@
+//! The seam proof (M3-a T9, design Rev 2 S5; two-group split M3-b T4,
+//! contract #47): build a real `SceneGpuStore` + one cell through SceneDB's
+//! public write/boundary API (mirrors `pulsar_scenedb/tests/gpu_store.rs`'s
+//! `test_context`/boundary-driving pattern), construct a `SceneDbBinding`
+//! over it, and run a small Helio-owned compute shader -- built from
+//! `SCENE_BINDINGS_WGSL` itself, the ACTUAL seam WGSL, not a stand-in -- that
+//! copies `instances[0]` and `instance_info[0]` (both `@group(0)`, the
+//! cull-read set) into Helio-owned output buffers at `@group(2)`. Readback
+//! must equal the values written on the CPU side, byte-exact.
+//!
+//! ## This is the smoke test that #47 closes (M3-b T4)
+//!
+//! This test's own compute pipeline only ever reads `@group(0)` (`instances`
+//! / `instance_info`, both COMPUTE-visible, 5 entries total including the 3
+//! it doesn't touch) plus its own 2 output buffers at `@group(2)` -- **7
+//! COMPUTE-visible storage buffers, under the WebGPU default 8**. It also
+//! binds `@group(1)` (the draw/material set) at pipeline-layout index 1 so
+//! the shader module's `@group(1)` declarations (present because it embeds
+//! the FULL `SCENE_BINDINGS_WGSL`, not just the cull half) type-check and
+//! the pipeline layout is positionally valid -- but every `@group(1)` entry
+//! is `VERTEX_FRAGMENT`-only (see `SceneDbBinding`'s doc comment), so it
+//! contributes ZERO to the compute stage's count. The test therefore does
+//! NOT need to construct a vertex/fragment pipeline to prove #47's closure;
+//! it only needs the compute stage's arithmetic to fit, which it now does
+//! under `wgpu::Limits::default()` -- no `adapter.limits()` workaround.
+//!
+//! ## This test IS the wgpu-major version lock
+//!
+//! `helio-scenedb`'s `Cargo.toml` declares `wgpu = { workspace = true }`
+//! (Helio's crates.io wgpu 30) alongside `pulsar_scenedb`'s own
+//! `gpu`-feature `wgpu = "30"` dep -- two independent `Cargo.lock` entries
+//! that happen to share a major version. Nothing at dependency-resolution
+//! time enforces that they stay in lockstep. What enforces it is this file:
+//! [`SceneDbBinding::new`] takes a `&pulsar_scenedb::gpu::SceneGpuStore`
+//! whose buffer accessors (`transform_buffer()`, etc.) return
+//! `&wgpu::Buffer` values built from `pulsar_scenedb`'s wgpu-30 `Device`,
+//! and this test feeds those straight into Helio-namespaced
+//! `wgpu::BindGroupLayout`/`wgpu::BindGroup`/`wgpu::ComputePipeline`
+//! construction. If the two `wgpu` deps ever diverged to different majors,
+//! `wgpu::Buffer`/`wgpu::Device`/`wgpu::Queue`/etc. would become DIFFERENT,
+//! non-unifiable Rust types across the crate boundary, and this file would
+//! fail to COMPILE (type mismatch at every `store.*_buffer()` call site and
+//! every `as_entire_binding()`/bind-group construction below) -- long before
+//! any runtime assertion could catch it. There is no separate runtime
+//! version-lock check anywhere in this crate; this smoke test compiling and
+//! passing IS the lock.
+
+use helio_scenedb::{wgsl::SCENE_BINDINGS_WGSL, SceneDbBinding};
+use pulsar_scenedb::gpu::{
+    CellSlot, ClusterBuffer, EngineGpuContext, FrameDriver, MaterialRegistry, MeshRegistry,
+    MeshletBuffer, RegionClassConfig, SceneGpuConfig, SceneGpuStore,
+};
+use pulsar_scenedb::{CellStorage, CellType, InstanceInfo, TypeToken};
+use std::sync::Arc;
+
+/// Mirrors `pulsar_scenedb/tests/gpu_store.rs::test_context` (same
+/// upstream-wgpu-30 API forms: `InstanceDescriptor::new_without_display_
+/// handle()`, `apply_limit_buckets`, `PollType::wait_indefinitely()`,
+/// `get_mapped_range()` returning a `Result`) -- this crate cannot import
+/// that test helper across a crate boundary, so it is reproduced here
+/// rather than approximated.
+///
+/// ## M3-b T4: `wgpu::Limits::default()`, not `adapter.limits()` (closes #47)
+///
+/// M3-a's version of this helper requested `adapter.limits()` because the
+/// single 9-entry `@group(0)` plus this test's own 2 output buffers put 11
+/// storage buffers into the COMPUTE stage — over the WebGPU default budget
+/// (`Limits::default().max_storage_buffers_per_shader_stage == 8`). After
+/// the M3-b T4 group split (`SceneDbBinding`'s doc comment has the full
+/// arithmetic), this test's compute pipeline only binds `@group(0)`'s 5
+/// COMPUTE-visible entries (`@group(1)`'s draw/material entries are
+/// `VERTEX_FRAGMENT`-only and don't count here) plus its own 2 output
+/// buffers — **7 ≤ 8**, so the conservative WebGPU-portable default now
+/// actually works, and the `adapter.limits()` workaround is gone. This
+/// assertion — that this test now runs under the SAME limits a browser
+/// target would enforce — is the literal content of #47's closure.
+fn test_context() -> EngineGpuContext {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+        apply_limit_buckets: false,
+    }))
+    .expect("no adapter — GPU tests need a local GPU");
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("helio-scenedb-seam-smoke"),
+        required_limits: wgpu::Limits::default(),
+        ..Default::default()
+    }))
+    .expect("device");
+    EngineGpuContext::new(Arc::new(device), Arc::new(queue))
+}
+
+fn readback(ctx: &EngineGpuContext, buf: &wgpu::Buffer, bytes: u64) -> Vec<u8> {
+    let staging = ctx.device().create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: bytes,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut enc = ctx.device().create_command_encoder(&Default::default());
+    enc.copy_buffer_to_buffer(buf, 0, &staging, 0, bytes);
+    ctx.queue().submit([enc.finish()]);
+    let slice = staging.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |r| r.expect("map"));
+    ctx.device().poll(wgpu::PollType::wait_indefinitely()).expect("poll");
+    let data = slice.get_mapped_range().expect("mapped range").to_vec();
+    staging.unmap();
+    data
+}
+
+fn mat(seed: f32) -> [f32; 16] {
+    core::array::from_fn(|i| seed + i as f32)
+}
+
+/// A `CellType`-based cell carrying both the `[f32; 16]` transform column
+/// and the `InstanceInfo` column, mirroring `gpu_store.rs::transform_info_
+/// cell`.
+fn transform_info_cell(capacity: u32) -> CellStorage {
+    let ct = CellType::new("helio-seam-smoke")
+        .with(TypeToken::of::<[f32; 16]>())
+        .with(TypeToken::of::<InstanceInfo>())
+        .build()
+        .unwrap();
+    CellStorage::from_cell_type(&ct, capacity).unwrap()
+}
+
+fn scene_cfg() -> SceneGpuConfig {
+    SceneGpuConfig {
+        classes: vec![RegionClassConfig { capacity: 64, max_resident_cells: 4 }],
+        tombstone_headroom: 8,
+        max_cells_metadata: 16,
+    }
+}
+
+#[test]
+fn seam_smoke_shader_reads_scenedb_buffers_byte_exact() {
+    let ctx = test_context();
+    let device: &wgpu::Device = ctx.device().as_ref();
+
+    // --- Build a real SceneGpuStore + one cell, through SceneDB's public
+    // write/boundary API (mirrors tests/gpu_store.rs's pattern exactly:
+    // register_cell -> alloc -> write_transform/write_instance_info ->
+    // drive the compile-time phase machine's Simulate->Harvest->Boundary
+    // chain by value). ---
+    let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+    let mut cell = transform_info_cell(64);
+    let id = store.register_cell(&cell, 0).unwrap();
+    let mut frames = FrameDriver::new();
+    let sim = frames.begin();
+    let h = cell.alloc().unwrap();
+    let transform = mat(9.0);
+    let info = InstanceInfo { mesh_index: 7, flags: 1 };
+    assert!(store.write_transform(id, &mut cell, h, &transform, &sim));
+    assert!(store.write_instance_info(id, &mut cell, h, info, &sim));
+    {
+        let mut slots = [CellSlot { id, cell: &mut cell }];
+        // retire -> compact -> sync: the only boundary path available
+        // outside pulsar_scenedb (retire_all/compact_all/sync_all are
+        // pub(crate)).
+        sim.end().end().end().run(&mut store, &mut slots);
+    }
+    let row = cell.row_of(h).unwrap() as usize;
+    let base = store.row_region_base(id) as usize;
+    assert_eq!(base + row, 0, "single cell, single alloc, class-0 region base 0 — row 0 for a clean index below");
+
+    // --- The asset-side stores SceneDbBinding also binds. Empty registries
+    // are fine here — the smoke test proves the wiring (byte-exact transfer
+    // through the bind group), not asset content; those get their own byte-
+    // exact coverage in pulsar_scenedb's own gpu_assets suite. ---
+    let meshes = MeshRegistry::new(&ctx, 1);
+    let clusters = ClusterBuffer::new(&ctx, 1);
+    let meshlets = MeshletBuffer::new(&ctx, 1);
+    let materials = MaterialRegistry::new(&ctx, 1);
+
+    // --- The seam itself (two groups, M3-b T4). ---
+    let binding = SceneDbBinding::new(device, &store, &meshes, &clusters, &meshlets, &materials);
+
+    // --- A Helio-owned compute shader, built from the ACTUAL seam WGSL
+    // (SCENE_BINDINGS_WGSL, both groups) plus a 4-line entry point copying
+    // instances[0] and instance_info[0] (@group(0), the cull-read set) into
+    // Helio-owned output storage buffers at @group(2) -- @group(1), the
+    // draw/material set, is declared by SCENE_BINDINGS_WGSL but untouched
+    // by main() below, per this file's module doc. ---
+    let shader_src = format!(
+        "{SCENE_BINDINGS_WGSL}\n{}",
+        r#"
+@group(2) @binding(0) var<storage, read_write> out_transform: array<mat4x4<f32>>;
+@group(2) @binding(1) var<storage, read_write> out_info: array<InstanceInfo>;
+
+@compute @workgroup_size(1)
+fn main() {
+    out_transform[0] = instances[0].transform;
+    out_info[0] = instance_info[0];
+}
+"#
+    );
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("seam-smoke-shader"),
+        source: wgpu::ShaderSource::Wgsl(shader_src.into()),
+    });
+
+    let out_transform_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("out-transform"),
+        size: 64,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let out_info_buf = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("out-info"),
+        size: 8,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let out_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+        label: Some("out-layout"),
+        entries: &[
+            wgpu::BindGroupLayoutEntry {
+                binding: 0,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+            wgpu::BindGroupLayoutEntry {
+                binding: 1,
+                visibility: wgpu::ShaderStages::COMPUTE,
+                ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ],
+    });
+    let out_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("out-bind-group"),
+        layout: &out_layout,
+        entries: &[
+            wgpu::BindGroupEntry { binding: 0, resource: out_transform_buf.as_entire_binding() },
+            wgpu::BindGroupEntry { binding: 1, resource: out_info_buf.as_entire_binding() },
+        ],
+    });
+
+    let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("seam-smoke-pipeline-layout"),
+        // group 0 = cull-read set (what main() actually reads), group 1 =
+        // draw/material set (declared by SCENE_BINDINGS_WGSL, unused by
+        // main(), bound only so the pipeline layout is positionally valid
+        // -- contributes 0 storage buffers to the COMPUTE stage's count,
+        // see this file's module doc), group 2 = this test's own outputs.
+        bind_group_layouts: &[
+            Some(&binding.cull_layout),
+            Some(&binding.draw_layout),
+            Some(&out_layout),
+        ],
+        immediate_size: 0,
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: Some("seam-smoke-pipeline"),
+        layout: Some(&pipeline_layout),
+        module: &shader,
+        entry_point: Some("main"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+
+    let mut encoder = device.create_command_encoder(&Default::default());
+    {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor::default());
+        pass.set_pipeline(&pipeline);
+        pass.set_bind_group(0, &binding.cull_bind_group, &[]);
+        pass.set_bind_group(1, &binding.draw_bind_group, &[]);
+        pass.set_bind_group(2, &out_bind_group, &[]);
+        pass.dispatch_workgroups(1, 1, 1);
+    }
+    ctx.queue().submit([encoder.finish()]);
+
+    // --- Readback: Helio-owned staging buffers, mirroring gpu_store.rs's
+    // `readback` helper. ---
+    let transform_bytes = readback(&ctx, &out_transform_buf, 64);
+    let info_bytes = readback(&ctx, &out_info_buf, 8);
+
+    let got_transform: Vec<f32> = transform_bytes
+        .chunks_exact(4)
+        .map(|c| f32::from_le_bytes(c.try_into().unwrap()))
+        .collect();
+    assert_eq!(
+        got_transform,
+        transform.to_vec(),
+        "shader-read instances[0].transform == the CPU transform written via write_transform"
+    );
+
+    let got_mesh_index = u32::from_le_bytes(info_bytes[0..4].try_into().unwrap());
+    let got_flags = u32::from_le_bytes(info_bytes[4..8].try_into().unwrap());
+    assert_eq!(
+        (got_mesh_index, got_flags),
+        (info.mesh_index, info.flags),
+        "shader-read instance_info[0] == the CPU InstanceInfo written via write_instance_info"
+    );
+}

--- a/crates/helio-scenedb/tests/support/mod.rs
+++ b/crates/helio-scenedb/tests/support/mod.rs
@@ -1,0 +1,511 @@
+//! Shared test-only support for the `helio-scenedb` cull-pass suite (M3-b
+//! T5/T6): the headless device bootstrap, the byte readback helper, the
+//! scene config, the `MeshMetadata` builder, and — new in T6 — small
+//! column-major matrix helpers plus an INDEPENDENT CPU reference
+//! implementation of the cull term list (design §4/§11/§12), used by both
+//! `tests/cull_equality.rs` (M3-b T6 deliverable 3) and `tests/cull_pass.rs`
+//! (M3-b T6 deliverable 4, the rotation regression pin).
+//!
+//! Lives at `tests/support/mod.rs` (a subdirectory, not a top-level
+//! `tests/*.rs` file) so cargo does NOT compile it as its own standalone
+//! integration-test binary — every consumer pulls it in via
+//! `#[path = "support/mod.rs"] mod support;`, the standard Rust idiom for
+//! sharing code between integration tests without a separate crate.
+//!
+//! ## The CPU reference's independence (M3-b T6 deliverable 3's explicit
+//! requirement: "written INDEPENDENTLY from the WGSL — do not transliterate
+//! the shader")
+//!
+//! [`cpu_cull_token`] below is derived directly from the design spec's own
+//! prose (§3.1 generation validation, the M3-α T4 mesh-bounds note, §11's
+//! `|M_3x3|` world-AABB formula, §12's W<=0 near-plane bypass, and the
+//! `n.p+d>=0` frustum-plane convention `spatial::Frustum` already
+//! documents) — not copied or mechanically adapted from `CULL_WGSL`'s WGSL
+//! text in `wgsl.rs`. It necessarily performs the SAME algorithm (that is
+//! the point of an equality oracle), but every line here was written by
+//! reading the spec sections, not the shader source.
+#![allow(dead_code)]
+
+use pulsar_scenedb::gpu::{EngineGpuContext, MeshMetadata};
+use pulsar_scenedb::gpu::{RegionClassConfig, SceneGpuConfig};
+use pulsar_scenedb::InstanceInfo;
+
+// ---------------------------------------------------------------------
+// Device bootstrap + readback (kept verbatim from `cull_pass.rs`'s M3-b T5
+// helpers so every T6 test file gets the identical headless harness).
+// ---------------------------------------------------------------------
+
+pub fn test_context() -> EngineGpuContext {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+        apply_limit_buckets: false,
+    }))
+    .expect("no adapter — GPU tests need a local GPU");
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("helio-scenedb-cull-support-test"),
+        // M3-b T4's point: this seam fits under WebGPU-portable default
+        // limits — no `adapter.limits()` workaround needed anywhere in T6.
+        required_limits: wgpu::Limits::default(),
+        ..Default::default()
+    }))
+    .expect("device");
+    EngineGpuContext::new(std::sync::Arc::new(device), std::sync::Arc::new(queue))
+}
+
+/// [`test_context`] plus `wgpu::Features::INDIRECT_FIRST_INSTANCE` (M3-b T7
+/// finding, `draw.rs`'s module doc + the M3-b T7 report have the full
+/// story): per wgpu-types 30's own doc on `DrawIndexedIndirectArgs::
+/// first_instance`, "Has to be 0, unless `Features::INDIRECT_FIRST_
+/// INSTANCE` is enabled" -- WITHOUT it, a nonzero `first_instance` in an
+/// indirect draw call is backend-defined behavior, and this stack's actual
+/// observed behavior (both the Vulkan and the platform-default backend,
+/// empirically) is to execute the draw AS IF `first_instance` were zero
+/// (silently, no validation error) -- which breaks design S14.1's
+/// `first_instance == command slot` bindless-lookup-key contract outright
+/// (every indirect draw's `@builtin(instance_index)` would read record 0,
+/// no matter which slot the draw call's args actually named). This is
+/// WIDELY supported on desktop GPUs (Vulkan/DX12/Metal all expose the
+/// underlying capability; the WebGPU spec merely gates it behind an opt-in
+/// feature) -- kept as a SEPARATE context constructor from [`test_context`]
+/// (rather than folding into it) so the cull-only suites keep proving the
+/// seam fits under the true baseline `wgpu::Limits::default()`-plus-
+/// zero-extra-features envelope T4 established, while T7's draw tests
+/// request exactly the one additional capability their own S14.1 usage
+/// genuinely requires -- and no more (`wgpu::Limits::default()` unchanged).
+pub fn test_context_indirect_first_instance() -> EngineGpuContext {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+        apply_limit_buckets: false,
+    }))
+    .expect("no adapter — GPU tests need a local GPU");
+    assert!(
+        adapter
+            .features()
+            .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE),
+        "this adapter does not support Features::INDIRECT_FIRST_INSTANCE -- the M3-b T7 draw \
+         executor's S14.1 first_instance-as-slot-key contract needs it; see this function's doc"
+    );
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("helio-scenedb-draw-support-test"),
+        required_features: wgpu::Features::INDIRECT_FIRST_INSTANCE,
+        required_limits: wgpu::Limits::default(),
+        ..Default::default()
+    }))
+    .expect("device");
+    EngineGpuContext::new(std::sync::Arc::new(device), std::sync::Arc::new(queue))
+}
+
+pub fn readback(ctx: &EngineGpuContext, buf: &wgpu::Buffer, bytes: u64) -> Vec<u8> {
+    let staging = ctx.device().create_buffer(&wgpu::BufferDescriptor {
+        label: Some("readback"),
+        size: bytes,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let mut enc = ctx.device().create_command_encoder(&Default::default());
+    enc.copy_buffer_to_buffer(buf, 0, &staging, 0, bytes);
+    ctx.queue().submit([enc.finish()]);
+    let slice = staging.slice(..);
+    slice.map_async(wgpu::MapMode::Read, |r| r.expect("map"));
+    ctx.device()
+        .poll(wgpu::PollType::wait_indefinitely())
+        .expect("poll");
+    let data = slice.get_mapped_range().expect("mapped range").to_vec();
+    staging.unmap();
+    data
+}
+
+pub fn scene_cfg() -> SceneGpuConfig {
+    SceneGpuConfig {
+        classes: vec![RegionClassConfig {
+            capacity: 256,
+            max_resident_cells: 4,
+        }],
+        tombstone_headroom: 8,
+        max_cells_metadata: 16,
+    }
+}
+
+pub fn mesh(
+    center: [f32; 3],
+    extents: [f32; 3],
+    index_count: u32,
+    index_offset: u32,
+    base_vertex: i32,
+) -> MeshMetadata {
+    MeshMetadata {
+        vertex_offset: 0,
+        index_offset,
+        index_count,
+        base_vertex,
+        material_index: 0,
+        lod_count: 1, // C5 XOR rule: traditional mesh, no cluster table
+        lod_distances: [0.0; 4],
+        local_aabb_center: center,
+        cluster_table_offset: 0,
+        local_aabb_extents: extents,
+        meshlet_count: 0,
+    }
+}
+
+// ---------------------------------------------------------------------
+// M3-b T6: column-major matrix helpers (the pinned convention — see
+// `pulsar_scenedb::page`'s `Pod for [f32; 16]` doc comment: `array[4*col +
+// row] = M[row][col]`, i.e. `to_cols_array()`, no transpose).
+// ---------------------------------------------------------------------
+
+pub fn mat3_rot_x(deg: f32) -> [[f32; 3]; 3] {
+    let (s, c) = deg.to_radians().sin_cos();
+    [[1.0, 0.0, 0.0], [0.0, c, -s], [0.0, s, c]]
+}
+
+pub fn mat3_rot_z(deg: f32) -> [[f32; 3]; 3] {
+    let (s, c) = deg.to_radians().sin_cos();
+    [[c, -s, 0.0], [s, c, 0.0], [0.0, 0.0, 1.0]]
+}
+
+pub fn mat3_mul(a: [[f32; 3]; 3], b: [[f32; 3]; 3]) -> [[f32; 3]; 3] {
+    let mut r = [[0.0f32; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            let mut s = 0.0;
+            for k in 0..3 {
+                s += a[i][k] * b[k][j];
+            }
+            r[i][j] = s;
+        }
+    }
+    r
+}
+
+pub fn mat3_transpose(a: [[f32; 3]; 3]) -> [[f32; 3]; 3] {
+    let mut r = [[0.0f32; 3]; 3];
+    for i in 0..3 {
+        for j in 0..3 {
+            r[i][j] = a[j][i];
+        }
+    }
+    r
+}
+
+/// Design §11's `|M_3x3|` operator applied directly to a 3x3 (elementwise
+/// abs, standard matrix-vector product) — NOT restricted to matrices that
+/// came from a 4x4; used both by [`cpu_cull_token`] (on the 4x4's
+/// upper-left block) and directly by the rotation-regression fixture in
+/// `cull_pass.rs` (on the bare rotation matrix, to compute BOTH the correct
+/// and the deliberately-wrong-transposed extents for the self-verifying
+/// guard).
+pub fn mat3_abs_mul_vec3(m: [[f32; 3]; 3], v: [f32; 3]) -> [f32; 3] {
+    let mut r = [0.0f32; 3];
+    for i in 0..3 {
+        r[i] = m[i][0].abs() * v[0] + m[i][1].abs() * v[1] + m[i][2].abs() * v[2];
+    }
+    r
+}
+
+/// Column-major-flat `mat4x4<f32>` (16 `f32`s) built from a 3x3 rotation
+/// `r` (standard `r[row][col]` indexing) and a translation `t` — the
+/// pinned M3-β T5-review convention (`array[4*col+row] = M[row][col]`, no
+/// transpose). This is the "correct" writer; the equivalent WRONG
+/// (transposed) writer used only by the regression fixture's guard swaps
+/// `row`/`col` on the rotation block.
+pub fn flatten_column_major(r: [[f32; 3]; 3], t: [f32; 3]) -> [f32; 16] {
+    let mut flat = [0.0f32; 16];
+    for col in 0..3 {
+        for row in 0..3 {
+            flat[4 * col + row] = r[row][col];
+        }
+    }
+    flat[12] = t[0];
+    flat[13] = t[1];
+    flat[14] = t[2];
+    flat[15] = 1.0;
+    flat
+}
+
+/// Column-major-flat pure translation (no rotation) — kept here so every
+/// T6 test file that wants a plain translate can share one implementation.
+pub fn translation(t: [f32; 3]) -> [f32; 16] {
+    flatten_column_major([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]], t)
+}
+
+/// Symmetric perspective projection, fovy=90deg, aspect=1 (`view_proj_
+/// 90deg`'s exact geometry from `cull_pass.rs` M3-b T5, reproduced here so
+/// T6's new files share ONE definition rather than three hand-copies).
+/// Column-major-flat, matching WGSL's `mat4x4<f32>` load convention.
+pub fn view_proj_90deg() -> [f32; 16] {
+    let near = 1.0_f32;
+    let far = 100.0_f32;
+    let a = far / (near - far);
+    let b = (near * far) / (near - far);
+    #[rustfmt::skip]
+    let m = [
+        1.0, 0.0, 0.0, 0.0,
+        0.0, 1.0, 0.0, 0.0,
+        0.0, 0.0, a, -1.0,
+        0.0, 0.0, b, 0.0,
+    ];
+    m
+}
+
+/// The 6 inward-normal (`n.p+d>=0` == inside) world-space planes of
+/// [`view_proj_90deg`]'s frustum, independently derived from the fovy=90/
+/// aspect=1/near=1/far=100 geometry (NOT extracted from the matrix) —
+/// identical to `cull_pass.rs`'s own `frustum_planes_90deg`.
+pub fn frustum_planes_90deg() -> [[f32; 4]; 6] {
+    [
+        [1.0, 0.0, -1.0, 0.0],  // left:   x - z >= 0
+        [-1.0, 0.0, -1.0, 0.0], // right: -x - z >= 0
+        [0.0, 1.0, -1.0, 0.0],  // bottom: y - z >= 0
+        [0.0, -1.0, -1.0, 0.0], // top:   -y - z >= 0
+        [0.0, 0.0, -1.0, -1.0], // near:  -z - 1 >= 0  (z <= -1)
+        [0.0, 0.0, 1.0, 100.0], // far:    z + 100 >= 0 (z >= -100)
+    ]
+}
+
+// ---------------------------------------------------------------------
+// M3-b T6: a tiny seedable PRNG (splitmix64) — no `rand` dependency exists
+// in this crate's `Cargo.toml`, and the equality test's ONLY requirement
+// is a deterministic, printable seed, not cryptographic quality.
+// ---------------------------------------------------------------------
+
+pub struct Rng(u64);
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng(seed)
+    }
+
+    pub fn next_u64(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.0;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform `f32` in `[0, 1)`.
+    pub fn next_f32(&mut self) -> f32 {
+        ((self.next_u64() >> 40) as f32) / ((1u64 << 24) as f32)
+    }
+
+    pub fn range_f32(&mut self, lo: f32, hi: f32) -> f32 {
+        lo + self.next_f32() * (hi - lo)
+    }
+
+    /// Uniform `u32` in `[0, bound)`. `bound` must be nonzero.
+    pub fn next_u32(&mut self, bound: u32) -> u32 {
+        (self.next_u64() % bound as u64) as u32
+    }
+
+    pub fn chance(&mut self, probability: f32) -> bool {
+        self.next_f32() < probability
+    }
+}
+
+// ---------------------------------------------------------------------
+// M3-b T6 deliverable 3: the independent CPU reference cull implementation.
+// ---------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum CpuDecision {
+    Stale,
+    Oob,
+    FrustumCulled,
+    Visible { near_clip: bool },
+}
+
+/// Row-indexed / mesh-indexed input snapshot the CPU reference reads —
+/// plain host-side `Vec`s / slices, deliberately NOT `wgpu::Buffer`s (this
+/// oracle never touches the device; the equality test constructs BOTH this
+/// struct and the real GPU upload from the SAME host-side values, then
+/// compares the two independently-computed outputs).
+pub struct CpuCullInputs<'a> {
+    pub tokens: &'a [u32],
+    pub expected_gens: &'a [u32],
+    pub slot_mirror: &'a [u32],
+    pub generations: &'a [u32],
+    pub instance_info: &'a [InstanceInfo],
+    pub instances: &'a [[f32; 16]],
+    pub mesh_table: &'a [MeshMetadata],
+    pub mesh_count: u32,
+    pub view_proj: [f32; 16],
+    pub planes: [[f32; 4]; 6],
+}
+
+/// `M * (p, 1)`, taking only the xyz result — column-major-flat `m`, the
+/// pinned convention (`mat4_upper3x3`/this function agree on the same flat
+/// layout `flatten_column_major` writes).
+pub fn mat4_mul_point(m: &[f32; 16], p: [f32; 3]) -> [f32; 3] {
+    let mut out = [0.0f32; 3];
+    for row in 0..3 {
+        let mut s = m[4 * 3 + row]; // translation column (col 3) times w=1
+        for col in 0..3 {
+            s += m[4 * col + row] * p[col];
+        }
+        out[row] = s;
+    }
+    out
+}
+
+/// Full `M * v` for a homogeneous `v` (used for the §12 corner-projection
+/// through the view-proj matrix — needs the resulting `w`, so `mat4_mul_
+/// point`'s xyz-only shortcut doesn't apply here).
+pub fn mat4_mul_vec4(m: &[f32; 16], v: [f32; 4]) -> [f32; 4] {
+    let mut out = [0.0f32; 4];
+    for row in 0..4 {
+        let mut s = 0.0;
+        for col in 0..4 {
+            s += m[4 * col + row] * v[col];
+        }
+        out[row] = s;
+    }
+    out
+}
+
+/// The upper-left 3x3 rotation/scale block of a column-major-flat 4x4,
+/// as a `[[f32;3];3]` in standard `[row][col]` indexing.
+pub fn mat4_upper3x3(m: &[f32; 16]) -> [[f32; 3]; 3] {
+    let mut r = [[0.0f32; 3]; 3];
+    for col in 0..3 {
+        for row in 0..3 {
+            r[row][col] = m[4 * col + row];
+        }
+    }
+    r
+}
+
+/// The `n.p+d>=0` == inside convention (`spatial::Frustum`'s own
+/// convention, per `wgsl.rs`'s module doc): true unless the box is
+/// ENTIRELY on the outside of `plane`.
+pub fn plane_test(center: [f32; 3], extents: [f32; 3], plane: [f32; 4]) -> bool {
+    let r = extents[0] * plane[0].abs() + extents[1] * plane[1].abs() + extents[2] * plane[2].abs();
+    let d = plane[0] * center[0] + plane[1] * center[1] + plane[2] * center[2] + plane[3];
+    d >= -r
+}
+
+/// The design §4 β term list, for ONE token index `i` into `inputs.tokens`:
+/// count-guard is the caller's loop bound (not modeled here — every `i` in
+/// `0..inputs.tokens.len()` is presumed already within the dispatch count);
+/// §3.1 generation validation -> mesh_index bounds check (M3-α T4) -> §11
+/// `|M_3x3|` world AABB -> §12 W<=0 near-clip bypass -> frustum planes.
+/// Returns `(row, decision)`.
+pub fn cpu_cull_token(inputs: &CpuCullInputs, i: usize) -> (u32, CpuDecision) {
+    let row = inputs.tokens[i];
+    let slot = inputs.slot_mirror[row as usize];
+    let live_gen = inputs.generations[slot as usize];
+    if live_gen != inputs.expected_gens[i] {
+        return (row, CpuDecision::Stale);
+    }
+
+    let mesh_index = inputs.instance_info[row as usize].mesh_index;
+    if mesh_index >= inputs.mesh_count {
+        return (row, CpuDecision::Oob);
+    }
+
+    let mesh = &inputs.mesh_table[mesh_index as usize];
+    let m = &inputs.instances[row as usize];
+    // GROUND TRUTH, not the shader's shortcut (M3-β T6 review, defect 1):
+    // transform all eight local-AABB corners through the full instance
+    // matrix and take their bounds. The shader uses design §11's `|M₃ₓ₃|`
+    // abs-matrix identity instead — mathematically equivalent for affine
+    // transforms but a SHORTCUT, and a reference that reimplements the same
+    // shortcut can only prove the code agrees with itself. Deriving the
+    // world AABB the slow, obviously-correct way makes this an oracle: it
+    // would catch an error in the abs-matrix formula itself, which is
+    // exactly the class of bug the T5 review's transform-convention probe
+    // showed this codebase is capable of harboring undetected.
+    let (world_center, world_extents) = {
+        let mut lo = [f32::INFINITY; 3];
+        let mut hi = [f32::NEG_INFINITY; 3];
+        for c in 0u32..8 {
+            let sx = if c & 1 != 0 { 1.0 } else { -1.0 };
+            let sy = if c & 2 != 0 { 1.0 } else { -1.0 };
+            let sz = if c & 4 != 0 { 1.0 } else { -1.0 };
+            let local = [
+                mesh.local_aabb_center[0] + sx * mesh.local_aabb_extents[0],
+                mesh.local_aabb_center[1] + sy * mesh.local_aabb_extents[1],
+                mesh.local_aabb_center[2] + sz * mesh.local_aabb_extents[2],
+            ];
+            let w = mat4_mul_point(m, local);
+            for k in 0..3 {
+                lo[k] = lo[k].min(w[k]);
+                hi[k] = hi[k].max(w[k]);
+            }
+        }
+        (
+            [
+                (lo[0] + hi[0]) * 0.5,
+                (lo[1] + hi[1]) * 0.5,
+                (lo[2] + hi[2]) * 0.5,
+            ],
+            [
+                (hi[0] - lo[0]) * 0.5,
+                (hi[1] - lo[1]) * 0.5,
+                (hi[2] - lo[2]) * 0.5,
+            ],
+        )
+    };
+    // Cross-check the shader's §11 shortcut against the ground truth above.
+    // If these ever diverge, the abs-matrix identity (or the pinned
+    // column-major flattening it depends on) is wrong — fail loudly here
+    // rather than let the equality test silently compare two copies of the
+    // same mistake.
+    {
+        let shortcut = mat3_abs_mul_vec3(mat4_upper3x3(m), mesh.local_aabb_extents);
+        for k in 0..3 {
+            let tol = 1e-4 * world_extents[k].abs().max(1.0);
+            assert!(
+                (shortcut[k] - world_extents[k]).abs() <= tol,
+                "design §11 |M₃ₓ₃| shortcut disagrees with 8-corner ground truth on axis {k}: \
+                 shortcut {} vs truth {} (row {row}) — the abs-matrix identity or the \
+                 column-major flattening convention is wrong",
+                shortcut[k],
+                world_extents[k]
+            );
+        }
+    }
+
+    let mut near_clip = false;
+    for c in 0u32..8 {
+        let sx = if c & 1 != 0 { 1.0 } else { -1.0 };
+        let sy = if c & 2 != 0 { 1.0 } else { -1.0 };
+        let sz = if c & 4 != 0 { 1.0 } else { -1.0 };
+        let corner = [
+            world_center[0] + sx * world_extents[0],
+            world_center[1] + sy * world_extents[1],
+            world_center[2] + sz * world_extents[2],
+        ];
+        let clip = mat4_mul_vec4(&inputs.view_proj, [corner[0], corner[1], corner[2], 1.0]);
+        if clip[3] <= 0.0 {
+            near_clip = true;
+        }
+    }
+
+    if near_clip {
+        return (row, CpuDecision::Visible { near_clip: true });
+    }
+
+    for plane in inputs.planes.iter() {
+        if !plane_test(world_center, world_extents, *plane) {
+            return (row, CpuDecision::FrustumCulled);
+        }
+    }
+    (row, CpuDecision::Visible { near_clip: false })
+}
+
+/// Runs [`cpu_cull_token`] over every token, returning `(row, decision)`
+/// for all of them in token order (callers reduce to whatever comparison
+/// shape they need — full decision list, visible-only row set, per-category
+/// counts for house-law guards, ...).
+pub fn cpu_cull_all(inputs: &CpuCullInputs) -> Vec<(u32, CpuDecision)> {
+    (0..inputs.tokens.len())
+        .map(|i| cpu_cull_token(inputs, i))
+        .collect()
+}

--- a/crates/helio/Cargo.toml
+++ b/crates/helio/Cargo.toml
@@ -22,6 +22,7 @@ pollster = { workspace = true }
 quark.workspace = true
 helio-voxel-core = { workspace = true }
 helio-bake = { path = "../helio-bake", optional = true }
+helio-scenedb = { workspace = true, optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 meshopt = "0.6.2"
 
@@ -29,6 +30,7 @@ meshopt = "0.6.2"
 default = ["profiling"]
 profiling = ["helio-core/profiling"]
 bake = ["helio-bake", "uuid"]
+scenedb = ["dep:helio-scenedb"]
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1"

--- a/crates/helio/src/lib.rs
+++ b/crates/helio/src/lib.rs
@@ -66,6 +66,9 @@ pub use helio_core::{
 };
 pub use libhelio::{LightType, Movability, ShadowQuality, SkyActor, VolumetricClouds};
 
+#[cfg(feature = "scenedb")]
+pub use helio_scenedb::{SceneDbBinding, SceneDbRenderSource};
+
 /// Convert a [`MeshUpload`] with a world-space transform into a [`BakeMesh`] for use
 /// in a [`BakeRequest`].
 ///

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -347,6 +347,12 @@ impl Renderer {
             },
             "Renderer",
         );
+        #[cfg(feature = "scenedb")]
+        if let Some(source) = self.scene_db_source.as_ref() {
+            frame_resources
+                .scene_db
+                .write(source.frame_resources(), "Renderer");
+        }
         if !self.billboard_scratch.is_empty() {
             frame_resources.billboards.write(
                 libhelio::BillboardFrameData {

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -84,6 +84,8 @@ pub struct Renderer {
     pub(crate) queue: Arc<wgpu::Queue>,
     pub(crate) graph: RenderGraph,
     pub(crate) scene: Scene,
+    #[cfg(feature = "scenedb")]
+    pub(crate) scene_db_source: Option<helio_scenedb::SceneDbRenderSource>,
     pub(crate) depth_texture: wgpu::Texture,
     pub(crate) depth_view: wgpu::TextureView,
     pub(crate) output_width: u32,
@@ -320,6 +322,28 @@ impl<'a> DebugBatch<'a> {
 }
 
 impl Renderer {
+    /// Attaches SceneDB-owned GPU state to the live render graph.
+    ///
+    /// Existing `Scene` rendering remains active while passes migrate. Attaching
+    /// a source only publishes the authoritative SceneDB buffers through
+    /// `FrameResources`; it does not copy or mirror their contents.
+    #[cfg(feature = "scenedb")]
+    pub fn attach_scene_db_source(&mut self, source: helio_scenedb::SceneDbRenderSource) {
+        self.scene_db_source = Some(source);
+    }
+
+    /// Detaches and returns the current SceneDB render source.
+    #[cfg(feature = "scenedb")]
+    pub fn detach_scene_db_source(&mut self) -> Option<helio_scenedb::SceneDbRenderSource> {
+        self.scene_db_source.take()
+    }
+
+    /// Returns whether SceneDB resources will be published to the next frame.
+    #[cfg(feature = "scenedb")]
+    pub fn has_scene_db_source(&self) -> bool {
+        self.scene_db_source.is_some()
+    }
+
     pub fn set_gi_config(&mut self, gi_config: GiConfig) {
         self.gi_config = gi_config;
     }

--- a/crates/helio/src/renderer/setup.rs
+++ b/crates/helio/src/renderer/setup.rs
@@ -144,6 +144,8 @@ impl Renderer {
             queue,
             graph,
             scene,
+            #[cfg(feature = "scenedb")]
+            scene_db_source: None,
             depth_texture,
             depth_view,
             output_width: width,

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -79,6 +79,23 @@ pub struct MainSceneResources<'a> {
     pub tlas: Option<&'a wgpu::Tlas>,
 }
 
+/// SceneDB-owned GPU state published by the high-level renderer.
+///
+/// The buffers and bind groups remain owned by SceneDB and the Helio-side
+/// adapter. Render-graph passes borrow them for one frame, avoiding a CPU
+/// snapshot or a second set of scene buffers.
+#[derive(Clone, Copy)]
+pub struct SceneDbFrameResources<'a> {
+    /// Read-only instance, generation, and mesh metadata used by GPU culling.
+    pub cull_bind_group: &'a wgpu::BindGroup,
+    /// Read-only cluster, meshlet, cell, and material metadata used by drawing.
+    pub draw_bind_group: &'a wgpu::BindGroup,
+    /// Global SceneDB geometry vertex arena.
+    pub vertex_buffer: &'a wgpu::Buffer,
+    /// Global SceneDB geometry index arena.
+    pub index_buffer: &'a wgpu::Buffer,
+}
+
 /// Debug-tracked resource slot.
 ///
 /// In debug builds, records which pass wrote the value so we can detect
@@ -238,6 +255,12 @@ pub struct FrameResources<'a> {
     pub full_res_depth_texture: Tracked<&'a wgpu::Texture>,
     /// High-level Helio scene resources used by wrapper-owned passes.
     pub main_scene: Tracked<MainSceneResources<'a>>,
+    /// Authoritative SceneDB GPU resources, when the renderer has a source attached.
+    ///
+    /// This is intentionally optional while Helio's existing passes migrate one
+    /// at a time. Consumers must use [`Tracked::get`] until their graph declares
+    /// SceneDB as a required input.
+    pub scene_db: Tracked<SceneDbFrameResources<'a>>,
     /// Sky context (has_sky, state_changed, sky_color)
     pub sky: crate::sky::SkyContext,
     /// Billboards to render this frame (uploaded by the high-level Renderer).
@@ -430,6 +453,7 @@ impl<'a> FrameResources<'a> {
             full_res_depth: Tracked::empty(),
             full_res_depth_texture: Tracked::empty(),
             main_scene: Tracked::empty(),
+            scene_db: Tracked::empty(),
             sky: crate::sky::SkyContext::default(),
             billboards: Tracked::empty(),
             vg: Tracked::empty(),
@@ -499,6 +523,7 @@ impl<'a> FrameResources<'a> {
             reset_field!(full_res_depth);
             reset_field!(full_res_depth_texture);
             reset_field!(main_scene);
+            reset_field!(scene_db);
             reset_field!(billboards);
             reset_field!(vg);
             reset_field!(water_caustics);
@@ -559,4 +584,3 @@ pub struct VgFrameData<'a> {
     /// Number of dirty instances; zero when `buffer_version` owns the update.
     pub instance_dirty_count: u32,
 }
-

--- a/docs/scenedb-renderer-migration.md
+++ b/docs/scenedb-renderer-migration.md
@@ -1,0 +1,85 @@
+# SceneDB renderer migration
+
+Issue: [Helio #121](https://github.com/Far-Beyond-Pulsar/Helio/issues/121)
+
+## Ownership rule
+
+SceneDB owns authoritative scene state and GPU scene buffers. Helio owns render
+pipelines and derived per-view data. A Helio pass may borrow SceneDB buffers
+directly, but Helio must not rebuild a CPU snapshot or upload a second copy of
+the same scene records.
+
+`helio-scenedb` is the only Helio crate that depends on `pulsar_scenedb`. The
+workspace pins the same SceneDB revision as Pulsar so public SceneDB types and
+wgpu handles have one Cargo package identity.
+
+## Current migration slice
+
+The optional `helio/scenedb` feature adds an owned `SceneDbRenderSource`.
+Attaching it to `Renderer` publishes borrowed `SceneDbFrameResources` into the
+live `FrameResources` for every frame:
+
+- cull bind group: transforms, instance metadata, slot mirror, generations,
+  and mesh metadata;
+- draw bind group: clusters, meshlets, cell metadata, and materials;
+- SceneDB's global vertex and index arenas.
+
+This path allocates Helio bind groups once at attachment. It performs no scene
+copy and no per-frame upload. Detaching or destroying a renderer drops only
+Helio-owned bindings and cloned wgpu handles; the SceneDB stores remain alive.
+
+No production pass consumes this slot yet. Existing `Scene`, constructors,
+graphs, demos, and downstream integrations therefore retain their exact
+behavior when the feature is disabled or no source is attached.
+
+## Compatibility inventory
+
+The following existing Helio state is still authoritative for current passes
+and cannot be removed until a replacement consumer is validated:
+
+| State | Current writers | Current consumers | SceneDB migration state |
+| --- | --- | --- | --- |
+| Object transforms, instance metadata, generations, visibility | `Scene` object/virtual-object APIs and `Scene::flush` | GBuffer, depth, shadow, virtual geometry, picking | SceneDB buffers published; production consumers pending |
+| Mesh/cluster/meshlet metadata and geometry | mesh and virtual-geometry insertion/removal | GBuffer, depth, shadow, virtual geometry | SceneDB buffers published; format/PBR integration pending |
+| Materials and texture references | material/texture APIs | GBuffer, transparent, decals, lighting | material registry published; texture-view/sampler table pending |
+| Lights and shadows | light actor APIs | light cull, shadow, deferred lighting, billboards/coronas | not represented by this adapter |
+| Camera and per-view culling | renderer camera update | all view-dependent passes, picking, gizmos | remains Helio-derived per view |
+| Groups and editor visibility | group/editor APIs | culling, picking, debug views | compatibility mapping pending |
+| Voxels and planetary terrain | voxel actors and terrain passes | voxel mesh/raymarch/planet passes | separate payloads; must remain working |
+| Water, decals, post-process volumes, reflection captures | specialized `Scene` APIs | corresponding graph passes | not represented by this adapter |
+| Resize and external-device lifecycle | `Renderer` | graph rebuild and all target-sized passes | unchanged; attached source must survive rebuild |
+
+Pulsar currently has additional direct `renderer.scene_mut()` writers in the
+static-mesh and light components, and a `sync_scene()` bridge in
+`engine_backend` that materializes Pulsar's legacy scene database into Helio
+objects. Picking, gizmo dragging, selection, and the physics picker also read
+Helio `Scene` handles. That bridge must stay until those writers and readers
+have moved to the pinned `pulsar_scenedb` API and the equivalence gates below
+pass.
+
+## Removal gates
+
+The legacy path may be removed only after all of these are true:
+
+1. A SceneDB-backed GBuffer path matches the current material, texture,
+   normal, object-ID, and motion-vector outputs.
+2. Depth, shadow, transparency, decals, reflections, and virtual geometry
+   either consume SceneDB directly or have an explicitly retained owner.
+3. Picking, selection, gizmos, and debug views resolve stable SceneDB IDs.
+4. Light components and all static-mesh writers publish to SceneDB without a
+   full-scene synchronization loop.
+5. Deletion, stale-generation rejection, streaming eviction/rehydration, and
+   dirty-range uploads pass lifecycle tests.
+6. Resize, external-device construction, camera movement, meshlet/LOD debug,
+   both voxel demos, and the Pulsar editor pass visual validation.
+7. CPU frame time, GPU pass time, bytes uploaded, and memory use are no worse
+   than matched legacy baselines; the full `sync_scene()` scan is absent.
+
+## Planned stacked work
+
+1. Add the SceneDB GBuffer/cull consumer using the published frame slot.
+2. Add PBR material and texture bindings plus stable picking/object IDs.
+3. Move Pulsar rendering components to SceneDB writers and validate deltas.
+4. Migrate remaining pass families and editor/physics readers.
+5. Remove `sync_scene()` and the duplicated Helio `Scene` records only after
+   all compatibility and performance gates pass.


### PR DESCRIPTION
## Summary

- restore the proven `helio-scenedb` GPU binding, cull, draw, repack, test, and timing seam on current `v4`
- add an optional `helio/scenedb` feature with an owned `SceneDbRenderSource`
- publish SceneDB-owned bind groups and geometry arenas through the live Helio `FrameResources` without copying scene records
- preserve the existing `Scene` path while production passes migrate
- document current Helio/Pulsar writers, readers, removal gates, and the stacked migration path

Advances #121. This does not close it: no production PBR pass consumes the new frame slot yet, and the legacy `Scene`/Pulsar `sync_scene()` paths remain until the documented compatibility gates pass.

## Why

The previous M3 seam proved SceneDB buffer layouts, generation validation, GPU culling, indirect drawing, teardown, and timing in isolation, but it was not connected to Helio's live renderer lifecycle. The new adapter gives render-graph passes a zero-copy authoritative source while keeping current rendering behavior unchanged unless the feature is explicitly enabled and a source is attached.

## Compatibility

- `scenedb` is opt-in and disabled by default
- existing `Renderer` constructors retain their signatures
- existing graphs, resize handling, external-device construction, voxel paths, and demos keep using `Scene`
- the attached source remains renderer-owned and is republished every frame
- SceneDB is pinned to the same revision currently used by Pulsar, avoiding duplicate package identities across the integration boundary

## Validation

- `cargo test -p helio-scenedb --no-fail-fast`
  - all layout, cull, stale/OOB, indirect equivalence, transform sweep, overflow, teardown, and shader-readback tests pass
- `cargo clippy -p helio-scenedb --all-targets --no-deps -- -D warnings`
- `cargo check -p helio --features scenedb`
- `cargo check -p helio`
- `cargo test -p libhelio`
- `cargo check --workspace --all-targets --exclude examples --features helio/scenedb`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --bin editor_demo_mini --features helio/scenedb`
- `cargo bench -p helio-scenedb --bench pass_timing --no-run`

The unrestricted all-example check also found a pre-existing current-`v4` failure in `corona_demo`: its `GpuLight` initializer is missing fields already required by `libhelio`. Neither file is changed here, so that unrelated demo fix is intentionally not folded into this PR.

## Next stacked work

1. add a SceneDB-backed GBuffer/cull consumer using this published frame slot
2. integrate PBR materials/textures and stable picking IDs
3. move Pulsar static-mesh and light component writers to SceneDB
4. migrate remaining pass/editor/physics readers
5. remove `sync_scene()` and duplicate `Scene` state only after visual and matched performance validation
