### PR TITLE
Update helio-core doctests for current APIs

### DIFF
--- a/crates/helio-core/src/context.rs
+++ b/crates/helio-core/src/context.rs
@@ -48,6 +48,15 @@
 //!         "MyPass"
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // Access render target and depth buffer
 //!         let target = ctx.target;
@@ -58,16 +67,18 @@
 //!         // let mesh_buffer = ctx.scene.meshes.buffer();
 //!
 //!         // Record GPU commands with automatic profiling
-//!         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-//!             label: Some("MyPass"),
-//!             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+//!         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 //!                 view: target,
 //!                 resolve_target: None,
+//!                 depth_slice: None,
 //!                 ops: wgpu::Operations {
 //!                     load: wgpu::LoadOp::Load,
 //!                     store: wgpu::StoreOp::Store,
 //!                 },
-//!             })],
+//!             })];
+//!         let descriptor = wgpu::RenderPassDescriptor {
+//!             label: Some("MyPass"),
+//!             color_attachments: &color_attachments,
 //!             depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
 //!                 view: depth,
 //!                 depth_ops: Some(wgpu::Operations {
@@ -78,7 +89,9 @@
 //!             }),
 //!             timestamp_writes: None,
 //!             occlusion_query_set: None,
-//!         });
+//!             multiview_mask: None,
+//!         };
+//!         let mut pass = ctx.begin_render_pass(&descriptor);
 //!
 //!         pass.set_pipeline(&self.pipeline);
 //!         pass.draw(0..3, 0..1);
@@ -131,6 +144,15 @@ use crate::{Profiler, SceneResources};
 ///         "MyPass"
 ///     }
 ///
+///     fn render_pass_descriptor<'a>(
+///         &'a self,
+///         _: &'a wgpu::TextureView,
+///         _: &'a wgpu::TextureView,
+///         _: &'a helio_core::FrameResources<'a>,
+///     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+///         None
+///     }
+///
 ///     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 ///         // Access render targets
 ///         let target = ctx.target;
@@ -141,20 +163,24 @@ use crate::{Profiler, SceneResources};
 ///         let (width, height) = (ctx.width, ctx.height);
 ///
 ///         // Record GPU commands (automatic profiling)
-///         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-///             label: Some("MyPass"),
-///             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+///         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 ///                 view: target,
 ///                 resolve_target: None,
+///                 depth_slice: None,
 ///                 ops: wgpu::Operations {
 ///                     load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
 ///                     store: wgpu::StoreOp::Store,
 ///                 },
-///             })],
+///             })];
+///         let descriptor = wgpu::RenderPassDescriptor {
+///             label: Some("MyPass"),
+///             color_attachments: &color_attachments,
 ///             depth_stencil_attachment: None,
 ///             timestamp_writes: None,
 ///             occlusion_query_set: None,
-///         });
+///             multiview_mask: None,
+///         };
+///         let mut pass = ctx.begin_render_pass(&descriptor);
 ///
 ///         pass.set_pipeline(&self.pipeline);
 ///         pass.draw(0..3, 0..1);
@@ -267,17 +293,15 @@ impl<'a> PassContext<'a> {
 }
 
 impl<'a> PassContext<'a> {
-    /// Begins a render pass with automatic GPU profiling.
+    /// Begins a self-managed render pass.
     ///
-    /// This is a wrapper around `encoder.begin_render_pass()` that automatically
-    /// injects GPU timestamp queries for profiling. **Always use this instead of
-    /// calling `encoder.begin_render_pass()` directly.**
+    /// This is the fallback path for a pass whose
+    /// [`RenderPass::render_pass_descriptor`](crate::RenderPass::render_pass_descriptor)
+    /// returns `None`. Preferred graphics passes return a descriptor and record
+    /// into the executor-provided active render pass instead.
     ///
-    /// # Profiling
-    ///
-    /// - GPU timestamps are written at the start and end of the pass
-    /// - Results are available for external telemetry systems
-    /// - Zero overhead when `profiling` feature is disabled
+    /// The graph still records the pass-level profiling scope; this helper only
+    /// opens the underlying wgpu render pass.
     ///
     /// # Example
     ///
@@ -286,21 +310,31 @@ impl<'a> PassContext<'a> {
     /// # struct MyPass;
     /// # impl RenderPass for MyPass {
     /// #     fn name(&self) -> &'static str { "MyPass" }
+    /// #     fn render_pass_descriptor<'a>(
+    /// #         &'a self,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a helio_core::FrameResources<'a>,
+    /// #     ) -> Option<wgpu::RenderPassDescriptor<'a>> { None }
     /// fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
-    ///     let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-    ///         label: Some("MyPass"),
-    ///         color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+    ///     let color_attachments = [Some(wgpu::RenderPassColorAttachment {
     ///             view: ctx.target,
     ///             resolve_target: None,
+    ///             depth_slice: None,
     ///             ops: wgpu::Operations {
     ///                 load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
     ///                 store: wgpu::StoreOp::Store,
     ///             },
-    ///         })],
+    ///         })];
+    ///     let descriptor = wgpu::RenderPassDescriptor {
+    ///         label: Some("MyPass"),
+    ///         color_attachments: &color_attachments,
     ///         depth_stencil_attachment: None,
     ///         timestamp_writes: None,
     ///         occlusion_query_set: None,
-    ///     });
+    ///         multiview_mask: None,
+    ///     };
+    ///     let mut pass = ctx.begin_render_pass(&descriptor);
     ///
     ///     // Record GPU commands
     ///     // pass.set_pipeline(&self.pipeline);
@@ -345,6 +379,12 @@ impl<'a> PassContext<'a> {
     /// # struct MyComputePass { pipeline: wgpu::ComputePipeline }
     /// # impl RenderPass for MyComputePass {
     /// #     fn name(&self) -> &'static str { "MyComputePass" }
+    /// #     fn render_pass_descriptor<'a>(
+    /// #         &'a self,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a helio_core::FrameResources<'a>,
+    /// #     ) -> Option<wgpu::RenderPassDescriptor<'a>> { None }
     /// fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
     ///     let mut pass = ctx.begin_compute_pass(&wgpu::ComputePassDescriptor {
     ///         label: Some("MyComputePass"),
@@ -407,10 +447,19 @@ impl<'a> PassContext<'a> {
 ///         "MyPass"
 ///     }
 ///
+///     fn render_pass_descriptor<'a>(
+///         &'a self,
+///         _: &'a wgpu::TextureView,
+///         _: &'a wgpu::TextureView,
+///         _: &'a helio_core::FrameResources<'a>,
+///     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+///         None
+///     }
+///
 ///     fn prepare(&mut self, ctx: &PrepareContext) -> Result<()> {
 ///         // Upload per-frame uniforms
 ///         let uniforms = MyUniforms {
-///             time: ctx.frame as f32,
+///             time: ctx.frame_num as f32,
 ///             resolution: [1920, 1080],
 ///         };
 ///         ctx.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
@@ -419,20 +468,24 @@ impl<'a> PassContext<'a> {
 ///
 ///     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 ///         // Use uploaded uniforms
-///         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-///             label: Some("MyPass"),
-///             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+///         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 ///                 view: ctx.target,
 ///                 resolve_target: None,
+///                 depth_slice: None,
 ///                 ops: wgpu::Operations {
 ///                     load: wgpu::LoadOp::Load,
 ///                     store: wgpu::StoreOp::Store,
 ///                 },
-///             })],
+///             })];
+///         let descriptor = wgpu::RenderPassDescriptor {
+///             label: Some("MyPass"),
+///             color_attachments: &color_attachments,
 ///             depth_stencil_attachment: None,
 ///             timestamp_writes: None,
 ///             occlusion_query_set: None,
-///         });
+///             multiview_mask: None,
+///         };
+///         let mut pass = ctx.begin_render_pass(&descriptor);
 ///
 ///         pass.set_pipeline(&self.pipeline);
 ///         // pass.set_bind_group(0, &self.bind_group, &[]);

--- a/crates/helio-core/src/lib.rs
+++ b/crates/helio-core/src/lib.rs
@@ -87,22 +87,35 @@
 //!         "MyPass"
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // PassContext provides zero-copy access to scene resources
-//!         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-//!             label: Some("MyPass"),
-//!             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+//!         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 //!                 view: ctx.target,
 //!                 resolve_target: None,
+//!                 depth_slice: None,
 //!                 ops: wgpu::Operations {
 //!                     load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
 //!                     store: wgpu::StoreOp::Store,
 //!                 },
-//!             })],
+//!             })];
+//!         let descriptor = wgpu::RenderPassDescriptor {
+//!             label: Some("MyPass"),
+//!             color_attachments: &color_attachments,
 //!             depth_stencil_attachment: None,
 //!             timestamp_writes: None,
 //!             occlusion_query_set: None,
-//!         });
+//!             multiview_mask: None,
+//!         };
+//!         let mut pass = ctx.begin_render_pass(&descriptor);
 //!
 //!         pass.set_pipeline(&self.pipeline);
 //!         // Access scene resources via ctx.scene
@@ -147,6 +160,15 @@
 //!         "MyPass" // Used for profiling labels
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn prepare(&mut self, ctx: &PrepareContext) -> Result<()> {
 //!         // Optional: Upload per-frame uniforms (called before execute)
 //!         // ctx.queue.write_buffer(&self.uniform_buffer, 0, data);
@@ -175,6 +197,7 @@
 //! use helio_core::GpuScene;
 //! use std::sync::Arc;
 //!
+//! # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 //! let mut scene = GpuScene::new(
 //!     Arc::new(device),
 //!     Arc::new(queue),
@@ -192,6 +215,7 @@
 //! let resources = scene.resources();
 //! // resources.lights.buffer() -> &wgpu::Buffer
 //! // resources.meshes.buffer() -> &wgpu::Buffer
+//! # }
 //! ```
 //!
 //! **Key Points:**
@@ -207,23 +231,36 @@
 //! ```rust,no_run
 //! use helio_core::{RenderPass, PassContext, Result};
 //!
-//! struct MyPass;
+//! struct MyPass {
+//!     pipeline: wgpu::RenderPipeline,
+//! }
 //!
 //! impl RenderPass for MyPass {
 //!     fn name(&self) -> &'static str { "MyPass" }
+//!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
 //!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // CPU profiling: Automatic scope created by RenderGraph
 //!         // GPU profiling: Automatic timestamps via begin_render_pass
 //!
-//!         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
+//!         let descriptor = wgpu::RenderPassDescriptor {
 //!             label: Some("MyPass"), // Used for GPU timestamp label
 //!             // ...
 //! #            color_attachments: &[],
 //! #            depth_stencil_attachment: None,
 //! #            timestamp_writes: None,
 //! #            occlusion_query_set: None,
-//!         });
+//! #            multiview_mask: None,
+//!         };
+//!         let mut pass = ctx.begin_render_pass(&descriptor);
 //!
 //!         // GPU timestamps automatically inserted at begin/end
 //!         pass.set_pipeline(&self.pipeline);
@@ -231,12 +268,7 @@
 //!
 //!         Ok(())
 //!     }
-//! #    pipeline: wgpu::RenderPipeline,
 //! }
-//! #
-//! # impl MyPass {
-//! #     fn new(pipeline: wgpu::RenderPipeline) -> Self { Self { pipeline } }
-//! # }
 //! ```
 //!
 //! **Key Points:**
@@ -271,12 +303,14 @@
 //! use helio_core::{RenderGraph, GpuScene};
 //! use std::sync::Arc;
 //!
+//! # fn example(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) {
 //! let mut graph = RenderGraph::new(&device, &queue);
-//! let mut scene = GpuScene::new(Arc::new(device), Arc::new(queue));
+//! let mut scene = GpuScene::new(device.clone(), queue.clone());
 //!
 //! // scene.lights.add(light);
 //! scene.flush(); // Upload changes
 //! // graph.execute(&scene, &target, &depth);
+//! # }
 //! ```
 //!
 //! ## Feature Flags
@@ -308,6 +342,15 @@
 //! impl RenderPass for MyPass {
 //!     fn name(&self) -> &'static str { "MyPass" }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // Zero-copy: borrow GPU buffers from scene
 //!         // let light_buffer = ctx.scene.lights.buffer(); // &wgpu::Buffer
@@ -329,6 +372,7 @@
 //! use helio_core::GpuScene;
 //! use std::sync::Arc;
 //!
+//! # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 //! let mut scene = GpuScene::new(Arc::new(device), Arc::new(queue));
 //!
 //! // Frame 1: Add lights (dirty = true)
@@ -342,6 +386,7 @@
 //! // Frame 3: Update one light (dirty = true)
 //! // scene.lights.update(light1_id, new_light);
 //! scene.flush(); // Uploads only changed data
+//! # }
 //! ```
 //!
 //! ### Automatic Profiling Pattern

--- a/crates/helio-core/src/profiling/gpu.rs
+++ b/crates/helio-core/src/profiling/gpu.rs
@@ -34,6 +34,7 @@
 //!
 //! ```rust,no_run
 //! # use helio_core::profiling::GpuProfiler;
+//! # fn example(device: &wgpu::Device, queue: &wgpu::Queue, mut encoder: &mut wgpu::CommandEncoder) {
 //! let mut profiler = GpuProfiler::new(&device, &queue);
 //!
 //! // Write start timestamp
@@ -43,6 +44,7 @@
 //!
 //! // Write end timestamp
 //! profiler.end_pass(&mut encoder, "ShadowPass");
+//! # }
 //! ```
 
 /// GPU profiler using timestamp queries.
@@ -65,11 +67,13 @@
 ///
 /// ```rust,no_run
 /// # use helio_core::profiling::GpuProfiler;
+/// # fn example(device: &wgpu::Device, queue: &wgpu::Queue, mut encoder: &mut wgpu::CommandEncoder) {
 /// let mut profiler = GpuProfiler::new(&device, &queue);
 ///
 /// profiler.begin_pass(&mut encoder, "ShadowPass");
 /// // GPU commands...
 /// profiler.end_pass(&mut encoder, "ShadowPass");
+/// # }
 /// ```
 use std::{
     collections::VecDeque,
@@ -132,7 +136,9 @@ impl GpuProfiler {
     ///
     /// ```rust,no_run
     /// # use helio_core::profiling::GpuProfiler;
+    /// # fn example(device: &wgpu::Device, queue: &wgpu::Queue) {
     /// let profiler = GpuProfiler::new(&device, &queue);
+    /// # }
     /// ```
     pub fn new(device: &wgpu::Device, queue: &wgpu::Queue) -> Self {
         // write_timestamp on a command encoder requires BOTH TIMESTAMP_QUERY and
@@ -218,9 +224,11 @@ impl GpuProfiler {
     ///
     /// ```rust,no_run
     /// # use helio_core::profiling::GpuProfiler;
+    /// # fn example(device: &wgpu::Device, queue: &wgpu::Queue) {
     /// # let mut profiler = GpuProfiler::new(&device, &queue);
     /// # let mut encoder = device.create_command_encoder(&Default::default());
     /// profiler.begin_pass(&mut encoder, "ShadowPass");
+    /// # }
     /// ```
     pub fn begin_pass(&mut self, encoder: &mut wgpu::CommandEncoder, name: &'static str) {
         if let Some(ref query_set) = self.query_set {
@@ -254,9 +262,11 @@ impl GpuProfiler {
     ///
     /// ```rust,no_run
     /// # use helio_core::profiling::GpuProfiler;
+    /// # fn example(device: &wgpu::Device, queue: &wgpu::Queue) {
     /// # let mut profiler = GpuProfiler::new(&device, &queue);
     /// # let mut encoder = device.create_command_encoder(&Default::default());
     /// profiler.end_pass(&mut encoder, "ShadowPass");
+    /// # }
     /// ```
     pub fn end_pass(&mut self, encoder: &mut wgpu::CommandEncoder, _name: &'static str) {
         if let Some(ref query_set) = self.query_set {

--- a/crates/helio-core/src/profiling/mod.rs
+++ b/crates/helio-core/src/profiling/mod.rs
@@ -47,6 +47,15 @@
 //!         "MyPass" // Used for profiling labels
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // CPU scope created automatically by RenderGraph
 //!         // GPU timestamps injected automatically by begin_render_pass
@@ -58,6 +67,7 @@
 //! #            depth_stencil_attachment: None,
 //! #            timestamp_writes: None,
 //! #            occlusion_query_set: None,
+//! #            multiview_mask: None,
 //!         });
 //!
 //!         // GPU commands are automatically profiled
@@ -123,6 +133,7 @@ pub use gpu::{GpuProfiler, GpuTimestamp};
 /// ```rust,no_run
 /// use helio_core::Profiler;
 ///
+/// # fn example(device: &wgpu::Device, queue: &wgpu::Queue, mut encoder: &mut wgpu::CommandEncoder) {
 /// let mut profiler = Profiler::new(&device, &queue);
 ///
 /// // CPU profiling (RAII scope)
@@ -135,6 +146,7 @@ pub use gpu::{GpuProfiler, GpuTimestamp};
 /// profiler.begin_gpu_pass(&mut encoder, "GBufferPass");
 /// // ... GPU commands ...
 /// profiler.end_gpu_pass(&mut encoder, "GBufferPass");
+/// # }
 /// ```
 pub struct Profiler {
     cpu: CpuProfiler,
@@ -179,11 +191,13 @@ impl Profiler {
     ///
     /// ```rust,no_run
     /// # use helio_core::Profiler;
+    /// # fn example(device: &wgpu::Device, queue: &wgpu::Queue) {
     /// # let mut profiler = Profiler::new(&device, &queue);
     /// {
     ///     let _scope = profiler.scope("MyPass");
     ///     // ... CPU work ...
     /// } // ScopeGuard drops, timing recorded
+    /// # }
     /// ```
     pub fn scope(&mut self, name: &'static str) -> ScopeGuard {
         self.cpu.scope(name)
@@ -412,11 +426,14 @@ impl Profiler {
     ///
     /// ```rust,no_run
     /// # use helio_core::RenderGraph;
+    /// # use std::sync::Arc;
+    /// # fn example(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) {
     /// # let graph = RenderGraph::new(&device, &queue);
     /// let (pass_timings, total_cpu_ms, total_gpu_ms) = graph.profiler().export_timings();
     ///
     /// // Forward to custom telemetry system
     /// // for timing in &pass_timings { ... }
+    /// # }
     /// ```
     pub fn export_timings(&self) -> (Vec<PassTiming>, f32, f32) {
         if !self.enabled {

--- a/crates/helio-core/src/scene/gpu_scene.rs
+++ b/crates/helio-core/src/scene/gpu_scene.rs
@@ -51,6 +51,7 @@
 //! use helio_core::GpuScene;
 //! use std::sync::Arc;
 //!
+//! # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 //! let mut scene = GpuScene::new(
 //!     Arc::new(device),
 //!     Arc::new(queue),
@@ -68,6 +69,7 @@
 //! let resources = scene.resources();
 //! // let light_buffer = resources.lights.buffer(); // &wgpu::Buffer
 //! // let mesh_buffer = resources.meshes.buffer();   // &wgpu::Buffer
+//! # }
 //! ```
 
 use crate::acceleration::{BlasManager, TlasManager};
@@ -125,6 +127,7 @@ use std::sync::Arc;
 /// use helio_core::GpuScene;
 /// use std::sync::Arc;
 ///
+/// # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 /// let mut scene = GpuScene::new(
 ///     Arc::new(device),
 ///     Arc::new(queue),
@@ -141,6 +144,7 @@ use std::sync::Arc;
 /// // Frame 3: Update one light (dirty = true)
 /// // scene.lights.update(light_id, PointLight { position: [1.0, 5.0, 0.0], color: [1.0, 0.0, 0.0] });
 /// scene.flush(); // Uploads only changed data
+/// # }
 /// ```
 pub struct GpuScene {
     /// GPU device (shared across scene).
@@ -289,10 +293,12 @@ impl GpuScene {
     /// use helio_core::GpuScene;
     /// use std::sync::Arc;
     ///
+    /// # fn example(device: wgpu::Device, queue: wgpu::Queue) {
     /// let scene = GpuScene::new(
     ///     Arc::new(device),
     ///     Arc::new(queue),
     /// );
+    /// # }
     /// ```
     pub fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
         let camera = GpuCameraBuffer::new(&device);
@@ -404,10 +410,12 @@ impl GpuScene {
     /// ```rust,no_run
     /// # use helio_core::GpuScene;
     /// # use std::sync::Arc;
+    /// # fn example(device: wgpu::Device, queue: wgpu::Queue) {
     /// # let scene = GpuScene::new(Arc::new(device), Arc::new(queue));
     /// let resources = scene.resources();
     /// // let light_buffer = resources.lights.buffer(); // &wgpu::Buffer
     /// // let mesh_buffer = resources.meshes.buffer();   // &wgpu::Buffer
+    /// # }
     /// ```
     pub fn resources(&self) -> SceneResources<'_> {
         SceneResources {
@@ -472,7 +480,13 @@ impl GpuScene {
     /// ```rust,no_run
     /// # use helio_core::{GpuScene, RenderGraph};
     /// # use std::sync::Arc;
-    /// # let mut scene = GpuScene::new(Arc::new(device), Arc::new(queue));
+    /// # fn example(
+    /// #     device: Arc<wgpu::Device>,
+    /// #     queue: Arc<wgpu::Queue>,
+    /// #     view: wgpu::TextureView,
+    /// #     depth_view: wgpu::TextureView,
+    /// # ) {
+    /// # let mut scene = GpuScene::new(device.clone(), queue.clone());
     /// # let mut graph = RenderGraph::new(&device, &queue);
     /// # let target = &view;
     /// # let depth = &depth_view;
@@ -485,6 +499,7 @@ impl GpuScene {
     ///
     /// // Execute render graph (passes read GPU buffers)
     /// // graph.execute(&scene, target, depth);
+    /// # }
     /// ```
     ///
     /// # Example: Dirty Tracking

--- a/crates/helio-core/src/scene/mod.rs
+++ b/crates/helio-core/src/scene/mod.rs
@@ -30,6 +30,7 @@
 //! use helio_core::GpuScene;
 //! use std::sync::Arc;
 //!
+//! # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 //! let mut scene = GpuScene::new(
 //!     Arc::new(device),
 //!     Arc::new(queue),
@@ -45,6 +46,7 @@
 //! // Passes receive zero-copy references
 //! let resources = scene.resources();
 //! // let light_buffer = resources.lights.buffer(); // &wgpu::Buffer
+//! # }
 //! ```
 
 mod gpu_scene;

--- a/crates/helio-core/src/scene/resources.rs
+++ b/crates/helio-core/src/scene/resources.rs
@@ -42,6 +42,15 @@
 //!         "MyPass"
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // Zero-copy access to scene resources
 //!         // let light_buffer = ctx.scene.lights.buffer();   // &wgpu::Buffer
@@ -93,6 +102,7 @@ use crate::component::ComponentRegistry;
 /// ```rust,no_run
 /// # use helio_core::{GpuScene, RenderPass, PassContext, Result};
 /// # use std::sync::Arc;
+/// # fn example(device: wgpu::Device, queue: wgpu::Queue) {
 /// # let scene = GpuScene::new(Arc::new(device), Arc::new(queue));
 /// // Get zero-copy references
 /// let resources = scene.resources();
@@ -101,6 +111,7 @@ use crate::component::ComponentRegistry;
 /// // let light_buffer = resources.lights.buffer();   // &wgpu::Buffer
 /// // let mesh_buffer = resources.meshes.buffer();    // &wgpu::Buffer
 /// // let material_buffer = resources.materials.buffer(); // &wgpu::Buffer
+/// # }
 /// ```
 ///
 /// # Future API

--- a/crates/helio-core/src/traits.rs
+++ b/crates/helio-core/src/traits.rs
@@ -30,10 +30,19 @@
 //!         "MyCustomPass"
 //!     }
 //!
+//!     fn render_pass_descriptor<'a>(
+//!         &'a self,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a wgpu::TextureView,
+//!         _: &'a helio_core::FrameResources<'a>,
+//!     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+//!         None
+//!     }
+//!
 //!     fn prepare(&mut self, ctx: &PrepareContext) -> Result<()> {
 //!         // Upload per-frame uniforms (runs on CPU before GPU submission)
 //!         let uniforms = MyUniforms {
-//!             time: ctx.frame as f32,
+//!             time: ctx.frame_num as f32,
 //!         };
 //!         ctx.queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
 //!         Ok(())
@@ -41,20 +50,24 @@
 //!
 //!     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
 //!         // Record GPU commands (profiling is automatic)
-//!         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-//!             label: Some("MyCustomPass"),
-//!             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+//!         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 //!                 view: ctx.target,
 //!                 resolve_target: None,
+//!                 depth_slice: None,
 //!                 ops: wgpu::Operations {
 //!                     load: wgpu::LoadOp::Load,
 //!                     store: wgpu::StoreOp::Store,
 //!                 },
-//!             })],
+//!             })];
+//!         let descriptor = wgpu::RenderPassDescriptor {
+//!             label: Some("MyCustomPass"),
+//!             color_attachments: &color_attachments,
 //!             depth_stencil_attachment: None,
 //!             timestamp_writes: None,
 //!             occlusion_query_set: None,
-//!         });
+//!             multiview_mask: None,
+//!         };
+//!         let mut pass = ctx.begin_render_pass(&descriptor);
 //!
 //!         pass.set_pipeline(&self.pipeline);
 //!         // Access scene resources: ctx.scene.lights, ctx.scene.meshes, etc.
@@ -187,21 +200,34 @@ impl<T: std::any::Any> AsAny for T {
 ///         "SimplePass"
 ///     }
 ///
+///     fn render_pass_descriptor<'a>(
+///         &'a self,
+///         _: &'a wgpu::TextureView,
+///         _: &'a wgpu::TextureView,
+///         _: &'a helio_core::FrameResources<'a>,
+///     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+///         None
+///     }
+///
 ///     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
-///         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-///             label: Some("SimplePass"),
-///             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+///         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 ///                 view: ctx.target,
 ///                 resolve_target: None,
+///                 depth_slice: None,
 ///                 ops: wgpu::Operations {
 ///                     load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
 ///                     store: wgpu::StoreOp::Store,
 ///                 },
-///             })],
+///             })];
+///         let descriptor = wgpu::RenderPassDescriptor {
+///             label: Some("SimplePass"),
+///             color_attachments: &color_attachments,
 ///             depth_stencil_attachment: None,
 ///             timestamp_writes: None,
 ///             occlusion_query_set: None,
-///         });
+///             multiview_mask: None,
+///         };
+///         let mut pass = ctx.begin_render_pass(&descriptor);
 ///
 ///         pass.set_pipeline(&self.pipeline);
 ///         pass.draw(0..3, 0..1);
@@ -227,6 +253,15 @@ impl<T: std::any::Any> AsAny for T {
 ///         "PassWithUniforms"
 ///     }
 ///
+///     fn render_pass_descriptor<'a>(
+///         &'a self,
+///         _: &'a wgpu::TextureView,
+///         _: &'a wgpu::TextureView,
+///         _: &'a helio_core::FrameResources<'a>,
+///     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+///         None
+///     }
+///
 ///     fn prepare(&mut self, ctx: &PrepareContext) -> Result<()> {
 ///         // Upload per-frame data (called before execute)
 ///         let uniforms = MyUniforms {
@@ -237,20 +272,24 @@ impl<T: std::any::Any> AsAny for T {
 ///     }
 ///
 ///     fn execute(&mut self, ctx: &mut PassContext) -> Result<()> {
-///         let mut pass = ctx.begin_render_pass(&wgpu::RenderPassDescriptor {
-///             label: Some("PassWithUniforms"),
-///             color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+///         let color_attachments = [Some(wgpu::RenderPassColorAttachment {
 ///                 view: ctx.target,
 ///                 resolve_target: None,
+///                 depth_slice: None,
 ///                 ops: wgpu::Operations {
 ///                     load: wgpu::LoadOp::Load,
 ///                     store: wgpu::StoreOp::Store,
 ///                 },
-///             })],
+///             })];
+///         let descriptor = wgpu::RenderPassDescriptor {
+///             label: Some("PassWithUniforms"),
+///             color_attachments: &color_attachments,
 ///             depth_stencil_attachment: None,
 ///             timestamp_writes: None,
 ///             occlusion_query_set: None,
-///         });
+///             multiview_mask: None,
+///         };
+///         let mut pass = ctx.begin_render_pass(&descriptor);
 ///
 ///         pass.set_pipeline(&self.pipeline);
 ///         pass.set_bind_group(0, &self.bind_group, &[]);
@@ -307,10 +346,11 @@ pub trait RenderPass: AsAny + MaybeSend + MaybeSync {
 
     /// Executes the pass by recording GPU commands.
     ///
-    /// This is the main entry point for rendering. Implementations should:
-    /// 1. Begin a render/compute pass using `ctx.begin_render_pass()` or `ctx.begin_compute_pass()`
-    /// 2. Set pipelines, bind groups, and issue draw/dispatch calls
-    /// 3. Access scene resources via `ctx.scene` (zero-copy)
+    /// This is the main entry point for recording work. Implementations should:
+    /// 1. Record into `ctx.active_render_pass_ptr()` when they return a render-pass descriptor,
+    ///    or begin their own render/compute pass for the fallback path.
+    /// 2. Set pipelines, bind groups, and issue draw/dispatch calls.
+    /// 3. Access scene resources via `ctx.scene` (zero-copy).
     ///
     /// # Parameters
     ///
@@ -354,11 +394,15 @@ pub trait RenderPass: AsAny + MaybeSend + MaybeSync {
         None
     }
 
-    /// Declares the render pass this pass needs, or `None` if the pass only
-    /// performs compute dispatches.  Every pass **must** implement this —
-    /// there is no default.  Compute-only passes return `None`; render passes
-    /// return `Some(descriptor)` so the executor can manage the render pass
-    /// lifecycle (subpass chaining, store-op patching, tile-memory fusion).
+    /// Declares the render pass this pass needs. Every pass **must** implement
+    /// this — there is no default. Returning `Some(descriptor)` is the preferred
+    /// graphics path: the executor owns the render-pass lifetime and can apply
+    /// subpass chaining, store-op patching, and tile-memory fusion.
+    ///
+    /// Return `None` for compute-only passes and for legacy/self-managed graphics
+    /// passes that open their own pass through [`PassContext::begin_render_pass`].
+    /// The latter remains supported but cannot participate in executor-managed
+    /// render-pass chaining.
     fn render_pass_descriptor<'a>(
         &'a self,
         target: &'a wgpu::TextureView,
@@ -405,10 +449,16 @@ pub trait RenderPass: AsAny + MaybeSend + MaybeSync {
     /// # struct MyPass { uniform_buffer: wgpu::Buffer }
     /// # impl RenderPass for MyPass {
     /// #     fn name(&self) -> &'static str { "MyPass" }
+    /// #     fn render_pass_descriptor<'a>(
+    /// #         &'a self,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a wgpu::TextureView,
+    /// #         _: &'a helio_core::FrameResources<'a>,
+    /// #     ) -> Option<wgpu::RenderPassDescriptor<'a>> { None }
     /// #     fn execute(&mut self, _: &mut PassContext) -> Result<()> { Ok(()) }
     /// fn prepare(&mut self, ctx: &PrepareContext) -> Result<()> {
     ///     let uniforms = MyUniforms {
-    ///         time: ctx.frame as f32,
+    ///         time: ctx.frame_num as f32,
     ///     };
     ///     ctx.queue.write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
     ///     Ok(())


### PR DESCRIPTION
## Summary

- update helio-core public examples for the current `RenderPass` contract and wgpu descriptor fields
- make GPU device/queue examples meaningful compile-checked `no_run` snippets
- clarify descriptor-managed graphics versus the self-managed fallback path

## Validation

- `cargo test -p helio-core --doc` — 51 passed, 4 intentionally ignored
- `cargo test --verbose` — passed
- `cargo test -p helio-core` — exposes two pre-existing HLFS WGSL validation failures in untouched files:
  - `hlfs_shade_rt.wgsl`: `mut` is reserved in WGSL
  - `hlfs_toroidal_shift.wgsl`: `vec3<i32>` receives a `u32`

## Scope

Documentation/API-maintenance only; no renderer or shader behavior changed.

Closes #67