### PR TITLE
Refactor VG to flat DAG and SW raster path

### DIFF
--- a/crates/examples/editor_demo_mini.rs
+++ b/crates/examples/editor_demo_mini.rs
@@ -1094,37 +1094,15 @@ impl AppState {
             overlay.populate = show_lod_legend.then(move || {
                 Box::new(move |overlay: &mut helio_pass_debug_overlay::DebugOverlayState| {
                     let stats = *shared_stats.lock().unwrap();
-                    overlay.write_text(0, 2, "VG LOD HEATMAP");
-                    if let Some((first, last)) = stats.selected_lod_range() {
-                        overlay.write_text(
-                            0,
-                            3,
-                            &format!(
-                                "GPU objects: {}  selected: LOD{}..LOD{}  asset max: LOD{}",
-                                stats.visible_objects(), first, last, stats.max_available_lod,
-                            ),
-                        );
-                        overlay.write_text(
-                            0,
-                            4,
-                            &format!(
-                                "Meshlets: {} visible  {} rejected",
-                                stats.visible_meshlets, stats.rejected_meshlets,
-                            ),
-                        );
-                    } else {
-                        overlay.write_text(0, 3, "GPU LOD sample pending / no VG objects visible");
-                    }
-                    for (lod, color) in LOD_COLORS.iter().enumerate() {
-                        let x = 8.0 + lod as f32 * 68.0;
-                        overlay.add_bar(x, 128.0, 20.0, 14.0, color[0], color[1], color[2], 1.0);
-                        overlay.write_small(
-                            (x / 8.0) as u32 + 3,
-                            11,
-                            &format!("L{lod}:{}", stats.lod_object_counts[lod]),
-                        );
-                    }
-                    overlay.write_text(0, 6, "LOD0 = full detail; asset max can be below LOD7");
+                    overlay.write_text(0, 2, "VG FLAT DAG CULL");
+                    overlay.write_text(
+                        0,
+                        3,
+                        &format!(
+                            "Meshlets: {} visible  {} rejected",
+                            stats.visible_meshlets, stats.rejected_meshlets,
+                        ),
+                    );
                 }) as Box<dyn Fn(&mut helio_pass_debug_overlay::DebugOverlayState) + Send + Sync>
             });
         }

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -76,6 +76,8 @@ struct CaseBuffers {
     indirect: wgpu::Buffer,
     draw_count: wgpu::Buffer,
     draw_count_readback: wgpu::Buffer,
+    emit_flags: wgpu::Buffer,
+    emit_flag_bytes: u64,
     object_dispatch_width: u32,
     object_dispatch_height: u32,
     work_dispatch_width: u32,
@@ -245,6 +247,7 @@ async fn run() {
             println!("{},SKIPPED,storage_binding_limit", case.name);
             continue;
         }
+        // Engine uses meshlet_count*2 so opaque and alpha each get a full half.
         let buffers = create_case_buffers(
             &device,
             &queue,
@@ -252,7 +255,7 @@ async fn run() {
             &cull_bind_group_layout,
             case,
             &limits,
-            TOTAL_MESHLETS,
+            TOTAL_MESHLETS * 2,
         );
 
         for _ in 0..warmup {
@@ -289,7 +292,7 @@ async fn run() {
             case.name
         );
         assert_eq!(
-            counters[1], buffers.expected_overflow,
+            counters[2], buffers.expected_overflow,
             "{} reported an unexpected capacity overflow",
             case.name
         );
@@ -342,6 +345,8 @@ async fn run() {
         );
     }
 
+    // Opaque half capacity = draw_capacity/2. Reject 17 by sizing the opaque half
+    // to TOTAL_MESHLETS - 17.
     let overflow_probe = create_case_buffers(
         &device,
         &queue,
@@ -353,7 +358,7 @@ async fn run() {
             meshlets_per_object: TOTAL_MESHLETS / 4096,
         },
         &limits,
-        TOTAL_MESHLETS - 17,
+        (TOTAL_MESHLETS - 17) * 2,
     );
     let _ = dispatch_and_time(
         &device,
@@ -366,8 +371,14 @@ async fn run() {
         &query_readback,
     );
     let counters = read_draw_counters(&device, &queue, &overflow_probe);
-    assert_eq!(counters, [TOTAL_MESHLETS, 17]);
-    eprintln!("overflow_probe,attempted={},rejected={}", counters[0], counters[1]);
+    // [opaque attempts, alpha attempts, overflow rejections]
+    assert_eq!(counters[0] + counters[2], TOTAL_MESHLETS);
+    assert_eq!(counters[2], 17);
+    eprintln!(
+        "overflow_probe,attempted={},rejected={}",
+        counters[0] + counters[2],
+        counters[2]
+    );
 
     let render_probe = create_case_buffers(
         &device,
@@ -493,7 +504,8 @@ fn create_case_buffers(
     let instance_cull = vec![InstanceCullData {
         max_scale: 1.0,
         min_scale: 1.0,
-        cull_flags: 0,
+        // bit0 = cone cull, bit1 = opaque (matches InstanceCullData / vg_cull.wgsl)
+        cull_flags: 2,
         valid_transform: 1,
     }; case.object_count as usize];
     let meshlets = vec![GpuMeshletEntry {
@@ -512,10 +524,14 @@ fn create_case_buffers(
         .map(|instance_index| {
             GpuVgObject {
                 instance_index,
-                meshlet_count: case.meshlets_per_object,
+                leaf_meshlet_count: case.meshlets_per_object,
                 first_meshlet: 0,
-                reserved: 0,
+                total_meshlet_count: case.meshlets_per_object,
                 local_bounds: [0.0, 0.0, -10.0, 1.0],
+                emit_flag_base: instance_index * case.meshlets_per_object,
+                visible: 0,
+                _pad0: 0,
+                _pad1: 0,
             }
         })
         .collect();
@@ -562,6 +578,16 @@ fn create_case_buffers(
     let instance_buffer = init_buffer(device, "Benchmark Instances", bytemuck::cast_slice(&instances), wgpu::BufferUsages::STORAGE);
     let instance_cull_buffer = init_buffer(device, "Benchmark Instance Cull", bytemuck::cast_slice(&instance_cull), wgpu::BufferUsages::STORAGE);
     let work_item_buffer = init_buffer(device, "Benchmark Work Items", bytemuck::cast_slice(&work_items), wgpu::BufferUsages::STORAGE);
+    let emit_flag_count = u64::from(case.object_count) * u64::from(case.meshlets_per_object);
+    let emit_flags_buffer = output_buffer(
+        device,
+        "Benchmark Emit Flags",
+        emit_flag_count.max(1) * 4,
+        wgpu::BufferUsages::empty(),
+    );
+    let vis_ids_buffer = output_buffer(device, "Benchmark Vis Meshlet IDs", 4, wgpu::BufferUsages::empty());
+    let vis_inst_buffer = output_buffer(device, "Benchmark Vis Instance IDs", 4, wgpu::BufferUsages::empty());
+    let vis_count_buffer = output_buffer(device, "Benchmark Vis Count", 4, wgpu::BufferUsages::empty());
     let indirect_buffer = output_buffer(
         device,
         "Benchmark Indirect",
@@ -577,12 +603,12 @@ fn create_case_buffers(
     let draw_count = output_buffer(
         device,
         "Benchmark Draw And Overflow Counters",
-        8,
+        12, // opaque, alpha, overflow
         wgpu::BufferUsages::INDIRECT,
     );
     let draw_count_readback = device.create_buffer(&wgpu::BufferDescriptor {
         label: Some("Benchmark Draw Count Readback"),
-        size: 8,
+        size: 12,
         usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
         mapped_at_creation: false,
     });
@@ -617,35 +643,34 @@ fn create_case_buffers(
         ..Default::default()
     });
 
+    // Full bind-group entries required by vg_cull.wgsl (select + cull share layout).
+    let full_entries = [
+        wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 2, resource: meshlet_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 5, resource: indirect_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 6, resource: metadata_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 7, resource: draw_count.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(&hiz_view) },
+        wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(&hiz_sampler) },
+        wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 11, resource: work_item_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 12, resource: vis_ids_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 13, resource: vis_inst_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 14, resource: vis_count_buffer.as_entire_binding() },
+        wgpu::BindGroupEntry { binding: 15, resource: emit_flags_buffer.as_entire_binding() },
+    ];
     let select_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("VG Object Select Benchmark Bind Group"),
         layout: select_layout,
-        entries: &[
-            wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 7, resource: draw_count.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
-        ],
+        entries: &full_entries,
     });
     let cull_bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("VG Cull Benchmark Bind Group"),
         layout: cull_layout,
-        entries: &[
-            wgpu::BindGroupEntry { binding: 0, resource: camera_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 1, resource: cull_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 2, resource: meshlet_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 3, resource: object_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 4, resource: instance_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 5, resource: indirect_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 6, resource: metadata_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 7, resource: draw_count.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 8, resource: wgpu::BindingResource::TextureView(&hiz_view) },
-            wgpu::BindGroupEntry { binding: 9, resource: wgpu::BindingResource::Sampler(&hiz_sampler) },
-            wgpu::BindGroupEntry { binding: 10, resource: instance_cull_buffer.as_entire_binding() },
-            wgpu::BindGroupEntry { binding: 11, resource: work_item_buffer.as_entire_binding() },
-        ],
+        entries: &full_entries,
     });
 
     CaseBuffers {
@@ -654,12 +679,15 @@ fn create_case_buffers(
         indirect: indirect_buffer,
         draw_count,
         draw_count_readback,
+        emit_flags: emit_flags_buffer,
+        emit_flag_bytes: emit_flag_count.max(1) * 4,
         object_dispatch_width,
         object_dispatch_height,
         work_dispatch_width,
         work_dispatch_height,
         expected_attempts: TOTAL_MESHLETS,
-        expected_overflow: TOTAL_MESHLETS.saturating_sub(draw_capacity),
+        // Opaque path only uses the first half of draw_capacity.
+        expected_overflow: TOTAL_MESHLETS.saturating_sub(draw_capacity / 2),
     }
 }
 
@@ -677,6 +705,7 @@ fn dispatch_and_time(
         label: Some("VG Cull Benchmark Encoder"),
     });
     encoder.clear_buffer(&buffers.draw_count, 0, None);
+    encoder.clear_buffer(&buffers.emit_flags, 0, Some(buffers.emit_flag_bytes));
     encoder.write_timestamp(query_set, 0);
     {
         let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
@@ -717,14 +746,14 @@ fn read_draw_counters(
     device: &wgpu::Device,
     queue: &wgpu::Queue,
     buffers: &CaseBuffers,
-) -> [u32; 2] {
+) -> [u32; 3] {
     let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
         label: Some("VG Cull Count Readback Encoder"),
     });
-    encoder.copy_buffer_to_buffer(&buffers.draw_count, 0, &buffers.draw_count_readback, 0, 8);
+    encoder.copy_buffer_to_buffer(&buffers.draw_count, 0, &buffers.draw_count_readback, 0, 12);
     queue.submit([encoder.finish()]);
-    let values = read_mapped::<u32>(device, &buffers.draw_count_readback, 2);
-    [values[0], values[1]]
+    let values = read_mapped::<u32>(device, &buffers.draw_count_readback, 3);
+    [values[0], values[1], values[2]]
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/examples/meshlet_cull_benchmark.rs
+++ b/crates/examples/meshlet_cull_benchmark.rs
@@ -49,7 +49,7 @@ struct CullUniforms {
     object_dispatch_width: u32,
     work_item_count: u32,
     work_dispatch_width: u32,
-    _pad0: u32,
+    hiz_valid: u32,
     _pad1: u32,
     _pad2: u32,
 }
@@ -59,7 +59,7 @@ struct CullUniforms {
 struct InstanceCullData {
     max_scale: f32,
     min_scale: f32,
-    cone_cull_enabled: u32,
+    cull_flags: u32,
     valid_transform: u32,
 }
 
@@ -493,7 +493,7 @@ fn create_case_buffers(
     let instance_cull = vec![InstanceCullData {
         max_scale: 1.0,
         min_scale: 1.0,
-        cone_cull_enabled: 0,
+        cull_flags: 0,
         valid_transform: 1,
     }; case.object_count as usize];
     let meshlets = vec![GpuMeshletEntry {
@@ -503,24 +503,19 @@ fn create_case_buffers(
         cone_cutoff: 2.0,
         cone_axis: [0.0, 0.0, 1.0],
         lod_error: 0.0,
-        first_index: 0,
-        index_count: 3,
-        vertex_offset: 0,
-        instance_index: 0,
+        packed_counts: 3 | (1 << 16), // vertex_count=3, triangle_count=1
+        meshlet_index_offset: 0,
+        meshlet_vertex_offset: 0,
+        parent_cluster_id: u32::MAX,
     }; case.meshlets_per_object as usize];
     let objects: Vec<_> = (0..case.object_count)
         .map(|instance_index| {
-            let mut lod_meshlet_counts = [0; 8];
-            lod_meshlet_counts[0] = case.meshlets_per_object;
             GpuVgObject {
                 instance_index,
-                lod_count: 1,
-                max_meshlet_count: case.meshlets_per_object,
+                meshlet_count: case.meshlets_per_object,
+                first_meshlet: 0,
                 reserved: 0,
                 local_bounds: [0.0, 0.0, -10.0, 1.0],
-                lod_errors: [0.0; 8],
-                lod_first_meshlets: [0; 8],
-                lod_meshlet_counts,
             }
         })
         .collect();
@@ -555,7 +550,7 @@ fn create_case_buffers(
         object_dispatch_width,
         work_item_count,
         work_dispatch_width,
-        _pad0: 0,
+        hiz_valid: 0,
         _pad1: 0,
         _pad2: 0,
     };

--- a/crates/helio-pass-gbuffer/shaders/gbuffer.wgsl
+++ b/crates/helio-pass-gbuffer/shaders/gbuffer.wgsl
@@ -143,7 +143,7 @@ struct VertexOutput {
     @location(3) world_tangent:  vec3<f32>,
     @location(4) bitangent_sign: f32,
     @location(5) @interpolate(flat) material_id:    u32,
-    @location(6) lightmap_uv:    vec2<f32>,  // Lightmap atlas UV (or (0,0) if no lightmap)
+    @location(6) lightmap_uv:    vec4<f32>,  // Lightmap atlas UV (or (0,0,0,0) if no lightmap)
 }
 
 fn decode_snorm8x4(packed: u32) -> vec3<f32> {
@@ -209,11 +209,11 @@ fn vs_main(v: Vertex, @builtin(instance_index) slot: u32) -> VertexOutput {
             use_uv1,
         );
         let raw_uv = region.uv_offset + lm_input * region.uv_scale;
-        out.lightmap_uv = clamp(raw_uv, region.uv_clamp_min, region.uv_clamp_max);
+        out.lightmap_uv = vec4<f32>(clamp(raw_uv, region.uv_clamp_min, region.uv_clamp_max), 0.0, 0.0);
     } else {
         // Sentinel: negative UV signals "no lightmap" to the deferred pass.
         // Cannot use (0,0) because a valid atlas region can start at (0,0).
-        out.lightmap_uv = vec2<f32>(-1.0, -1.0);
+        out.lightmap_uv = vec4<f32>(-1.0, -1.0, 0.0, 0.0);
     }
     return out;
 }
@@ -225,7 +225,7 @@ struct GBufferOutput {
     @location(1) normal:      vec4<f32>,
     @location(2) orm:         vec4<f32>,
     @location(3) emissive:    vec4<f32>,
-    @location(4) lightmap_uv: vec2<f32>,
+    @location(4) lightmap_uv: vec4<f32>,
     @location(5) sss:         vec4<f32>,
     @location(6) extra:       vec4<f32>,
 }
@@ -397,7 +397,7 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
             vec4<f32>(0.0, 0.0, 1.0, 0.0),
             vec4<f32>(0.0),
             vec4<f32>(0.0),
-            vec2<f32>(0.0),
+            vec4<f32>(0.0),
             vec4<f32>(0.0),
             vec4<f32>(0.0)
         );
@@ -411,7 +411,7 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
             vec4<f32>(0.0, 0.0, 1.0, 0.0),
             vec4<f32>(0.0),
             vec4<f32>(0.0),
-            vec2<f32>(0.0),
+            vec4<f32>(0.0),
             vec4<f32>(0.0),
             vec4<f32>(0.0)
         );
@@ -431,7 +431,7 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
             vec4<f32>(N_geom, 0.0),
             vec4<f32>(1.0, roughness, metallic, 0.0),
             vec4<f32>(0.0),
-            vec2<f32>(0.0),
+            vec4<f32>(0.0),
             vec4<f32>(0.0),
             vec4<f32>(0.0)
         );

--- a/crates/helio-pass-gbuffer/src/lib.rs
+++ b/crates/helio-pass-gbuffer/src/lib.rs
@@ -236,9 +236,10 @@ impl RenderPass for GBufferPass {
         builder.with_extra_usage(wgpu::TextureUsages::STORAGE_BINDING);
         builder.write_color_raw(
             "gbuffer_lightmap_uv",
-            wgpu::TextureFormat::Rg16Float,
+            wgpu::TextureFormat::Rgba16Float,
             ResourceSize::MatchSurface,
         );
+        builder.with_extra_usage(wgpu::TextureUsages::STORAGE_BINDING);
         builder.write_color_raw(
             "gbuffer_sss",
             wgpu::TextureFormat::Rgba16Float,
@@ -757,7 +758,7 @@ impl GBufferPass {
                         write_mask: wgpu::ColorWrites::ALL,
                     }),
                     Some(wgpu::ColorTargetState {
-                        format: wgpu::TextureFormat::Rg16Float,
+                        format: wgpu::TextureFormat::Rgba16Float,
                         blend: None,
                         write_mask: wgpu::ColorWrites::ALL,
                     }),

--- a/crates/helio-pass-virtual-geometry/shaders/vg_binning.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_binning.wgsl
@@ -1,0 +1,147 @@
+// Tile binning compute shader (Phase 5: Software Rasterization).
+//
+// Reads the compact visible meshlet list produced by the cull shader and
+// distributes each meshlet into the screen-space tiles it overlaps.
+// Each thread handles one visible meshlet.
+
+struct Camera {
+    view:           mat4x4<f32>,
+    proj:           mat4x4<f32>,
+    view_proj:      mat4x4<f32>,
+    view_proj_inv:  mat4x4<f32>,
+    position_near:  vec4<f32>,
+    forward_far:    vec4<f32>,
+    jitter_frame:   vec4<f32>,
+    prev_view_proj: mat4x4<f32>,
+}
+
+struct MeshletEntry {
+    center:               vec3<f32>,
+    radius:               f32,
+    cone_apex:            vec3<f32>,
+    cone_cutoff:          f32,
+    cone_axis:            vec3<f32>,
+    lod_error:            f32,
+    packed_counts:        u32,
+    meshlet_index_offset: u32,
+    meshlet_vertex_offset: u32,
+    parent_cluster_id:    u32,
+}
+
+struct CullUniforms {
+    object_count:           u32,
+    screen_width:           u32,
+    screen_height:          u32,
+    hiz_mip_count:          u32,
+    draw_capacity:          u32,
+    lod_error_threshold_px: f32,
+    object_dispatch_width:  u32,
+    work_item_count:        u32,
+    work_dispatch_width:    u32,
+    hiz_valid:              u32,
+    _pad1:                  u32,
+    _pad2:                  u32,
+}
+
+struct InstanceData {
+    transform:    mat4x4<f32>,
+    normal_mat_0: vec4<f32>,
+    normal_mat_1: vec4<f32>,
+    normal_mat_2: vec4<f32>,
+    bounds:       vec4<f32>,
+    mesh_id:      u32,
+    material_id:  u32,
+    flags:        u32,
+    _pad:         u32,
+}
+
+@group(0) @binding(0) var<storage, read> visible_meshlet_ids:   array<u32>;
+@group(0) @binding(1) var<storage, read> visible_instance_ids:  array<u32>;
+@group(0) @binding(2) var<storage, read> instances:             array<InstanceData>;
+@group(0) @binding(3) var<storage, read> meshlets:              array<MeshletEntry>;
+@group(0) @binding(4) var<uniform>       camera:                Camera;
+@group(0) @binding(5) var<uniform>       cull_uni:              CullUniforms;
+@group(0) @binding(6) var<storage, read_write> tile_counts:     array<atomic<u32>>;
+@group(0) @binding(7) var<storage, read_write> tile_meshlet_ids:    array<u32>;
+@group(0) @binding(8) var<storage, read_write> tile_instance_ids:   array<u32>;
+
+const TILE_SIZE_X: u32 = 8u;
+const TILE_SIZE_Y: u32 = 8u;
+const MAX_MESHLETS_PER_TILE: u32 = 64u;
+
+@compute @workgroup_size(64)
+fn cs_binning(@builtin(global_invocation_id) id: vec3<u32>) {
+    let vis_count = cull_uni.draw_capacity;
+    if id.x >= vis_count { return; }
+
+    let meshlet_id = visible_meshlet_ids[id.x];
+    if meshlet_id >= arrayLength(&meshlets) { return; }
+
+    let instance_id = visible_instance_ids[id.x];
+    if instance_id >= arrayLength(&instances) { return; }
+
+    let meshlet = meshlets[meshlet_id];
+    let inst = instances[instance_id];
+
+    // Transform bounding sphere center to world space
+    let center_ws = (inst.transform * vec4<f32>(meshlet.center, 1.0)).xyz;
+    let world_radius = max(meshlet.radius * 1.0, 0.0);
+
+    // Approximate world radius from the instance transform scale
+    let s0 = length(inst.transform[0].xyz);
+    let s1 = length(inst.transform[1].xyz);
+    let s2 = length(inst.transform[2].xyz);
+    let max_scale = max(max(s0, s1), s2);
+    let world_radius_scaled = world_radius * max_scale;
+
+    // Project center to clip space
+    let clip_center = camera.view_proj * vec4<f32>(center_ws, 1.0);
+    if clip_center.w <= 0.0 { return; }
+
+    // NDC to screen
+    let w_inv = 1.0 / clip_center.w;
+    let ndc = clip_center.xyz * w_inv;
+    if abs(ndc.x) > 1.0 || abs(ndc.y) > 1.0 || ndc.z < 0.0 || ndc.z > 1.0 {
+        // Check if bounding sphere can still be visible even if center is outside
+        // Full sphere-cull is complex; for now just check if sphere touches the frustum
+    }
+
+    // Projected sphere radius in screen pixels
+    let proj_radius_x = abs(world_radius_scaled * camera.proj[0][0] * w_inv);
+    let proj_radius_y = abs(world_radius_scaled * camera.proj[1][1] * w_inv);
+    let screen_radius_x = proj_radius_x * f32(cull_uni.screen_width) * 0.5;
+    let screen_radius_y = proj_radius_y * f32(cull_uni.screen_height) * 0.5;
+
+    // Screen-space center
+    let screen_cx = (ndc.x * 0.5 + 0.5) * f32(cull_uni.screen_width);
+    let screen_cy = (ndc.y * -0.5 + 0.5) * f32(cull_uni.screen_height);
+
+    // Compute tile bounding box
+    let min_px = i32(floor(screen_cx - screen_radius_x));
+    let min_py = i32(floor(screen_cy - screen_radius_y));
+    let max_px = i32(ceil(screen_cx + screen_radius_x));
+    let max_py = i32(ceil(screen_cy + screen_radius_y));
+
+    let tile_x_start = max(0, min_px / i32(TILE_SIZE_X));
+    let tile_y_start = max(0, min_py / i32(TILE_SIZE_Y));
+    let tile_x_end = min(i32((cull_uni.screen_width + TILE_SIZE_X - 1u) / TILE_SIZE_X), (max_px + i32(TILE_SIZE_X) - 1) / i32(TILE_SIZE_X));
+    let tile_y_end = min(i32((cull_uni.screen_height + TILE_SIZE_Y - 1u) / TILE_SIZE_Y), (max_py + i32(TILE_SIZE_Y) - 1) / i32(TILE_SIZE_Y));
+
+    let tile_grid_x = (cull_uni.screen_width + TILE_SIZE_X - 1u) / TILE_SIZE_X;
+
+    var ty = tile_y_start;
+    while ty < tile_y_end {
+        var tx = tile_x_start;
+        while tx < tile_x_end {
+            let tile_idx = u32(ty) * tile_grid_x + u32(tx);
+            let slot = atomicAdd(&tile_counts[tile_idx], 1u);
+            if slot < MAX_MESHLETS_PER_TILE {
+                let base = tile_idx * MAX_MESHLETS_PER_TILE;
+                tile_meshlet_ids[base + slot] = meshlet_id;
+                tile_instance_ids[base + slot] = instance_id;
+            }
+            tx++;
+        }
+        ty++;
+    }
+}

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -1,9 +1,12 @@
-// Virtual geometry culling compute shader.
+// Virtual geometry culling compute shader (Flat Cluster DAG).
 //
-// Stage one assigns one lane per object for conservative object culling and a
-// whole-object LOD decision. Stage two assigns one 64-lane workgroup to each
-// immutable meshlet span, so very large objects scale across the GPU instead of
-// serialising all their meshlets through one workgroup.
+// Stage one (cs_select_objects): per-object frustum culling.  No LOD selection
+// happens here — every meshlet independently decides its own LOD.
+//
+// Stage two (cs_cull_meshlets): iterates ALL meshlets for each object and uses
+// the per-meshlet DAG (parent_cluster_id + lod_error) to decide whether to
+// emit a draw command.  A single workgroup covers up to 64 meshlets from one
+// object (across all LODs).
 
 struct Camera {
     view:           mat4x4<f32>,
@@ -18,28 +21,25 @@ struct Camera {
 
 /// Mirrors GpuMeshletEntry (Rust, 64 bytes).
 struct MeshletEntry {
-    center:         vec3<f32>,
-    radius:         f32,
-    cone_apex:      vec3<f32>,
-    cone_cutoff:    f32,
-    cone_axis:      vec3<f32>,
-    lod_error:      f32,
-    first_index:    u32,
-    index_count:    u32,
-    vertex_offset:  i32,
-    instance_index: u32,
+    center:              vec3<f32>,
+    radius:              f32,
+    cone_apex:           vec3<f32>,
+    cone_cutoff:         f32,
+    cone_axis:           vec3<f32>,
+    lod_error:           f32,
+    packed_counts:       u32,   // lo 16 = vertex_count, hi 16 = triangle_count
+    meshlet_index_offset: u32,  // offset in u16 elements into meshlet index stream
+    meshlet_vertex_offset: u32, // offset in vertex elements into meshlet vertex stream
+    parent_cluster_id:   u32,
 }
 
-/// Mirrors GpuVgObject (Rust, 128 bytes).
+/// Mirrors GpuVgObject (Rust, 32 bytes).
 struct VgObjectData {
-    instance_index:       u32,
-    lod_count:            u32,
-    max_meshlet_count:    u32,
-    selected_lod_plus_one: u32,
-    local_bounds:         vec4<f32>,
-    lod_errors:           array<f32, 8>,
-    lod_first_meshlets:   array<u32, 8>,
-    lod_meshlet_counts:   array<u32, 8>,
+    instance_index:  u32,
+    meshlet_count:   u32,
+    first_meshlet:   u32,
+    _pad:            u32,
+    local_bounds:    vec4<f32>,
 }
 
 /// Mirrors GpuInstanceData (Rust, 144 bytes).
@@ -98,11 +98,6 @@ struct CullUniforms {
     object_dispatch_width: u32,
     work_item_count:       u32,
     work_dispatch_width:   u32,
-    // 0 on frame 0 (or right after a resize rebuilds the graph): the Hi-Z
-    // pyramid hasn't been built from any real depth yet, so its texture reads
-    // back as 0.0 — which this engine's near=0.0 depth convention would
-    // otherwise read as "everything is behind the (nonexistent) occluder",
-    // culling the whole visible scene for that one frame.
     hiz_valid:             u32,
     _pad1:                 u32,
     _pad2:                 u32,
@@ -115,21 +110,23 @@ struct CullUniforms {
 @group(0) @binding(4) var<storage, read> instances: array<InstanceData>;
 @group(0) @binding(5) var<storage, read_write> indirect: array<DrawIndexedIndirect>;
 @group(0) @binding(6) var<storage, read_write> draw_metadata: array<VgDrawMetadata>;
-// Counter 0 is the attempted visible-draw count consumed by indirect-count
-// rendering. Counter 1 records attempts rejected by the bounded output arrays.
 @group(0) @binding(7) var<storage, read_write> draw_counters: array<atomic<u32>>;
 @group(0) @binding(8) var hiz_tex: texture_2d<f32>;
 @group(0) @binding(9) var hiz_samp: sampler;
 @group(0) @binding(10) var<storage, read> instance_cull: array<InstanceCullData>;
 @group(0) @binding(11) var<storage, read> work_items: array<VgWorkItem>;
+@group(0) @binding(12) var<storage, read_write> visible_meshlet_ids:   array<u32>;
+@group(0) @binding(13) var<storage, read_write> visible_instance_ids:  array<u32>;
+@group(0) @binding(14) var<storage, read_write> visible_meshlet_count: atomic<u32>;
 
 var<workgroup> wg_planes: array<vec4<f32>, 6>;
 var<workgroup> wg_first_meshlet: u32;
 var<workgroup> wg_meshlet_count: u32;
 var<workgroup> wg_instance_index: u32;
-var<workgroup> wg_selected_lod: u32;
-var<workgroup> wg_object_visible: u32;
 var<workgroup> wg_local_meshlet_base: u32;
+var<workgroup> wg_object_visible: u32;
+// Workgroup dedup: each lane stores its selected meshlet (0xFFFFFFFF = skip).
+var<workgroup> wg_selected: array<u32, 64>;
 
 fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
     return (dot(wg_planes[0].xyz, center) + wg_planes[0].w >= -radius)
@@ -140,7 +137,7 @@ fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
         && (dot(wg_planes[5].xyz, center) + wg_planes[5].w >= -radius);
 }
 
-fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
+fn emit_draw(meshlet_index: u32, instance_index: u32, lod_level: u32) {
     if meshlet_index >= arrayLength(&meshlets)
         || instance_index >= arrayLength(&instances)
         || instance_index >= arrayLength(&instance_cull)
@@ -149,105 +146,9 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
     }
 
     let m = meshlets[meshlet_index];
-    let inst = instances[instance_index];
     let inst_cull = instance_cull[instance_index];
     if inst_cull.valid_transform == 0u {
         return;
-    }
-
-    let model = inst.transform;
-    let center_ws = (model * vec4<f32>(m.center, 1.0)).xyz;
-    let world_radius = max(m.radius * inst_cull.max_scale, 0.0);
-    let cam_to_center = center_ws - camera.position_near.xyz;
-
-    if !sphere_visible(center_ws, world_radius) {
-        return;
-    }
-
-    // Exact meshoptimizer perspective-cone test. The normal matrix is safe
-    // only for angle-preserving, non-reflected transforms; CPU precomputes the
-    // conservative enable bit once per changed instance.
-    let cam_dist_sq = dot(cam_to_center, cam_to_center);
-    let guard_radius = world_radius * 1.5;
-    if cam_dist_sq > guard_radius * guard_radius
-        && m.cone_cutoff <= 1.0
-        && (inst_cull.cull_flags & CULL_FLAG_CONE_CULL) != 0u
-    {
-        let normal_mat = mat3x3<f32>(
-            inst.normal_mat_0.xyz,
-            inst.normal_mat_1.xyz,
-            inst.normal_mat_2.xyz,
-        );
-        let cone_axis_ws = normalize(normal_mat * m.cone_axis);
-        let cone_apex_ws = (model * vec4<f32>(m.cone_apex, 1.0)).xyz;
-        let camera_to_apex = cone_apex_ws - camera.position_near.xyz;
-        let apex_distance_sq = dot(camera_to_apex, camera_to_apex);
-        if apex_distance_sq > 1.0e-12
-            && dot(camera_to_apex / sqrt(apex_distance_sq), cone_axis_ws) >= m.cone_cutoff
-        {
-            return;
-        }
-    }
-
-    // Conservative max-depth Hi-Z test. Reject only when the complete
-    // projected sphere is on-screen and all four footprint corners are behind
-    // existing depth at the chosen mip. Skipped entirely on the frame the
-    // pyramid isn't valid yet (see CullUniforms.hiz_valid) — otherwise an
-    // untouched depth texture reads back as 0.0 and every meshlet looks
-    // occluded.
-    let cull_clip = camera.view_proj * vec4<f32>(center_ws, 1.0);
-    if cull_uni.hiz_valid != 0u && cull_clip.w > 0.0 {
-        let cull_ndc = cull_clip.xyz / cull_clip.w;
-        let cull_uv = vec2<f32>(cull_ndc.x * 0.5 + 0.5, cull_ndc.y * -0.5 + 0.5);
-        let nearest_view_depth = cull_clip.w - world_radius;
-        if nearest_view_depth > camera.position_near.w {
-            let ndc_r = max(
-                abs(world_radius * camera.proj[0][0] / nearest_view_depth),
-                abs(world_radius * camera.proj[1][1] / nearest_view_depth),
-            );
-            let uv_radius = ndc_r * 0.5;
-            let uv_min = cull_uv - vec2<f32>(uv_radius);
-            let uv_max = cull_uv + vec2<f32>(uv_radius);
-
-            if all(uv_min >= vec2<f32>(0.0)) && all(uv_max <= vec2<f32>(1.0)) {
-                let dist_sq = dot(cam_to_center, cam_to_center);
-                var near_z = 0.0;
-                if dist_sq > world_radius * world_radius {
-                    let direction = cam_to_center / sqrt(dist_sq);
-                    let near_ws = center_ws - direction * world_radius;
-                    let near_clip = camera.view_proj * vec4<f32>(near_ws, 1.0);
-                    if near_clip.w > 0.0 {
-                        near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
-                    }
-                }
-
-                let half_height = f32(cull_uni.screen_height) * 0.5;
-                let diameter_px = max(ndc_r * half_height * 2.0, 1.0);
-                let mip = clamp(
-                    u32(ceil(log2(diameter_px))),
-                    0u,
-                    cull_uni.hiz_mip_count - 1u,
-                );
-                let hiz_00 = textureSampleLevel(hiz_tex, hiz_samp, uv_min, f32(mip)).r;
-                let hiz_01 = textureSampleLevel(
-                    hiz_tex,
-                    hiz_samp,
-                    vec2<f32>(uv_max.x, uv_min.y),
-                    f32(mip),
-                ).r;
-                let hiz_10 = textureSampleLevel(
-                    hiz_tex,
-                    hiz_samp,
-                    vec2<f32>(uv_min.x, uv_max.y),
-                    f32(mip),
-                ).r;
-                let hiz_11 = textureSampleLevel(hiz_tex, hiz_samp, uv_max, f32(mip)).r;
-                let hiz_depth = max(max(hiz_00, hiz_01), max(hiz_10, hiz_11));
-                if near_z > hiz_depth + 1.0 / 65536.0 {
-                    return;
-                }
-            }
-        }
     }
 
     let is_opaque = (inst_cull.cull_flags & CULL_FLAG_OPAQUE) != 0u;
@@ -273,11 +174,12 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
         slot = half_capacity + alpha_slot;
     }
 
+    let tri_count = m.packed_counts >> 16u;
     var command: DrawIndexedIndirect;
-    command.index_count = m.index_count;
+    command.index_count = tri_count * 3u;
     command.instance_count = 1u;
-    command.first_index = m.first_index;
-    command.base_vertex = m.vertex_offset;
+    command.first_index = m.meshlet_index_offset;
+    command.base_vertex = i32(m.meshlet_vertex_offset);
     command.first_instance = slot;
     indirect[slot] = command;
     draw_metadata[slot] = VgDrawMetadata(
@@ -286,6 +188,13 @@ fn cull_meshlet(meshlet_index: u32, instance_index: u32, lod_level: u32) {
         lod_level,
         0u,
     );
+
+    // Append to the visible meshlet list for SW rasterizer binning
+    let vis_idx = atomicAdd(&visible_meshlet_count, 1u);
+    if vis_idx < arrayLength(&visible_meshlet_ids) {
+        visible_meshlet_ids[vis_idx] = meshlet_index;
+        visible_instance_ids[vis_idx] = instance_index;
+    }
 }
 
 fn publish_frustum_planes() {
@@ -303,6 +212,11 @@ fn publish_frustum_planes() {
     wg_planes[4] = p4 / length(p4.xyz);
     wg_planes[5] = p5 / length(p5.xyz);
 }
+
+// ── Stage 1: object selection (simplified — frustum cull only) ───────────────
+//
+// Per-object frustum culling.  No per-LOD selection — every visible object
+// is fully processed by stage 2, which uses the flat DAG for per-meshlet LOD.
 
 @compute @workgroup_size(64)
 fn cs_select_objects(
@@ -323,11 +237,9 @@ fn cs_select_objects(
         return;
     }
 
-    var selected_lod_plus_one = 0u;
     let object = objects[object_index];
-    let lod_count = min(object.lod_count, 8u);
-    if lod_count > 0u
-        && object.instance_index < arrayLength(&instances)
+    var visible = 0u;
+    if object.instance_index < arrayLength(&instances)
         && object.instance_index < arrayLength(&instance_cull)
     {
         let inst = instances[object.instance_index];
@@ -338,44 +250,23 @@ fn cs_select_objects(
             ).xyz;
             let world_radius = max(object.local_bounds.w * derived.max_scale, 0.0);
             if sphere_visible(center_ws, world_radius) {
-                let camera_distance = length(center_ws - camera.position_near.xyz);
-                let closest_distance = max(
-                    camera_distance - world_radius,
-                    max(camera.position_near.w, 1.0e-4),
-                );
-                let focal_pixels = abs(camera.proj[1][1])
-                    * f32(cull_uni.screen_height) * 0.5;
-                var selected_lod = 0u;
-                var level = 1u;
-                loop {
-                    if level >= lod_count {
-                        break;
-                    }
-                    let error_px = object.lod_errors[level]
-                        * derived.max_scale * focal_pixels / closest_distance;
-                    if error_px <= cull_uni.lod_error_threshold_px {
-                        selected_lod = level;
-                        level += 1u;
-                    } else {
-                        break;
-                    }
-                }
-                selected_lod_plus_one = selected_lod + 1u;
-                // Counters 0/1 are the opaque/alpha indirect draw counts,
-                // counter 2 is the publication-overflow count. Larger
-                // production buffers also expose a selected-object histogram
-                // and the deepest LOD that the visible assets contain. The
-                // length guard keeps the same shader compatible with minimal
-                // benchmark buffers.
-                if arrayLength(&draw_counters) >= 12u {
-                    atomicAdd(&draw_counters[3u + selected_lod], 1u);
-                    atomicMax(&draw_counters[11], lod_count - 1u);
-                }
+                visible = 1u;
             }
         }
     }
-    objects[object_index].selected_lod_plus_one = selected_lod_plus_one;
+
+    // Store visibility in the reserved/pad field so stage 2 can skip
+    // invisible objects without re-culling the instance bounds.
+    objects[object_index]._pad = visible;
 }
+
+// ── Stage 2: meshlet cull with flat DAG ─────────────────────────────────────
+//
+// Each work item covers up to 64 meshlets across ALL LODs for one object.
+// Each lane independently traverses its meshlet's parent chain:
+//   - If projected_error > threshold  → emit this meshlet
+//   - If projected_error <= threshold → follow parent to a coarser level
+//   - Arriving at a root (parent_cluster_id == 0xFFFFFFFF) always emits
 
 @compute @workgroup_size(64)
 fn cs_cull_meshlets(
@@ -390,9 +281,8 @@ fn cs_cull_meshlets(
         wg_first_meshlet = 0u;
         wg_meshlet_count = 0u;
         wg_instance_index = 0u;
-        wg_selected_lod = 0u;
-        wg_object_visible = 0u;
         wg_local_meshlet_base = 0u;
+        wg_object_visible = 0u;
 
         if work_index < cull_uni.work_item_count
             && work_index < arrayLength(&work_items)
@@ -400,17 +290,12 @@ fn cs_cull_meshlets(
             let item = work_items[work_index];
             if item.object_index < arrayLength(&objects) {
                 let object = objects[item.object_index];
-                if object.selected_lod_plus_one != 0u {
-                    let selected_lod = object.selected_lod_plus_one - 1u;
-                    let selected_count = object.lod_meshlet_counts[selected_lod];
-                    if item.local_meshlet_base < selected_count {
-                        wg_first_meshlet = object.lod_first_meshlets[selected_lod];
-                        wg_meshlet_count = selected_count;
-                        wg_instance_index = object.instance_index;
-                        wg_selected_lod = selected_lod;
-                        wg_local_meshlet_base = item.local_meshlet_base;
-                        wg_object_visible = 1u;
-                    }
+                if object._pad != 0u && item.local_meshlet_base < object.meshlet_count {
+                    wg_first_meshlet = object.first_meshlet;
+                    wg_meshlet_count = object.meshlet_count;
+                    wg_instance_index = object.instance_index;
+                    wg_local_meshlet_base = item.local_meshlet_base;
+                    wg_object_visible = 1u;
                 }
             }
         }
@@ -420,12 +305,171 @@ fn cs_cull_meshlets(
     if wg_object_visible == 0u {
         return;
     }
-    let local_meshlet = wg_local_meshlet_base + lane;
-    if local_meshlet < wg_meshlet_count {
-        cull_meshlet(
-            wg_first_meshlet + local_meshlet,
-            wg_instance_index,
-            wg_selected_lod,
-        );
+
+    let meshlet_index = wg_first_meshlet + wg_local_meshlet_base + lane;
+    if meshlet_index >= wg_first_meshlet + wg_meshlet_count {
+        return;
     }
+
+    let inst = instances[wg_instance_index];
+    let inst_cull = instance_cull[wg_instance_index];
+    if inst_cull.valid_transform == 0u {
+        return;
+    }
+
+    // ── Initialize dedup slot ─────────────────────────────────────────────
+    wg_selected[lane] = 0xFFFFFFFFu;
+
+    // ── DAG traversal (coarse→fine) ─────────────────────────────────────────
+    //
+    // 1. Walk up from this meshlet to the root, recording each ancestor.
+    // 2. Walk DOWN from root toward the starting meshlet, checking projected
+    //    error at each level.  Emit the coarsest level whose cumulative error
+    //    is below threshold (good enough for this distance).
+    //
+    // This matches Nanite's approach: coarse for far, fine for near.
+    let model = inst.transform;
+    let focal_pixels = abs(camera.proj[1][1]) * f32(cull_uni.screen_height) * 0.5;
+
+    // ── Walk up to root, building ancestor list ────────────────────────────
+    var ancestor: array<u32, 8>;
+    var depth: u32 = 0u;
+    var current: u32 = meshlet_index;
+    loop {
+        ancestor[depth] = current;
+        depth++;
+        let m = meshlets[current];
+        if m.parent_cluster_id == 0xFFFFFFFFu || depth >= 8u {
+            break;
+        }
+        current = m.parent_cluster_id;
+    }
+
+    // ── Walk DOWN from root toward the starting meshlet ────────────────────
+    // ancestor[0] = starting meshlet (finest), ancestor[depth-1] = root (coarsest).
+    // Start at root (index depth-1), walk toward 0.
+    // Use a flag (selected != 0xFFFFFFFF) so we can break to dedup barrier
+    // instead of returning early (which would skip the workgroupBarrier).
+    var selected: u32 = 0xFFFFFFFFu;
+    var i: u32 = depth;
+    loop {
+        if i == 0u { break; }
+        i--;
+
+        let idx = ancestor[i];
+        let m = meshlets[idx];
+
+        // Frustum cull (conservative sphere)
+        let center_ws = (model * vec4<f32>(m.center, 1.0)).xyz;
+        let world_radius = max(m.radius * inst_cull.max_scale, 0.0);
+        if !sphere_visible(center_ws, world_radius) {
+            break; // culled — skip entire chain
+        }
+
+        // Cone cull
+        let cam_to_center = center_ws - camera.position_near.xyz;
+        let cam_dist_sq = dot(cam_to_center, cam_to_center);
+        let guard_radius = world_radius * 1.5;
+        if cam_dist_sq > guard_radius * guard_radius
+            && m.cone_cutoff <= 1.0
+            && (inst_cull.cull_flags & CULL_FLAG_CONE_CULL) != 0u
+        {
+            let normal_mat = mat3x3<f32>(
+                inst.normal_mat_0.xyz,
+                inst.normal_mat_1.xyz,
+                inst.normal_mat_2.xyz,
+            );
+            let cone_axis_ws = normalize(normal_mat * m.cone_axis);
+            let cone_apex_ws = (model * vec4<f32>(m.cone_apex, 1.0)).xyz;
+            let camera_to_apex = cone_apex_ws - camera.position_near.xyz;
+            let apex_distance_sq = dot(camera_to_apex, camera_to_apex);
+            if apex_distance_sq > 1.0e-12
+                && dot(camera_to_apex / sqrt(apex_distance_sq), cone_axis_ws) >= m.cone_cutoff
+            {
+                break;
+            }
+        }
+
+        // Hi-Z occlusion test
+        let cull_clip = camera.view_proj * vec4<f32>(center_ws, 1.0);
+        if cull_uni.hiz_valid != 0u && cull_clip.w > 0.0 {
+            let cull_ndc = cull_clip.xyz / cull_clip.w;
+            let cull_uv = vec2<f32>(cull_ndc.x * 0.5 + 0.5, cull_ndc.y * -0.5 + 0.5);
+            let nearest_view_depth = cull_clip.w - world_radius;
+            if nearest_view_depth > camera.position_near.w {
+                let ndc_r = max(
+                    abs(world_radius * camera.proj[0][0] / nearest_view_depth),
+                    abs(world_radius * camera.proj[1][1] / nearest_view_depth),
+                );
+                let uv_radius = ndc_r * 0.5;
+                let uv_min = cull_uv - vec2<f32>(uv_radius);
+                let uv_max = cull_uv + vec2<f32>(uv_radius);
+
+                if all(uv_min >= vec2<f32>(0.0)) && all(uv_max <= vec2<f32>(1.0)) {
+                    let dist_sq = dot(cam_to_center, cam_to_center);
+                    var near_z = 0.0;
+                    if dist_sq > world_radius * world_radius {
+                        let direction = cam_to_center / sqrt(dist_sq);
+                        let near_ws = center_ws - direction * world_radius;
+                        let near_clip = camera.view_proj * vec4<f32>(near_ws, 1.0);
+                        if near_clip.w > 0.0 {
+                            near_z = clamp(near_clip.z / near_clip.w, 0.0, 1.0);
+                        }
+                    }
+
+                    let half_height = f32(cull_uni.screen_height) * 0.5;
+                    let diameter_px = max(ndc_r * half_height * 2.0, 1.0);
+                    let mip = clamp(
+                        u32(ceil(log2(diameter_px))),
+                        0u,
+                        cull_uni.hiz_mip_count - 1u,
+                    );
+                    let hiz_00 = textureSampleLevel(hiz_tex, hiz_samp, uv_min, f32(mip)).r;
+                    let hiz_01 = textureSampleLevel(
+                        hiz_tex, hiz_samp,
+                        vec2<f32>(uv_max.x, uv_min.y), f32(mip),
+                    ).r;
+                    let hiz_10 = textureSampleLevel(
+                        hiz_tex, hiz_samp,
+                        vec2<f32>(uv_min.x, uv_max.y), f32(mip),
+                    ).r;
+                    let hiz_11 = textureSampleLevel(hiz_tex, hiz_samp, uv_max, f32(mip)).r;
+                    let hiz_depth = max(max(hiz_00, hiz_01), max(hiz_10, hiz_11));
+                    if near_z > hiz_depth + 1.0 / 65536.0 {
+                        break;
+                    }
+                }
+            }
+        }
+
+        // ── LOD error check ────────────────────────────────────────────────
+        let camera_distance = length(center_ws - camera.position_near.xyz);
+        let closest_distance = max(camera_distance - world_radius, 1.0e-4);
+        let projected_error = m.lod_error
+            * inst_cull.max_scale * focal_pixels / closest_distance;
+
+        if projected_error <= cull_uni.lod_error_threshold_px || i == 0u {
+            selected = idx;
+            break;
+        }
+        // projected_error > threshold → need finer detail → continue loop.
+    }
+
+    // Store selection (0xFFFFFFFF if culled or no selection made).
+    wg_selected[lane] = selected;
+
+    // ── Workgroup dedup and emit ──────────────────────────────────────────
+    // All lanes reach this barrier (no early returns above).
+    workgroupBarrier();
+
+    let chosen = wg_selected[lane];
+    if chosen == 0xFFFFFFFFu { return; }
+
+    // Check if any lane < this one already claimed the same meshlet.
+    for (var other = 0u; other < lane; other++) {
+        if wg_selected[other] == chosen {
+            return; // already emitted by a lower-index lane
+        }
+    }
+    emit_draw(chosen, wg_instance_index, 0u);
 }

--- a/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_cull.wgsl
@@ -1,12 +1,11 @@
 // Virtual geometry culling compute shader (Flat Cluster DAG).
 //
-// Stage one (cs_select_objects): per-object frustum culling.  No LOD selection
-// happens here — every meshlet independently decides its own LOD.
+// Stage one (cs_select_objects): per-object frustum culling.
 //
-// Stage two (cs_cull_meshlets): iterates ALL meshlets for each object and uses
-// the per-meshlet DAG (parent_cluster_id + lod_error) to decide whether to
-// emit a draw command.  A single workgroup covers up to 64 meshlets from one
-// object (across all LODs).
+// Stage two (cs_cull_meshlets): each work item covers up to 64 DAG LEAVES
+// (finest-LOD meshlets) of one object. Each leaf walks the parent chain and
+// selects exactly one cluster. Global atomic emit flags ensure each meshlet
+// is drawn at most once per frame (cross-workgroup fan-in safe).
 
 struct Camera {
     view:           mat4x4<f32>,
@@ -33,13 +32,19 @@ struct MeshletEntry {
     parent_cluster_id:   u32,
 }
 
-/// Mirrors GpuVgObject (Rust, 32 bytes).
+/// Mirrors GpuVgObject (Rust, 48 bytes).
+/// leaf_meshlet_count = DAG leaves (finest LOD) starting at first_meshlet.
+/// emit_flag_base indexes a per-object slice of meshlet_emit_flags.
 struct VgObjectData {
-    instance_index:  u32,
-    meshlet_count:   u32,
-    first_meshlet:   u32,
-    _pad:            u32,
-    local_bounds:    vec4<f32>,
+    instance_index:       u32,
+    leaf_meshlet_count:   u32,
+    first_meshlet:        u32,
+    total_meshlet_count:  u32,
+    local_bounds:         vec4<f32>,
+    emit_flag_base:       u32,
+    visible:              u32,
+    _pad0:                u32,
+    _pad1:                u32,
 }
 
 /// Mirrors GpuInstanceData (Rust, 144 bytes).
@@ -118,14 +123,19 @@ struct CullUniforms {
 @group(0) @binding(12) var<storage, read_write> visible_meshlet_ids:   array<u32>;
 @group(0) @binding(13) var<storage, read_write> visible_instance_ids:  array<u32>;
 @group(0) @binding(14) var<storage, read_write> visible_meshlet_count: atomic<u32>;
+// Per-meshlet emit claim flags (cleared each frame). atomicExchange claims once.
+@group(0) @binding(15) var<storage, read_write> meshlet_emit_flags: array<atomic<u32>>;
 
 var<workgroup> wg_planes: array<vec4<f32>, 6>;
 var<workgroup> wg_first_meshlet: u32;
-var<workgroup> wg_meshlet_count: u32;
+var<workgroup> wg_leaf_count: u32;
+var<workgroup> wg_total_meshlet_count: u32;
+var<workgroup> wg_emit_flag_base: u32;
 var<workgroup> wg_instance_index: u32;
 var<workgroup> wg_local_meshlet_base: u32;
 var<workgroup> wg_object_visible: u32;
-// Workgroup dedup: each lane stores its selected meshlet (0xFFFFFFFF = skip).
+// Workgroup-local selected meshlet (0xFFFFFFFF = skip). Used for intra-wg
+// pre-filter before the per-object atomic claim.
 var<workgroup> wg_selected: array<u32, 64>;
 
 fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
@@ -137,11 +147,36 @@ fn sphere_visible(center: vec3<f32>, radius: f32) -> bool {
         && (dot(wg_planes[5].xyz, center) + wg_planes[5].w >= -radius);
 }
 
-fn emit_draw(meshlet_index: u32, instance_index: u32, lod_level: u32) {
+fn emit_draw(
+    meshlet_index: u32,
+    instance_index: u32,
+    lod_level: u32,
+    emit_flag_base: u32,
+    first_meshlet: u32,
+    total_meshlet_count: u32,
+) {
     if meshlet_index >= arrayLength(&meshlets)
         || instance_index >= arrayLength(&instances)
         || instance_index >= arrayLength(&instance_cull)
     {
+        return;
+    }
+
+    // Per-object claim: first lane across all workgroups for THIS object wins.
+    // Local index keeps shared meshlet descriptors independent per instance.
+    if meshlet_index < first_meshlet {
+        return;
+    }
+    let local = meshlet_index - first_meshlet;
+    if local >= total_meshlet_count {
+        return;
+    }
+    let flag_index = emit_flag_base + local;
+    if flag_index >= arrayLength(&meshlet_emit_flags) {
+        return;
+    }
+    let prior = atomicExchange(&meshlet_emit_flags[flag_index], 1u);
+    if prior != 0u {
         return;
     }
 
@@ -213,10 +248,7 @@ fn publish_frustum_planes() {
     wg_planes[5] = p5 / length(p5.xyz);
 }
 
-// ── Stage 1: object selection (simplified — frustum cull only) ───────────────
-//
-// Per-object frustum culling.  No per-LOD selection — every visible object
-// is fully processed by stage 2, which uses the flat DAG for per-meshlet LOD.
+// ── Stage 1: object selection (frustum cull only) ────────────────────────────
 
 @compute @workgroup_size(64)
 fn cs_select_objects(
@@ -255,18 +287,15 @@ fn cs_select_objects(
         }
     }
 
-    // Store visibility in the reserved/pad field so stage 2 can skip
-    // invisible objects without re-culling the instance bounds.
-    objects[object_index]._pad = visible;
+    // Store visibility so stage 2 can skip invisible objects.
+    objects[object_index].visible = visible;
 }
 
-// ── Stage 2: meshlet cull with flat DAG ─────────────────────────────────────
+// ── Stage 2: meshlet cull with flat DAG (leaves-only entry) ──────────────────
 //
-// Each work item covers up to 64 meshlets across ALL LODs for one object.
-// Each lane independently traverses its meshlet's parent chain:
-//   - If projected_error > threshold  → emit this meshlet
-//   - If projected_error <= threshold → follow parent to a coarser level
-//   - Arriving at a root (parent_cluster_id == 0xFFFFFFFF) always emits
+// Each work item covers up to 64 LEAF meshlets for one object.
+// Each lane walks its leaf's parent chain coarse→fine and emits the coarsest
+// level whose projected error is ≤ threshold. Global atomics dedup fan-in.
 
 @compute @workgroup_size(64)
 fn cs_cull_meshlets(
@@ -279,7 +308,9 @@ fn cs_cull_meshlets(
     if lane == 0u {
         publish_frustum_planes();
         wg_first_meshlet = 0u;
-        wg_meshlet_count = 0u;
+        wg_leaf_count = 0u;
+        wg_total_meshlet_count = 0u;
+        wg_emit_flag_base = 0u;
         wg_instance_index = 0u;
         wg_local_meshlet_base = 0u;
         wg_object_visible = 0u;
@@ -290,9 +321,12 @@ fn cs_cull_meshlets(
             let item = work_items[work_index];
             if item.object_index < arrayLength(&objects) {
                 let object = objects[item.object_index];
-                if object._pad != 0u && item.local_meshlet_base < object.meshlet_count {
+                // leaf_meshlet_count is the entry range; local_meshlet_base indexes leaves.
+                if object.visible != 0u && item.local_meshlet_base < object.leaf_meshlet_count {
                     wg_first_meshlet = object.first_meshlet;
-                    wg_meshlet_count = object.meshlet_count;
+                    wg_leaf_count = object.leaf_meshlet_count;
+                    wg_total_meshlet_count = object.total_meshlet_count;
+                    wg_emit_flag_base = object.emit_flag_base;
                     wg_instance_index = object.instance_index;
                     wg_local_meshlet_base = item.local_meshlet_base;
                     wg_object_visible = 1u;
@@ -307,7 +341,7 @@ fn cs_cull_meshlets(
     }
 
     let meshlet_index = wg_first_meshlet + wg_local_meshlet_base + lane;
-    if meshlet_index >= wg_first_meshlet + wg_meshlet_count {
+    if meshlet_index >= wg_first_meshlet + wg_leaf_count {
         return;
     }
 
@@ -322,12 +356,9 @@ fn cs_cull_meshlets(
 
     // ── DAG traversal (coarse→fine) ─────────────────────────────────────────
     //
-    // 1. Walk up from this meshlet to the root, recording each ancestor.
-    // 2. Walk DOWN from root toward the starting meshlet, checking projected
-    //    error at each level.  Emit the coarsest level whose cumulative error
-    //    is below threshold (good enough for this distance).
-    //
-    // This matches Nanite's approach: coarse for far, fine for near.
+    // 1. Walk up from this LEAF meshlet to the root, recording each ancestor.
+    // 2. Walk DOWN from root toward the leaf, checking projected error.
+    //    Emit the coarsest level whose cumulative error is below threshold.
     let model = inst.transform;
     let focal_pixels = abs(camera.proj[1][1]) * f32(cull_uni.screen_height) * 0.5;
 
@@ -342,14 +373,17 @@ fn cs_cull_meshlets(
         if m.parent_cluster_id == 0xFFFFFFFFu || depth >= 8u {
             break;
         }
+        // Guard against corrupt / out-of-range parent links.
+        if m.parent_cluster_id >= arrayLength(&meshlets) {
+            break;
+        }
         current = m.parent_cluster_id;
     }
 
-    // ── Walk DOWN from root toward the starting meshlet ────────────────────
-    // ancestor[0] = starting meshlet (finest), ancestor[depth-1] = root (coarsest).
-    // Start at root (index depth-1), walk toward 0.
-    // Use a flag (selected != 0xFFFFFFFF) so we can break to dedup barrier
-    // instead of returning early (which would skip the workgroupBarrier).
+    // ── Walk DOWN from root toward the starting leaf ───────────────────────
+    // ancestor[0] = leaf (finest), ancestor[depth-1] = root (coarsest).
+    // Use selected != 0xFFFFFFFF so we can break to the dedup barrier
+    // instead of returning early (which would skip workgroupBarrier).
     var selected: u32 = 0xFFFFFFFFu;
     var i: u32 = depth;
     loop {
@@ -366,7 +400,7 @@ fn cs_cull_meshlets(
             break; // culled — skip entire chain
         }
 
-        // Cone cull
+        // Cone cull (meshopt convention: reject when view·axis >= cutoff)
         let cam_to_center = center_ws - camera.position_near.xyz;
         let cam_dist_sq = dot(cam_to_center, cam_to_center);
         let guard_radius = world_radius * 1.5;
@@ -458,18 +492,26 @@ fn cs_cull_meshlets(
     // Store selection (0xFFFFFFFF if culled or no selection made).
     wg_selected[lane] = selected;
 
-    // ── Workgroup dedup and emit ──────────────────────────────────────────
-    // All lanes reach this barrier (no early returns above).
+    // ── Workgroup pre-dedup then global emit ───────────────────────────────
+    // All active lanes that reached here must hit this barrier.
     workgroupBarrier();
 
     let chosen = wg_selected[lane];
     if chosen == 0xFFFFFFFFu { return; }
 
-    // Check if any lane < this one already claimed the same meshlet.
+    // Intra-workgroup pre-filter: only the lowest lane claiming `chosen` proceeds.
+    // Global atomic in emit_draw still required for cross-workgroup fan-in.
     for (var other = 0u; other < lane; other++) {
         if wg_selected[other] == chosen {
-            return; // already emitted by a lower-index lane
+            return;
         }
     }
-    emit_draw(chosen, wg_instance_index, 0u);
+    emit_draw(
+        chosen,
+        wg_instance_index,
+        0u,
+        wg_emit_flag_base,
+        wg_first_meshlet,
+        wg_total_meshlet_count,
+    );
 }

--- a/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_gbuffer.wgsl
@@ -94,22 +94,24 @@ struct VgDrawMetadata {
     reserved:       u32,
 }
 
-@group(0) @binding(0) var<uniform>       camera:        Camera;
-@group(0) @binding(1) var<uniform>       globals:       Globals;
-@group(0) @binding(2) var<storage, read> instance_data: array<GpuInstanceData>;
-@group(0) @binding(3) var<storage, read> draw_metadata: array<VgDrawMetadata>;
+@group(0) @binding(0) var<uniform>       camera:           Camera;
+@group(0) @binding(1) var<uniform>       globals:          Globals;
+@group(0) @binding(2) var<storage, read> instance_data:    array<GpuInstanceData>;
+@group(0) @binding(3) var<storage, read> draw_metadata:    array<VgDrawMetadata>;
+@group(0) @binding(4) var<storage, read> meshlet_vertices: array<GpuMeshletVertex>;
 
 @group(1) @binding(0) var<storage, read> materials:          array<GpuMaterial>;
 @group(1) @binding(1) var<storage, read> material_textures:  array<MaterialTextureData>;
 @group(1) @binding(2) var                scene_textures:     binding_array<texture_2d<f32>, 256>;
 @group(1) @binding(3) var                scene_samplers:     binding_array<sampler, 256>;
 
-struct Vertex {
-    @location(0) position:       vec3<f32>,
-    @location(1) bitangent_sign: f32,
-    @location(2) tex_coords:     vec2<f32>,
-    @location(3) normal:         u32,
-    @location(4) tangent:        u32,
+struct GpuMeshletVertex {
+    position:       vec3<f32>,
+    bitangent_sign: f32,
+    tex_coords0:    vec2<f32>,
+    tex_coords1:    vec2<f32>,
+    normal:         u32,
+    tangent:        u32,
 }
 
 struct VertexOutput {
@@ -128,7 +130,8 @@ fn decode_snorm8x4(packed: u32) -> vec3<f32> {
 }
 
 @vertex
-fn vs_main(v: Vertex, @builtin(instance_index) draw_slot: u32) -> VertexOutput {
+fn vs_main(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) draw_slot: u32) -> VertexOutput {
+    let v         = meshlet_vertices[vertex_id];
     let draw      = draw_metadata[draw_slot];
     let inst      = instance_data[draw.instance_index];
     let world_pos = inst.transform * vec4<f32>(v.position, 1.0);
@@ -150,7 +153,7 @@ fn vs_main(v: Vertex, @builtin(instance_index) draw_slot: u32) -> VertexOutput {
     out.world_normal   = normalize(normal_mat  * decode_snorm8x4(v.normal));
     out.world_tangent  = normalize(model_mat3  * decode_snorm8x4(v.tangent));
     out.bitangent_sign = v.bitangent_sign;
-    out.tex_coords     = v.tex_coords;
+    out.tex_coords     = v.tex_coords0;
     out.material_id    = inst.material_id;
     out.meshlet_id     = draw.meshlet_index;
     return out;
@@ -161,7 +164,7 @@ struct GBufferOutput {
     @location(1) normal:    vec4<f32>,
     @location(2) orm:       vec4<f32>,
     @location(3) emissive:  vec4<f32>,
-    @location(4) vg_flag:   vec2<f32>,
+    @location(4) vg_flag:   vec4<f32>,
     @location(5) sss:       vec4<f32>,
     @location(6) extra:     vec4<f32>,
 }
@@ -210,6 +213,23 @@ fn resolve_specular_f0(
     );
 }
 
+// ── Visibility pass fragment: depth-only, no outputs ──────────────────────
+// Only performs alpha-test discard; writes nothing to color targets.
+@fragment
+fn fs_visibility(input: VertexOutput) {
+    let material = materials[input.material_id];
+    let material_tex = material_textures[input.material_id];
+    let uv = input.tex_coords;
+
+    let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
+    let alpha = material.base_color.a * base_sample.a;
+
+    if has_alpha_test {
+        if alpha <= 0.001 { discard; }
+        if alpha < material_tex.params.z { discard; }
+    }
+}
+
 @fragment
 fn fs_main(input: VertexOutput) -> GBufferOutput {
     // ── Normal rendering ──────────────────────────────────────────────────────
@@ -253,7 +273,7 @@ fn fs_main(input: VertexOutput) -> GBufferOutput {
     out.normal  = vec4<f32>(N, specular_f0.r);
     out.orm     = vec4<f32>(ao, roughness, metallic, specular_f0.g);
     out.emissive = vec4<f32>(emissive, specular_f0.b);
-    out.vg_flag = vec2<f32>(-2.0, -2.0);
+    out.vg_flag = vec4<f32>(-2.0, -2.0, 0.0, 0.0);
     out.sss     = vec4<f32>(0.0);
     out.extra   = vec4<f32>(0.0);
     return out;
@@ -289,7 +309,7 @@ fn fs_debug(input: VertexOutput) -> GBufferOutput {
     out.normal   = vec4<f32>(face_n, 0.0);
     out.orm      = vec4<f32>(1.0, 1.0, 0.0, 0.0);
     out.emissive = vec4<f32>(base_color, 0.0);
-    out.vg_flag  = vec2<f32>(-2.0, -2.0);
+    out.vg_flag  = vec4<f32>(-2.0, -2.0, 0.0, 0.0);
     out.sss      = vec4<f32>(0.0);
     out.extra    = vec4<f32>(0.0);
     return out;
@@ -302,7 +322,8 @@ struct LodVertexOutput {
 }
 
 @vertex
-fn vs_debug_lod(v: Vertex, @builtin(instance_index) draw_slot: u32) -> LodVertexOutput {
+fn vs_debug_lod(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index) draw_slot: u32) -> LodVertexOutput {
+    let v         = meshlet_vertices[vertex_id];
     let draw      = draw_metadata[draw_slot];
     let lod_level = draw.lod_level;
     let inst      = instance_data[draw.instance_index];
@@ -334,7 +355,7 @@ fn fs_debug_lod(input: LodVertexOutput) -> GBufferOutput {
     out.normal   = vec4<f32>(face_n, 0.0);
     out.orm      = vec4<f32>(1.0, 1.0, 0.0, 0.0);
     out.emissive = vec4<f32>(lod_color, 0.0);
-    out.vg_flag  = vec2<f32>(-2.0, -2.0);
+    out.vg_flag  = vec4<f32>(-2.0, -2.0, 0.0, 0.0);
     out.sss      = vec4<f32>(0.0);
     out.extra    = vec4<f32>(0.0);
     return out;

--- a/crates/helio-pass-virtual-geometry/shaders/vg_rasterize.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_rasterize.wgsl
@@ -1,0 +1,199 @@
+enable wgpu_int16;
+
+// Software rasterize compute shader (Phase 5).
+//
+// One workgroup per 8×8 pixel tile.  Each thread handles one pixel and
+// iterates over all meshlets + triangles in the tile, keeping the nearest
+// depth.  Writes three visibility buffers:
+//   - visibility_depth:   f32 bits of the nearest depth (non-atomic)
+//   - visibility_data:    meshlet_id|(triangle_id<<22) with bit-31 valid flag
+//   - visibility_instance: instance_index of the winning meshlet
+
+struct Camera {
+    view:           mat4x4<f32>,
+    proj:           mat4x4<f32>,
+    view_proj:      mat4x4<f32>,
+    view_proj_inv:  mat4x4<f32>,
+    position_near:  vec4<f32>,
+    forward_far:    vec4<f32>,
+    jitter_frame:   vec4<f32>,
+    prev_view_proj: mat4x4<f32>,
+}
+
+struct MeshletEntry {
+    center:               vec3<f32>,
+    radius:               f32,
+    cone_apex:            vec3<f32>,
+    cone_cutoff:          f32,
+    cone_axis:            vec3<f32>,
+    lod_error:            f32,
+    packed_counts:        u32,
+    meshlet_index_offset: u32,
+    meshlet_vertex_offset: u32,
+    parent_cluster_id:    u32,
+}
+
+struct CullUniforms {
+    object_count:           u32,
+    screen_width:           u32,
+    screen_height:          u32,
+    hiz_mip_count:          u32,
+    draw_capacity:          u32,
+    lod_error_threshold_px: f32,
+    object_dispatch_width:  u32,
+    work_item_count:        u32,
+    work_dispatch_width:    u32,
+    hiz_valid:              u32,
+    _pad1:                  u32,
+    _pad2:                  u32,
+}
+
+struct InstanceData {
+    transform:    mat4x4<f32>,
+    normal_mat_0: vec4<f32>,
+    normal_mat_1: vec4<f32>,
+    normal_mat_2: vec4<f32>,
+    bounds:       vec4<f32>,
+    mesh_id:      u32,
+    material_id:  u32,
+    flags:        u32,
+    _pad:         u32,
+}
+
+struct GpuMeshletVertex {
+    position:       vec3<f32>,
+    bitangent_sign: f32,
+    tex_coords0:    vec2<f32>,
+    tex_coords1:    vec2<f32>,
+    normal:         u32,
+    tangent:        u32,
+}
+
+@group(0) @binding(0)  var<storage, read>     tile_counts:        array<u32>;
+@group(0) @binding(1)  var<storage, read>     tile_meshlet_ids:   array<u32>;
+@group(0) @binding(2)  var<storage, read>     tile_instance_ids:  array<u32>;
+@group(0) @binding(3)  var<storage, read>     meshlets:           array<MeshletEntry>;
+@group(0) @binding(4)  var<storage, read>     meshlet_vertices:   array<GpuMeshletVertex>;
+@group(0) @binding(5)  var<storage, read>     meshlet_indices:    array<u16>;
+@group(0) @binding(6)  var<storage, read_write> visibility_depth:  array<u32>;
+@group(0) @binding(7)  var<storage, read_write> visibility_data:   array<u32>;
+@group(0) @binding(8)  var<storage, read_write> visibility_instance: array<u32>;
+@group(0) @binding(9)  var<uniform>           camera:             Camera;
+@group(0) @binding(10) var<uniform>           cull_uni:           CullUniforms;
+@group(0) @binding(11) var<storage, read>     instances:          array<InstanceData>;
+
+const TILE_SIZE_X: u32 = 8u;
+const TILE_SIZE_Y: u32 = 8u;
+const MAX_MESHLETS_PER_TILE: u32 = 64u;
+const VIS_VALID_BIT: u32 = 2147483648u;
+
+fn edge_function(a: vec2<f32>, b: vec2<f32>, c: vec2<f32>) -> f32 {
+    return (c.x - a.x) * (b.y - a.y) - (c.y - a.y) * (b.x - a.x);
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn cs_rasterize(
+    @builtin(workgroup_id) wg_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>,
+) {
+    let tile_grid_x = (cull_uni.screen_width + TILE_SIZE_X - 1u) / TILE_SIZE_X;
+    let tile_grid_y = (cull_uni.screen_height + TILE_SIZE_Y - 1u) / TILE_SIZE_Y;
+
+    if wg_id.x >= tile_grid_x || wg_id.y >= tile_grid_y { return; }
+
+    let tile_x = wg_id.x;
+    let tile_y = wg_id.y;
+    let tile_idx = tile_y * tile_grid_x + tile_x;
+
+    let pixel_x = tile_x * TILE_SIZE_X + local_id.x;
+    let pixel_y = tile_y * TILE_SIZE_Y + local_id.y;
+
+    if pixel_x >= cull_uni.screen_width || pixel_y >= cull_uni.screen_height { return; }
+
+    let pixel_idx = pixel_y * cull_uni.screen_width + pixel_x;
+    let p = vec2<f32>(f32(pixel_x) + 0.5, f32(pixel_y) + 0.5);
+
+    var best_depth_bits = 0x7F7FFFFFu;
+    var best_data: u32 = 0u;
+    var best_instance: u32 = 0u;
+
+    let meshlet_count = tile_counts[tile_idx];
+    let tile_base = tile_idx * MAX_MESHLETS_PER_TILE;
+
+    for (var m = 0u; m < min(meshlet_count, MAX_MESHLETS_PER_TILE); m++) {
+        let meshlet_id = tile_meshlet_ids[tile_base + m];
+        if meshlet_id >= arrayLength(&meshlets) { continue; }
+
+        let instance_id = tile_instance_ids[tile_base + m];
+        if instance_id >= arrayLength(&instances) { continue; }
+
+        let meshlet = meshlets[meshlet_id];
+        let inst = instances[instance_id];
+
+        let tri_count = meshlet.packed_counts >> 16u;
+        let vert_offset = meshlet.meshlet_vertex_offset;
+        let idx_offset = meshlet.meshlet_index_offset;
+
+        for (var t = 0u; t < tri_count; t++) {
+            let idx_base = idx_offset + t * 3u;
+            let i0 = u32(meshlet_indices[idx_base]);
+            let i1 = u32(meshlet_indices[idx_base + 1u]);
+            let i2 = u32(meshlet_indices[idx_base + 2u]);
+
+            let v0 = meshlet_vertices[vert_offset + i0];
+            let v1 = meshlet_vertices[vert_offset + i1];
+            let v2 = meshlet_vertices[vert_offset + i2];
+
+            let clip0 = camera.view_proj * (inst.transform * vec4<f32>(v0.position, 1.0));
+            let clip1 = camera.view_proj * (inst.transform * vec4<f32>(v1.position, 1.0));
+            let clip2 = camera.view_proj * (inst.transform * vec4<f32>(v2.position, 1.0));
+
+            if clip0.w <= 0.0 || clip1.w <= 0.0 || clip2.w <= 0.0 { continue; }
+
+            let ndc0 = clip0.xyz / clip0.w;
+            let ndc1 = clip1.xyz / clip1.w;
+            let ndc2 = clip2.xyz / clip2.w;
+
+            if (ndc0.x < -1.0 && ndc1.x < -1.0 && ndc2.x < -1.0) ||
+               (ndc0.x > 1.0 && ndc1.x > 1.0 && ndc2.x > 1.0) ||
+               (ndc0.y < -1.0 && ndc1.y < -1.0 && ndc2.y < -1.0) ||
+               (ndc0.y > 1.0 && ndc1.y > 1.0 && ndc2.y > 1.0) { continue; }
+
+            let s0 = vec2<f32>((ndc0.x * 0.5 + 0.5) * f32(cull_uni.screen_width),
+                               (ndc0.y * -0.5 + 0.5) * f32(cull_uni.screen_height));
+            let s1 = vec2<f32>((ndc1.x * 0.5 + 0.5) * f32(cull_uni.screen_width),
+                               (ndc1.y * -0.5 + 0.5) * f32(cull_uni.screen_height));
+            let s2 = vec2<f32>((ndc2.x * 0.5 + 0.5) * f32(cull_uni.screen_width),
+                               (ndc2.y * -0.5 + 0.5) * f32(cull_uni.screen_height));
+
+            let ew0 = edge_function(s1, s2, p);
+            let ew1 = edge_function(s2, s0, p);
+            let ew2 = edge_function(s0, s1, p);
+
+            if ew0 < 0.0 || ew1 < 0.0 || ew2 < 0.0 { continue; }
+
+            let area = ew0 + ew1 + ew2;
+            if area <= 0.0 { continue; }
+
+            let bary_u = ew0 / area;
+            let bary_v = ew1 / area;
+            let bary_w = ew2 / area;
+
+            let depth = ndc0.z * bary_u + ndc1.z * bary_v + ndc2.z * bary_w;
+            if depth < 0.0 || depth > 1.0 { continue; }
+
+            let depth_bits = bitcast<u32>(depth);
+            if depth_bits < best_depth_bits {
+                best_depth_bits = depth_bits;
+                best_data = meshlet_id | (t << 22u) | VIS_VALID_BIT;
+                best_instance = instance_id;
+            }
+        }
+    }
+
+    if best_data != 0u {
+        visibility_depth[pixel_idx] = best_depth_bits;
+        visibility_data[pixel_idx] = best_data;
+        visibility_instance[pixel_idx] = best_instance;
+    }
+}

--- a/crates/helio-pass-virtual-geometry/shaders/vg_shade.wgsl
+++ b/crates/helio-pass-virtual-geometry/shaders/vg_shade.wgsl
@@ -1,0 +1,348 @@
+// Shading compute shader (Phase 5: Software Rasterization).
+//
+// Full-screen compute dispatch.  Each thread reads the visibility buffer,
+// reconstructs the triangle from the meshlet data, interpolates vertex
+// attributes with the instance transform, samples materials, and writes
+// the GBuffer.
+
+enable wgpu_binding_array;
+enable wgpu_int16;
+
+struct Camera {
+    view:           mat4x4<f32>,
+    proj:           mat4x4<f32>,
+    view_proj:      mat4x4<f32>,
+    view_proj_inv:  mat4x4<f32>,
+    position_near:  vec4<f32>,
+    forward_far:    vec4<f32>,
+    jitter_frame:   vec4<f32>,
+    prev_view_proj: mat4x4<f32>,
+}
+
+struct Globals {
+    frame:             u32,
+    delta_time:        f32,
+    light_count:       u32,
+    ambient_intensity: f32,
+    ambient_color:     vec4<f32>,
+    rc_world_min:      vec4<f32>,
+    rc_world_max:      vec4<f32>,
+    csm_splits:        vec4<f32>,
+    debug_mode:        u32,
+    _pad0:             u32,
+    _pad1:             u32,
+    _pad2:             u32,
+}
+
+struct MeshletEntry {
+    center:               vec3<f32>,
+    radius:               f32,
+    cone_apex:            vec3<f32>,
+    cone_cutoff:          f32,
+    cone_axis:            vec3<f32>,
+    lod_error:            f32,
+    packed_counts:        u32,
+    meshlet_index_offset: u32,
+    meshlet_vertex_offset: u32,
+    parent_cluster_id:    u32,
+}
+
+struct InstanceData {
+    transform:    mat4x4<f32>,
+    normal_mat_0: vec4<f32>,
+    normal_mat_1: vec4<f32>,
+    normal_mat_2: vec4<f32>,
+    bounds:       vec4<f32>,
+    mesh_id:      u32,
+    material_id:  u32,
+    flags:        u32,
+    _pad:         u32,
+}
+
+struct GpuMeshletVertex {
+    position:       vec3<f32>,
+    bitangent_sign: f32,
+    tex_coords0:    vec2<f32>,
+    tex_coords1:    vec2<f32>,
+    normal:         u32,
+    tangent:        u32,
+}
+
+struct GpuMaterial {
+    base_color:         vec4<f32>,
+    emissive:           vec4<f32>,
+    roughness_metallic: vec4<f32>,
+    tex_base_color:     u32,
+    tex_normal:         u32,
+    tex_roughness:      u32,
+    tex_emissive:       u32,
+    tex_occlusion:      u32,
+    workflow:           u32,
+    flags:              u32,
+    material_class:     u32,
+    class_params:       vec4<f32>,
+}
+
+struct MaterialTextureSlot {
+    texture_index: u32,
+    uv_channel:    u32,
+    _pad0:         u32,
+    _pad1:         u32,
+    offset_scale:  vec4<f32>,
+    rotation:      vec4<f32>,
+}
+
+struct MaterialTextureData {
+    base_color:         MaterialTextureSlot,
+    normal:             MaterialTextureSlot,
+    roughness_metallic: MaterialTextureSlot,
+    emissive:           MaterialTextureSlot,
+    occlusion:          MaterialTextureSlot,
+    specular_color:     MaterialTextureSlot,
+    specular_weight:    MaterialTextureSlot,
+    params:             vec4<f32>,
+}
+
+@group(0) @binding(0)  var<storage, read>     visibility_depth:    array<u32>;
+@group(0) @binding(1)  var<storage, read>     visibility_data:     array<u32>;
+@group(0) @binding(2)  var<storage, read>     visibility_instance: array<u32>;
+@group(0) @binding(3)  var<storage, read>     meshlets:            array<MeshletEntry>;
+@group(0) @binding(4)  var<storage, read>     meshlet_vertices:    array<GpuMeshletVertex>;
+@group(0) @binding(5)  var<storage, read>     meshlet_indices:     array<u16>;
+@group(0) @binding(6)  var<uniform>           camera:              Camera;
+@group(0) @binding(7)  var<uniform>           globals:             Globals;
+@group(0) @binding(8)  var<storage, read>     instances:           array<InstanceData>;
+
+@group(1) @binding(0)  var<storage, read>                 materials:         array<GpuMaterial>;
+@group(1) @binding(1)  var<storage, read>                 material_textures: array<MaterialTextureData>;
+@group(1) @binding(2)  var                                scene_textures:    binding_array<texture_2d<f32>, 256>;
+@group(1) @binding(3)  var                                scene_samplers:    binding_array<sampler, 256>;
+
+@group(2) @binding(0)  var albedo_tex:    texture_storage_2d<rgba8unorm, write>;
+@group(2) @binding(1)  var normal_tex:    texture_storage_2d<rgba16float, write>;
+@group(2) @binding(2)  var orm_tex:       texture_storage_2d<rgba8unorm, write>;
+@group(2) @binding(3)  var emissive_tex:  texture_storage_2d<rgba16float, write>;
+@group(2) @binding(4)  var lightmap_uv_tex: texture_storage_2d<rgba16float, write>;
+@group(2) @binding(5)  var sss_tex:       texture_storage_2d<rgba16float, write>;
+@group(2) @binding(6)  var extra_tex:     texture_storage_2d<rgba16float, write>;
+
+const VIS_VALID_BIT: u32 = 2147483648u;
+const NO_TEXTURE: u32 = 0xffffffffu;
+const MATERIAL_WORKFLOW_METALLIC: u32 = 0u;
+const MATERIAL_WORKFLOW_SPECULAR: u32 = 1u;
+
+fn decode_snorm8x4(packed: u32) -> vec3<f32> {
+    return unpack4x8snorm(packed).xyz;
+}
+
+fn edge_function(a: vec2<f32>, b: vec2<f32>, c: vec2<f32>) -> f32 {
+    return (c.x - a.x) * (b.y - a.y) - (c.y - a.y) * (b.x - a.x);
+}
+
+fn select_uv(slot: MaterialTextureSlot, base_uv: vec2<f32>) -> vec2<f32> {
+    let scaled = base_uv * slot.offset_scale.zw;
+    let s = slot.rotation.x;
+    let c = slot.rotation.y;
+    let rotated = vec2<f32>(scaled.x * c - scaled.y * s, scaled.x * s + scaled.y * c);
+    return rotated + slot.offset_scale.xy;
+}
+
+fn sample_texture(slot: MaterialTextureSlot, base_uv: vec2<f32>, fallback: vec4<f32>) -> vec4<f32> {
+    if slot.texture_index == NO_TEXTURE { return fallback; }
+    let uv = select_uv(slot, base_uv);
+    return textureSampleLevel(scene_textures[slot.texture_index], scene_samplers[slot.texture_index], uv, 0.0);
+}
+
+fn resolve_specular_f0(
+    material: GpuMaterial, material_tex: MaterialTextureData,
+    albedo: vec3<f32>, metallic: f32, uv: vec2<f32>,
+) -> vec3<f32> {
+    if material.workflow == MATERIAL_WORKFLOW_SPECULAR {
+        let specular_color = sample_texture(material_tex.specular_color, uv, vec4<f32>(1.0)).rgb;
+        let specular_weight = sample_texture(material_tex.specular_weight, uv, vec4<f32>(1.0)).a;
+        let ior = max(material.roughness_metallic.z, 1.0);
+        let dielectric_f0 = pow((ior - 1.0) / (ior + 1.0), 2.0);
+        return material.roughness_metallic.w * specular_weight * specular_color * dielectric_f0;
+    }
+    return clamp(mix(vec3<f32>(0.04), albedo, metallic), vec3<f32>(0.0), vec3<f32>(0.999));
+}
+
+fn hash_color(idx: u32) -> vec3<f32> {
+    var h = idx * 2747636419u;
+    h ^= h >> 16u;
+    h *= 2654435769u;
+    h ^= h >> 16u;
+    let i = h % 12u;
+    var pal: array<vec3<f32>, 12>;
+    pal[0]  = vec3<f32>(1.00, 0.18, 0.18);
+    pal[1]  = vec3<f32>(1.00, 0.55, 0.00);
+    pal[2]  = vec3<f32>(1.00, 0.90, 0.00);
+    pal[3]  = vec3<f32>(0.35, 1.00, 0.10);
+    pal[4]  = vec3<f32>(0.00, 0.90, 0.40);
+    pal[5]  = vec3<f32>(0.00, 0.85, 1.00);
+    pal[6]  = vec3<f32>(0.10, 0.40, 1.00);
+    pal[7]  = vec3<f32>(0.55, 0.10, 1.00);
+    pal[8]  = vec3<f32>(0.90, 0.10, 1.00);
+    pal[9]  = vec3<f32>(1.00, 0.10, 0.60);
+    pal[10] = vec3<f32>(0.00, 0.65, 0.65);
+    pal[11] = vec3<f32>(1.00, 0.70, 0.10);
+    return pal[i];
+}
+
+@compute @workgroup_size(8, 8, 1)
+fn cs_shade(@builtin(global_invocation_id) id: vec3<u32>) {
+    let pixel_x = id.x;
+    let pixel_y = id.y;
+
+    let screen_w = u32(textureDimensions(albedo_tex).x);
+    let screen_h = u32(textureDimensions(albedo_tex).y);
+    if pixel_x >= screen_w || pixel_y >= screen_h { return; }
+
+    let pxl = vec2<i32>(i32(pixel_x), i32(pixel_y));
+    let pixel_idx = pixel_y * screen_w + pixel_x;
+
+    let packed = visibility_data[pixel_idx];
+    if (packed & VIS_VALID_BIT) == 0u {
+        // No geometry — clear GBuffer at this pixel
+        textureStore(albedo_tex,   pxl, vec4<f32>(0.0, 0.0, 0.0, 0.0));
+        textureStore(normal_tex,   pxl, vec4<f32>(0.0, 0.0, 0.0, 0.0));
+        textureStore(orm_tex,      pxl, vec4<f32>(0.0, 0.0, 0.0, 0.0));
+        textureStore(emissive_tex, pxl, vec4<f32>(0.0, 0.0, 0.0, 0.0));
+        textureStore(lightmap_uv_tex, pxl, vec4<f32>(0.0, 0.0, 0.0, 0.0));
+        textureStore(sss_tex,      pxl, vec4<f32>(0.0));
+        textureStore(extra_tex,    pxl, vec4<f32>(0.0));
+        return;
+    }
+
+    let meshlet_id = packed & 0x3FFFFFu;
+    let triangle_id = packed >> 22u;
+    let instance_id = visibility_instance[pixel_idx];
+
+    if meshlet_id >= arrayLength(&meshlets) { return; }
+    if instance_id >= arrayLength(&instances) { return; }
+
+    let meshlet = meshlets[meshlet_id];
+    let inst = instances[instance_id];
+
+    let vert_offset = meshlet.meshlet_vertex_offset;
+    let idx_offset = meshlet.meshlet_index_offset;
+
+    let idx_base = idx_offset + triangle_id * 3u;
+    if idx_base + 2u >= arrayLength(&meshlet_indices) { return; }
+
+    let i0 = u32(meshlet_indices[idx_base]);
+    let i1 = u32(meshlet_indices[idx_base + 1u]);
+    let i2 = u32(meshlet_indices[idx_base + 2u]);
+
+    if vert_offset + max(i0, max(i1, i2)) >= arrayLength(&meshlet_vertices) { return; }
+
+    let v0 = meshlet_vertices[vert_offset + i0];
+    let v1 = meshlet_vertices[vert_offset + i1];
+    let v2 = meshlet_vertices[vert_offset + i2];
+
+    // Transform to clip space
+    let clip0 = camera.view_proj * (inst.transform * vec4<f32>(v0.position, 1.0));
+    let clip1 = camera.view_proj * (inst.transform * vec4<f32>(v1.position, 1.0));
+    let clip2 = camera.view_proj * (inst.transform * vec4<f32>(v2.position, 1.0));
+
+    if clip0.w <= 0.0 || clip1.w <= 0.0 || clip2.w <= 0.0 { return; }
+
+    let ndc0 = clip0.xyz / clip0.w;
+    let ndc1 = clip1.xyz / clip1.w;
+    let ndc2 = clip2.xyz / clip2.w;
+
+    let w_f = f32(screen_w);
+    let h_f = f32(screen_h);
+
+    let s0 = vec2<f32>((ndc0.x * 0.5 + 0.5) * w_f, (ndc0.y * -0.5 + 0.5) * h_f);
+    let s1 = vec2<f32>((ndc1.x * 0.5 + 0.5) * w_f, (ndc1.y * -0.5 + 0.5) * h_f);
+    let s2 = vec2<f32>((ndc2.x * 0.5 + 0.5) * w_f, (ndc2.y * -0.5 + 0.5) * h_f);
+
+    let p = vec2<f32>(f32(pixel_x) + 0.5, f32(pixel_y) + 0.5);
+
+    let ew0 = edge_function(s1, s2, p);
+    let ew1 = edge_function(s2, s0, p);
+    let ew2 = edge_function(s0, s1, p);
+
+    let area = ew0 + ew1 + ew2;
+    if area <= 0.0 { return; }
+
+    let bary_u = ew0 / area;
+    let bary_v = ew1 / area;
+    let bary_w = ew2 / area;
+
+    // Perspective-correct interpolation for world position
+    let w0_inv = 1.0 / clip0.w;
+    let w1_inv = 1.0 / clip1.w;
+    let w2_inv = 1.0 / clip2.w;
+
+    let wp_inv = bary_u * w0_inv + bary_v * w1_inv + bary_w * w2_inv;
+    if wp_inv <= 0.0 { return; }
+    let wp = 1.0 / wp_inv;
+
+    // World position
+    let world_pos0 = (inst.transform * vec4<f32>(v0.position, 1.0)).xyz;
+    let world_pos1 = (inst.transform * vec4<f32>(v1.position, 1.0)).xyz;
+    let world_pos2 = (inst.transform * vec4<f32>(v2.position, 1.0)).xyz;
+
+    let world_pos = (world_pos0 * bary_u * w0_inv + world_pos1 * bary_v * w1_inv + world_pos2 * bary_w * w2_inv) * wp;
+
+    // Normals
+    let normal_mat = mat3x3<f32>(inst.normal_mat_0.xyz, inst.normal_mat_1.xyz, inst.normal_mat_2.xyz);
+    let model_mat3 = mat3x3<f32>(inst.transform[0].xyz, inst.transform[1].xyz, inst.transform[2].xyz);
+
+    let n0 = normalize(normal_mat * decode_snorm8x4(v0.normal));
+    let n1 = normalize(normal_mat * decode_snorm8x4(v1.normal));
+    let n2 = normalize(normal_mat * decode_snorm8x4(v2.normal));
+    let world_normal = normalize((n0 * bary_u * w0_inv + n1 * bary_v * w1_inv + n2 * bary_w * w2_inv) * wp);
+
+    // Tangents
+    let t0 = normalize(model_mat3 * decode_snorm8x4(v0.tangent));
+    let t1 = normalize(model_mat3 * decode_snorm8x4(v1.tangent));
+    let t2 = normalize(model_mat3 * decode_snorm8x4(v2.tangent));
+    let world_tangent = normalize((t0 * bary_u * w0_inv + t1 * bary_v * w1_inv + t2 * bary_w * w2_inv) * wp);
+
+    // Tex coords
+    let uv = v0.tex_coords0 * bary_u + v1.tex_coords0 * bary_v + v2.tex_coords0 * bary_w;
+
+    // Material
+    let material_id = inst.material_id;
+    let material = materials[material_id];
+    let material_tex = material_textures[material_id];
+
+    let base_sample = sample_texture(material_tex.base_color, uv, vec4<f32>(1.0));
+    let albedo = material.base_color * base_sample;
+    let alpha = albedo.a;
+
+    if alpha <= 0.001 { return; }
+
+    let N_geom = world_normal;
+    var N: vec3<f32>;
+    if material_tex.normal.texture_index != NO_TEXTURE {
+        let T = normalize(world_tangent - dot(world_tangent, N_geom) * N_geom);
+        let B = cross(N_geom, T) * v0.bitangent_sign;
+        var norm_ts = sample_texture(material_tex.normal, uv, vec4<f32>(0.5, 0.5, 1.0, 1.0)).rgb * 2.0 - 1.0;
+        norm_ts = vec3<f32>(norm_ts.x * material_tex.params.x, norm_ts.y * material_tex.params.x, norm_ts.z);
+        N = normalize(T * norm_ts.x + B * norm_ts.y + N_geom * norm_ts.z);
+    } else {
+        N = N_geom;
+    }
+
+    let orm_sample       = sample_texture(material_tex.roughness_metallic, uv, vec4<f32>(1.0));
+    let occlusion_sample = sample_texture(material_tex.occlusion, uv, vec4<f32>(1.0));
+    let emissive_sample  = sample_texture(material_tex.emissive, uv, vec4<f32>(1.0));
+
+    let ao        = 1.0 + (occlusion_sample.r - 1.0) * material_tex.params.y;
+    let roughness = clamp(material.roughness_metallic.x * orm_sample.g, 0.045, 1.0);
+    let metallic  = clamp(material.roughness_metallic.y * orm_sample.b, 0.0, 1.0);
+    let specular_f0 = resolve_specular_f0(material, material_tex, albedo.rgb, metallic, uv);
+    let emissive  = material.emissive.rgb * material.emissive.w * emissive_sample.rgb;
+
+    textureStore(albedo_tex,   pxl, vec4<f32>(albedo.rgb, alpha));
+    textureStore(normal_tex,   pxl, vec4<f32>(N, specular_f0.r));
+    textureStore(orm_tex,      pxl, vec4<f32>(ao, roughness, metallic, specular_f0.g));
+    textureStore(emissive_tex, pxl, vec4<f32>(emissive, specular_f0.b));
+    textureStore(lightmap_uv_tex, pxl, vec4<f32>(-2.0, -2.0, 0.0, 0.0));
+    textureStore(sss_tex,      pxl, vec4<f32>(0.0));
+    textureStore(extra_tex,    pxl, vec4<f32>(0.0));
+}

--- a/crates/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/helio-pass-virtual-geometry/src/lib.rs
@@ -23,9 +23,8 @@ pub const LOD_LEVEL_COUNT: u32 = 8;
 /// Slot 0 is the opaque meshlet draw count consumed by the first
 /// indirect-count draw call, slot 1 is the alpha-test draw count consumed
 /// by the second draw call, slot 2 is the capacity-rejection overflow
-/// count, slots 3..10 form the selected-LOD object histogram, and slot 11
-/// stores the largest LOD available among visible objects.
-pub(crate) const DRAW_COUNTER_COUNT: u64 = 12;
+/// count.  With the flat DAG no per-LOD histogram is maintained.
+pub(crate) const DRAW_COUNTER_COUNT: u64 = 3;
 pub(crate) const DRAW_COUNTER_BYTES: u64 = DRAW_COUNTER_COUNT * 4;
 
 /// Latest non-blocking GPU readback from the virtual-geometry cull pass.
@@ -36,36 +35,24 @@ pub(crate) const DRAW_COUNTER_BYTES: u64 = DRAW_COUNTER_COUNT * 4;
 pub struct VirtualGeometryDebugStats {
     pub visible_meshlets: u32,
     pub rejected_meshlets: u32,
-    pub lod_object_counts: [u32; LOD_LEVEL_COUNT as usize],
-    pub max_available_lod: u32,
 }
 
 impl VirtualGeometryDebugStats {
-    pub fn visible_objects(self) -> u32 {
-        self.lod_object_counts.iter().copied().sum()
-    }
-
-    pub fn selected_lod_range(self) -> Option<(u32, u32)> {
-        let first = self.lod_object_counts.iter().position(|&count| count != 0)? as u32;
-        let last = self.lod_object_counts.iter().rposition(|&count| count != 0)? as u32;
-        Some((first, last))
-    }
-
     fn from_counters(counters: &[u32]) -> Option<Self> {
         if counters.len() < DRAW_COUNTER_COUNT as usize {
             return None;
         }
 
-        let mut lod_object_counts = [0; LOD_LEVEL_COUNT as usize];
-        lod_object_counts.copy_from_slice(&counters[3..11]);
         Some(Self {
             visible_meshlets: counters[0] + counters[1],
             rejected_meshlets: counters[2],
-            lod_object_counts,
-            max_available_lod: counters[11].min(LOD_LEVEL_COUNT - 1),
         })
     }
 }
+
+pub(crate) const TILE_SIZE_X: u32 = 8;
+pub(crate) const TILE_SIZE_Y: u32 = 8;
+pub(crate) const MAX_MESHLETS_PER_TILE: u32 = 64;
 
 pub(crate) const INITIAL_MESHLETS: u64 = 1024;
 pub(crate) const INITIAL_OBJECTS: u64 = 256;
@@ -76,26 +63,12 @@ pub(crate) const INITIAL_INSTANCES: u64 = 256;
 /// At 36 bytes per slot (20-byte indirect command plus 16-byte draw metadata),
 /// this bounds the publication buffers to 9 MiB plus the two counters. Callers
 /// with a measured platform-specific budget can override it explicitly.
-/// Upper bound on how many meshlet draws a single frame can publish to the
-/// indirect/draw-metadata buffers. This is a genuine ceiling, not a
-/// pre-allocation size — `VirtualGeometryPass` starts small and grows these
-/// buffers toward this value only as scenes actually need it (see
-/// `prepare()` in `rendering.rs`), so raising it costs nothing for scenes
-/// that don't need the extra headroom.
 ///
-/// 262_144 (the previous value) is nowhere near enough for any real scene
-/// with more than a couple hundred separate VG object instances: the budget
-/// is sized against `vg.max_draw_count`, the *worst-case* sum of every
-/// object's LOD0 meshlet count, which scales with instance count, not just
-/// unique mesh complexity. A scene with ~1200 instances of a ~90k-triangle,
-/// 7-section asset (the shipyard demo's shipping containers) needs
-/// ~2.5 million draw slots — once `cull_meshlet()`'s atomic slot counter
-/// (`vg_cull.wgsl`) exceeds the budget, every excess meshlet is silently
-/// rejected via the overflow counter, which looks exactly like the culling
-/// tests themselves are wrongly rejecting on-screen geometry: it isn't the
-/// visibility tests, it's the output buffer running out of room, and which
-/// meshlets lose that race is effectively fixed frame-to-frame for a static
-/// scene, so the drops look like a consistent, reproducible mis-cull.
+/// In Phase 3 the indirect buffer grows dynamically on demand — this budget is
+/// now a soft warning threshold, not a hard ceiling. If the needed capacity
+/// exceeds it, a warning is logged and the buffer continues to grow. The GPU
+/// cull shader's overflow guard silently drops excess draws when the buffer
+/// is full and the CPU grows it for subsequent frames.
 pub const DEFAULT_MAX_PUBLISHED_MESHLETS: u32 = 4_194_304;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -120,14 +93,6 @@ impl VirtualGeometryBudget {
 
     pub const fn max_published_meshlets(self) -> u32 {
         self.max_published_meshlets
-    }
-
-    pub const fn clamp_draw_count(self, worst_case_draw_count: u32) -> u32 {
-        if worst_case_draw_count < self.max_published_meshlets {
-            worst_case_draw_count
-        } else {
-            self.max_published_meshlets
-        }
     }
 }
 
@@ -339,9 +304,7 @@ mod tests {
     fn default_publication_budget_is_144_mib_plus_counters() {
         let budget = VirtualGeometryBudget::default();
         assert_eq!(budget.max_published_meshlets(), DEFAULT_MAX_PUBLISHED_MESHLETS);
-        assert_eq!(budget.publication_bytes(), 144 * 1024 * 1024 + 48);
-        assert_eq!(budget.clamp_draw_count(65_536), 65_536);
-        assert_eq!(budget.clamp_draw_count(u32::MAX), DEFAULT_MAX_PUBLISHED_MESHLETS);
+        assert_eq!(budget.publication_bytes(), 144 * 1024 * 1024 + 12);
     }
 
     #[test]
@@ -440,16 +403,11 @@ mod tests {
 
     #[test]
     fn debug_stats_decode_the_gpu_counter_layout() {
-        let stats = VirtualGeometryDebugStats::from_counters(&[
-            100, 23, 4, 0, 2, 5, 0, 0, 1, 0, 0, 6,
-        ])
-        .expect("complete counter layout");
+        let stats = VirtualGeometryDebugStats::from_counters(&[100, 23, 4])
+            .expect("complete counter layout");
 
         assert_eq!(stats.visible_meshlets, 123);
         assert_eq!(stats.rejected_meshlets, 4);
-        assert_eq!(stats.visible_objects(), 8);
-        assert_eq!(stats.selected_lod_range(), Some((1, 5)));
-        assert_eq!(stats.max_available_lod, 6);
-        assert!(VirtualGeometryDebugStats::from_counters(&[0; 11]).is_none());
+        assert!(VirtualGeometryDebugStats::from_counters(&[0; 2]).is_none());
     }
 }

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -52,6 +52,9 @@ pub struct VirtualGeometryPass {
     pub(crate) instance_cull_buf: wgpu::Buffer,
     pub(crate) instance_cull_scratch: Vec<InstanceCullData>,
     pub(crate) work_item_buf: wgpu::Buffer,
+    /// Per-meshlet atomic emit claim flags (cleared each frame). Ensures each
+    /// meshlet is drawn at most once when multiple leaves fan in to one parent.
+    pub(crate) meshlet_emit_flags_buf: wgpu::Buffer,
     pub(crate) indirect_buf: wgpu::Buffer,
     pub(crate) draw_metadata_buf: wgpu::Buffer,
     pub(crate) draw_count_buf: wgpu::Buffer,
@@ -67,6 +70,7 @@ pub struct VirtualGeometryPass {
     pub(crate) last_meshlet_count: u32,
     pub(crate) last_object_count: u32,
     pub(crate) last_work_item_count: u32,
+    pub(crate) last_emit_flag_count: u32,
     pub(crate) object_dispatch_width: u32,
     pub(crate) work_dispatch_width: u32,
     // ── Software rasterizer (Phase 5) ─────────────────────────────────────
@@ -141,6 +145,7 @@ impl VirtualGeometryPass {
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
         let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
         let work_item_buf = Self::make_work_item_buf(device, INITIAL_OBJECTS);
+        let meshlet_emit_flags_buf = Self::make_meshlet_emit_flags_buf(device, INITIAL_MESHLETS);
         let initial_publication_capacity =
             INITIAL_MESHLETS.min(u64::from(budget.max_published_meshlets()));
         let indirect_buf = Self::make_indirect_buf(device, initial_publication_capacity);
@@ -312,6 +317,17 @@ impl VirtualGeometryPass {
                 },
                 wgpu::BindGroupLayoutEntry {
                     binding: 14,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                // Per-meshlet global emit claim flags (atomic u32, cleared each frame).
+                wgpu::BindGroupLayoutEntry {
+                    binding: 15,
                     visibility: wgpu::ShaderStages::COMPUTE,
                     ty: wgpu::BindingType::Buffer {
                         ty: wgpu::BufferBindingType::Storage { read_only: false },
@@ -835,6 +851,7 @@ impl VirtualGeometryPass {
             instance_cull_buf,
             instance_cull_scratch: Vec::with_capacity(INITIAL_INSTANCES as usize),
             work_item_buf,
+            meshlet_emit_flags_buf,
             indirect_buf,
             draw_metadata_buf,
             draw_count_buf,
@@ -850,6 +867,7 @@ impl VirtualGeometryPass {
             last_meshlet_count: 0,
             last_object_count: 0,
             last_work_item_count: 0,
+            last_emit_flag_count: 0,
             object_dispatch_width: 1,
             work_dispatch_width: 1,
             // Software rasterizer fields
@@ -969,7 +987,7 @@ impl VirtualGeometryPass {
     fn make_object_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Object Buffer"),
-            size: capacity * 32,
+            size: capacity * std::mem::size_of::<GpuVgObject>() as u64,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -988,6 +1006,15 @@ impl VirtualGeometryPass {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Work Item Buffer"),
             size: capacity * std::mem::size_of::<libhelio::GpuVgWorkItem>() as u64,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_meshlet_emit_flags_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Meshlet Emit Flags"),
+            size: capacity.max(1) * 4,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -1117,7 +1144,16 @@ impl RenderPass for VirtualGeometryPass {
 
             let meshlet_capacity = self.meshlet_buf.size() / 64;
             if (vg.meshlet_count as u64) > meshlet_capacity {
-                self.meshlet_buf = Self::make_meshlet_buf(ctx.device, vg.meshlet_count as u64 * 2);
+                let new_cap = vg.meshlet_count as u64 * 2;
+                self.meshlet_buf = Self::make_meshlet_buf(ctx.device, new_cap);
+                grew = true;
+            }
+            let emit_flags_capacity = self.meshlet_emit_flags_buf.size() / 4;
+            if (vg.emit_flag_count as u64) > emit_flags_capacity {
+                self.meshlet_emit_flags_buf = Self::make_meshlet_emit_flags_buf(
+                    ctx.device,
+                    (vg.emit_flag_count as u64 * 2).max(1),
+                );
                 grew = true;
             }
             let meshlet_vertex_capacity = self.meshlet_vertex_buf.size() / 48;
@@ -1136,7 +1172,8 @@ impl RenderPass for VirtualGeometryPass {
                 );
                 grew = true;
             }
-            let object_capacity = self.object_buf.size() / 32;
+            let object_stride = std::mem::size_of::<GpuVgObject>() as u64;
+            let object_capacity = self.object_buf.size() / object_stride;
             if (vg.object_count as u64) > object_capacity {
                 self.object_buf = Self::make_object_buf(ctx.device, vg.object_count as u64 * 2);
                 grew = true;
@@ -1194,6 +1231,7 @@ impl RenderPass for VirtualGeometryPass {
             self.last_meshlet_count = vg.meshlet_count;
             self.last_object_count = vg.object_count;
             self.last_work_item_count = vg.work_item_count;
+            self.last_emit_flag_count = vg.emit_flag_count;
         } else if vg.instance_version != self.last_instance_version {
             let start = vg.instance_dirty_start as usize;
             let count = vg.instance_dirty_count as usize;
@@ -1526,6 +1564,10 @@ impl RenderPass for VirtualGeometryPass {
                         binding: 14,
                         resource: self.visible_meshlet_count_buf.as_entire_binding(),
                     },
+                    wgpu::BindGroupEntry {
+                        binding: 15,
+                        resource: self.meshlet_emit_flags_buf.as_entire_binding(),
+                    },
                 ],
             }));
             self.cull_bind_group_hiz_key = Some(hiz_key);
@@ -1543,6 +1585,15 @@ impl RenderPass for VirtualGeometryPass {
         let max_draw_count = self.last_meshlet_count * 2;
 
         unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(&self.draw_count_buf, 0, None);
+        // Clear per-object emit claim flags so each (object, meshlet) can be claimed once.
+        let emit_clear_bytes = (self.last_emit_flag_count as u64).saturating_mul(4);
+        if emit_clear_bytes > 0 {
+            unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(
+                &self.meshlet_emit_flags_buf,
+                0,
+                Some(emit_clear_bytes),
+            );
+        }
         if !self.use_count_indirect {
             unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(&self.indirect_buf, 0, None);
         }

--- a/crates/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/helio-pass-virtual-geometry/src/rendering.rs
@@ -4,7 +4,7 @@ use std::num::NonZeroU32;
 use crate::{
     CullUniforms, InstanceCullData, LodQuality, VgGlobals, VirtualGeometryBudget,
     VirtualGeometryDebugStats, DRAW_COUNTER_BYTES, INITIAL_INSTANCES, INITIAL_MESHLETS,
-    INITIAL_OBJECTS, MAX_TEXTURES,
+    INITIAL_OBJECTS, MAX_TEXTURES, MAX_MESHLETS_PER_TILE, TILE_SIZE_X, TILE_SIZE_Y,
 };
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
@@ -30,8 +30,12 @@ pub struct VirtualGeometryPass {
     pub(crate) cull_bind_group: Option<wgpu::BindGroup>,
     pub(crate) cull_bind_group_hiz_key: Option<(usize, usize)>,
     pub(crate) cull_buf: wgpu::Buffer,
-    pub(crate) opaque_draw_pipeline: wgpu::RenderPipeline,
-    pub(crate) alpha_draw_pipeline: wgpu::RenderPipeline,
+    // Visibility pass pipelines (depth-only, writes SV_Position, no color targets)
+    pub(crate) visibility_opaque_pipeline: wgpu::RenderPipeline,
+    pub(crate) visibility_alpha_pipeline: wgpu::RenderPipeline,
+    // Shading pass pipelines (full GBuffer, depth test Equal, depth write disabled)
+    pub(crate) shading_opaque_pipeline: wgpu::RenderPipeline,
+    pub(crate) shading_alpha_pipeline: wgpu::RenderPipeline,
     pub(crate) debug_draw_pipeline: wgpu::RenderPipeline,
     pub(crate) lod_debug_pipeline: wgpu::RenderPipeline,
     pub(crate) draw_bgl_0: wgpu::BindGroupLayout,
@@ -41,6 +45,8 @@ pub struct VirtualGeometryPass {
     pub(crate) bg1_version: Option<u64>,
     pub(crate) globals_buf: wgpu::Buffer,
     pub(crate) meshlet_buf: wgpu::Buffer,
+    pub(crate) meshlet_vertex_buf: wgpu::Buffer,
+    pub(crate) meshlet_index_buf: wgpu::Buffer,
     pub(crate) object_buf: wgpu::Buffer,
     pub(crate) instance_buf: wgpu::Buffer,
     pub(crate) instance_cull_buf: wgpu::Buffer,
@@ -61,9 +67,38 @@ pub struct VirtualGeometryPass {
     pub(crate) last_meshlet_count: u32,
     pub(crate) last_object_count: u32,
     pub(crate) last_work_item_count: u32,
-    pub(crate) last_max_draw_count: u32,
     pub(crate) object_dispatch_width: u32,
     pub(crate) work_dispatch_width: u32,
+    // ── Software rasterizer (Phase 5) ─────────────────────────────────────
+    pub use_sw_rasterizer: bool,
+    last_screen_width: u32,
+    last_screen_height: u32,
+    // Binning pass
+    binning_pipeline: wgpu::ComputePipeline,
+    binning_bgl: wgpu::BindGroupLayout,
+    binning_bg: Option<wgpu::BindGroup>,
+    // Rasterize pass
+    rasterize_pipeline: wgpu::ComputePipeline,
+    rasterize_bgl: wgpu::BindGroupLayout,
+    rasterize_bg: Option<wgpu::BindGroup>,
+    // Shade pass
+    shade_pipeline: wgpu::ComputePipeline,
+    shade_bgl_0: wgpu::BindGroupLayout,
+    shade_bgl_1: wgpu::BindGroupLayout,
+    shade_bgl_2: wgpu::BindGroupLayout,
+    shade_bg_0: Option<wgpu::BindGroup>,
+    shade_bg_1: Option<wgpu::BindGroup>,
+    shade_bg_2: Option<wgpu::BindGroup>,
+    // SW rasterizer buffers
+    visible_meshlet_ids_buf: wgpu::Buffer,
+    visible_instance_ids_buf: wgpu::Buffer,
+    visible_meshlet_count_buf: wgpu::Buffer,
+    tile_counts_buf: wgpu::Buffer,
+    tile_meshlet_ids_buf: wgpu::Buffer,
+    tile_instance_ids_buf: wgpu::Buffer,
+    visibility_depth_buf: wgpu::Buffer,
+    visibility_data_buf: wgpu::Buffer,
+    visibility_instance_buf: wgpu::Buffer,
 }
 
 impl VirtualGeometryPass {
@@ -100,6 +135,8 @@ impl VirtualGeometryPass {
         });
 
         let meshlet_buf = Self::make_meshlet_buf(device, INITIAL_MESHLETS);
+        let meshlet_vertex_buf = Self::make_meshlet_vertex_buf(device, INITIAL_MESHLETS * 64);
+        let meshlet_index_buf = Self::make_meshlet_index_buf(device, INITIAL_MESHLETS * 64 * 3);
         let object_buf = Self::make_object_buf(device, INITIAL_OBJECTS);
         let instance_buf = Self::make_instance_buf(device, INITIAL_INSTANCES);
         let instance_cull_buf = Self::make_instance_cull_buf(device, INITIAL_INSTANCES);
@@ -252,6 +289,37 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                // Visible meshlet output (SW rasterizer)
+                wgpu::BindGroupLayoutEntry {
+                    binding: 12,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 13,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 14,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -320,6 +388,16 @@ impl VirtualGeometryPass {
                     },
                     count: None,
                 },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
+                    visibility: wgpu::ShaderStages::VERTEX,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
             ],
         });
 
@@ -343,6 +421,10 @@ impl VirtualGeometryPass {
                     binding: 3,
                     resource: draw_metadata_buf.as_entire_binding(),
                 },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: meshlet_vertex_buf.as_entire_binding(),
+                },
             ],
         }));
 
@@ -353,37 +435,8 @@ impl VirtualGeometryPass {
             bind_group_layouts: &[Some(&draw_bgl_0), Some(&draw_bgl_1)],
             immediate_size: 0,
         });
-        let vg_vertex_buffers = &[Some(wgpu::VertexBufferLayout {
-            array_stride: 40,
-            step_mode: wgpu::VertexStepMode::Vertex,
-            attributes: &[
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x3,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32,
-                    offset: 12,
-                    shader_location: 1,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Float32x2,
-                    offset: 16,
-                    shader_location: 2,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Uint32,
-                    offset: 32,
-                    shader_location: 3,
-                },
-                wgpu::VertexAttribute {
-                    format: wgpu::VertexFormat::Uint32,
-                    offset: 36,
-                    shader_location: 4,
-                },
-            ],
-        })];
+        // No vertex buffers — vertex data is read from the meshlet_vertices storage buffer.
+        let vg_vertex_buffers = &[];
         let gbuffer_targets = &[
             Some(wgpu::ColorTargetState {
                 format: wgpu::TextureFormat::Rgba8Unorm,
@@ -406,7 +459,7 @@ impl VirtualGeometryPass {
                 write_mask: wgpu::ColorWrites::ALL,
             }),
             Some(wgpu::ColorTargetState {
-                format: wgpu::TextureFormat::Rg16Float,
+                format: wgpu::TextureFormat::Rgba16Float,
                 blend: None,
                 write_mask: wgpu::ColorWrites::ALL,
             }),
@@ -434,7 +487,26 @@ impl VirtualGeometryPass {
             bias: wgpu::DepthBiasState::default(),
         });
 
-        let make_draw_pipeline = |label: &'static str, constants: &[(&str, f64)]| {
+        let visibility_depth = Some(wgpu::DepthStencilState {
+            format: wgpu::TextureFormat::Depth32Float,
+            depth_write_enabled: Some(true),
+            depth_compare: Some(wgpu::CompareFunction::Less),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        });
+        let shading_depth = Some(wgpu::DepthStencilState {
+            format: wgpu::TextureFormat::Depth32Float,
+            depth_write_enabled: Some(false),
+            depth_compare: Some(wgpu::CompareFunction::Equal),
+            stencil: wgpu::StencilState::default(),
+            bias: wgpu::DepthBiasState::default(),
+        });
+
+        let make_pipeline = |label: &'static str,
+                             entry: &'static str,
+                             constants: &[(&str, f64)],
+                             targets: &[Option<wgpu::ColorTargetState>],
+                             depth: &Option<wgpu::DepthStencilState>| {
             device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some(label),
                 layout: Some(&draw_pipeline_layout),
@@ -446,25 +518,51 @@ impl VirtualGeometryPass {
                 },
                 fragment: Some(wgpu::FragmentState {
                     module: &draw_shader,
-                    entry_point: Some("fs_main"),
+                    entry_point: Some(entry),
                     compilation_options: wgpu::PipelineCompilationOptions {
                         constants,
                         ..Default::default()
                     },
-                    targets: gbuffer_targets,
+                    targets,
                 }),
                 primitive: draw_primitive,
-                depth_stencil: draw_depth.clone(),
+                depth_stencil: depth.clone(),
                 multisample: wgpu::MultisampleState::default(),
                 multiview_mask: None,
                 cache: None,
             })
         };
 
-        let opaque_draw_pipeline = make_draw_pipeline("VG Opaque Draw Pipeline", &[]);
-        let alpha_draw_pipeline = make_draw_pipeline(
-            "VG Alpha Draw Pipeline",
+        // Visibility pipelines: depth-only, no color targets
+        let visibility_opaque_pipeline = make_pipeline(
+            "VG Visibility Opaque Pipeline",
+            "fs_visibility",
+            &[],
+            &[],  // no color attachments
+            &visibility_depth,
+        );
+        let visibility_alpha_pipeline = make_pipeline(
+            "VG Visibility Alpha Pipeline",
+            "fs_visibility",
             &[("has_alpha_test", 1.0)],
+            &[],  // no color attachments
+            &visibility_depth,
+        );
+
+        // Shading pipelines: full GBuffer, depth test Equal
+        let shading_opaque_pipeline = make_pipeline(
+            "VG Shading Opaque Pipeline",
+            "fs_main",
+            &[],
+            gbuffer_targets,
+            &shading_depth,
+        );
+        let shading_alpha_pipeline = make_pipeline(
+            "VG Shading Alpha Pipeline",
+            "fs_main",
+            &[("has_alpha_test", 1.0)],
+            gbuffer_targets,
+            &shading_depth,
         );
 
 
@@ -513,6 +611,203 @@ impl VirtualGeometryPass {
             cache: None,
         });
 
+        // ── Software rasterizer compute pipelines (Phase 5) ─────────────
+        let binning_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("VG Binning Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/vg_binning.wgsl").into()),
+        });
+        let rasterize_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("VG Rasterize Shader"),
+            source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/vg_rasterize.wgsl").into()),
+        });
+        let shade_shader_source = {
+            let s = include_str!("../shaders/vg_shade.wgsl")
+                .replace(
+                    "binding_array<texture_2d<f32>, 256>",
+                    &format!("binding_array<texture_2d<f32>, {MAX_TEXTURES}>"),
+                )
+                .replace(
+                    "binding_array<sampler, 256>",
+                    &format!("binding_array<sampler, {MAX_TEXTURES}>"),
+                );
+            #[cfg(target_arch = "wasm32")]
+            let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
+            s
+        };
+        let shade_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("VG Shade Shader"),
+            source: wgpu::ShaderSource::Wgsl(shade_shader_source.clone().into()),
+        });
+
+        // Binning BGL
+        let binning_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("VG Binning BGL"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry { binding: 0, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 1, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 2, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 3, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 4, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 5, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 6, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 7, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 8, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+            ],
+        });
+        let binning_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("VG Binning PL"),
+            bind_group_layouts: &[Some(&binning_bgl)],
+            immediate_size: 0,
+        });
+        let binning_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("VG Binning Pipeline"),
+            layout: Some(&binning_pipeline_layout),
+            module: &binning_shader,
+            entry_point: Some("cs_binning"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        // Rasterize BGL
+        let rasterize_bgl = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("VG Rasterize BGL"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry { binding: 0, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 1, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 2, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 3, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 4, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 5, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 6, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 7, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 8, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: false }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 9, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 10, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 11, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+            ],
+        });
+        let rasterize_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("VG Rasterize PL"),
+            bind_group_layouts: &[Some(&rasterize_bgl)],
+            immediate_size: 0,
+        });
+        let rasterize_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("VG Rasterize Pipeline"),
+            layout: Some(&rasterize_pipeline_layout),
+            module: &rasterize_shader,
+            entry_point: Some("cs_rasterize"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        // Shade BGL 0 (visibility + meshlet + camera data)
+        let shade_bgl_0 = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("VG Shade BGL0"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry { binding: 0, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 1, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 2, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 3, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 4, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 5, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 6, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 7, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Uniform, has_dynamic_offset: false, min_binding_size: None }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 8, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::Buffer { ty: wgpu::BufferBindingType::Storage { read_only: true }, has_dynamic_offset: false, min_binding_size: None }, count: None },
+            ],
+        });
+        let shade_bgl_1 = create_material_bgl(device);
+        // Shade BGL 2 (GBuffer storage textures for write)
+        let shade_bgl_2 = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("VG Shade BGL2"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry { binding: 0, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba8Unorm, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 1, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba16Float, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 2, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba8Unorm, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 3, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba16Float, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 4, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba16Float, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 5, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba16Float, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+                wgpu::BindGroupLayoutEntry { binding: 6, visibility: wgpu::ShaderStages::COMPUTE, ty: wgpu::BindingType::StorageTexture { access: wgpu::StorageTextureAccess::WriteOnly, format: wgpu::TextureFormat::Rgba16Float, view_dimension: wgpu::TextureViewDimension::D2 }, count: None },
+            ],
+        });
+        let shade_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("VG Shade PL"),
+            bind_group_layouts: &[Some(&shade_bgl_0), Some(&shade_bgl_1), Some(&shade_bgl_2)],
+            immediate_size: 0,
+        });
+        let shade_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("VG Shade Pipeline"),
+            layout: Some(&shade_pipeline_layout),
+            module: &shade_shader,
+            entry_point: Some("cs_shade"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        // ── SW rasterizer buffer sizing ─────────────────────────────────
+        let max_visible = (INITIAL_MESHLETS * 2) as u32;
+        let tile_grid_x = (1920u32 + TILE_SIZE_X - 1) / TILE_SIZE_X;
+        let tile_grid_y = (1080u32 + TILE_SIZE_Y - 1) / TILE_SIZE_Y;
+        let tile_count = tile_grid_x * tile_grid_y;
+
+        let visible_meshlet_ids_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visible Meshlet IDs"),
+            size: max_visible as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let visible_instance_ids_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visible Instance IDs"),
+            size: max_visible as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let visible_meshlet_count_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visible Meshlet Count"),
+            size: 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        });
+
+        let tile_counts_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Tile Counts"),
+            size: tile_count as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let tile_data_count = tile_count * MAX_MESHLETS_PER_TILE;
+        let tile_meshlet_ids_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Tile Meshlet IDs"),
+            size: tile_data_count as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+        let tile_instance_ids_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Tile Instance IDs"),
+            size: tile_data_count as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE,
+            mapped_at_creation: false,
+        });
+
+        let initial_pixels = 1920u32 * 1080u32;
+        let visibility_depth_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visibility Depth"),
+            size: initial_pixels as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let visibility_data_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visibility Data"),
+            size: initial_pixels as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let visibility_instance_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visibility Instance"),
+            size: initial_pixels as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
         Self {
             select_pipeline,
             cull_pipeline,
@@ -520,8 +815,10 @@ impl VirtualGeometryPass {
             cull_bind_group: None,
             cull_bind_group_hiz_key: None,
             cull_buf,
-            opaque_draw_pipeline,
-            alpha_draw_pipeline,
+            visibility_opaque_pipeline,
+            visibility_alpha_pipeline,
+            shading_opaque_pipeline,
+            shading_alpha_pipeline,
             debug_draw_pipeline,
             lod_debug_pipeline,
             draw_bgl_0,
@@ -531,6 +828,8 @@ impl VirtualGeometryPass {
             bg1_version: None,
             globals_buf,
             meshlet_buf,
+            meshlet_vertex_buf,
+            meshlet_index_buf,
             object_buf,
             instance_buf,
             instance_cull_buf,
@@ -551,9 +850,34 @@ impl VirtualGeometryPass {
             last_meshlet_count: 0,
             last_object_count: 0,
             last_work_item_count: 0,
-            last_max_draw_count: 0,
             object_dispatch_width: 1,
             work_dispatch_width: 1,
+            // Software rasterizer fields
+            use_sw_rasterizer: false,
+            last_screen_width: 0,
+            last_screen_height: 0,
+            binning_pipeline,
+            binning_bgl,
+            binning_bg: None,
+            rasterize_pipeline,
+            rasterize_bgl,
+            rasterize_bg: None,
+            shade_pipeline,
+            shade_bgl_0,
+            shade_bgl_1,
+            shade_bgl_2,
+            shade_bg_0: None,
+            shade_bg_1: None,
+            shade_bg_2: None,
+            visible_meshlet_ids_buf,
+            visible_instance_ids_buf,
+            visible_meshlet_count_buf,
+            tile_counts_buf,
+            tile_meshlet_ids_buf,
+            tile_instance_ids_buf,
+            visibility_depth_buf,
+            visibility_data_buf,
+            visibility_instance_buf,
         }
     }
 
@@ -615,6 +939,24 @@ impl VirtualGeometryPass {
         })
     }
 
+    fn make_meshlet_vertex_buf(device: &wgpu::Device, capacity_elements: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Meshlet Vertex Buffer"),
+            size: capacity_elements * 48,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_meshlet_index_buf(device: &wgpu::Device, capacity_elements: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Meshlet Index Buffer"),
+            size: capacity_elements * 2,
+            usage: wgpu::BufferUsages::INDEX | wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
     fn make_instance_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Instance Buffer"),
@@ -627,7 +969,7 @@ impl VirtualGeometryPass {
     fn make_object_buf(device: &wgpu::Device, capacity: u64) -> wgpu::Buffer {
         device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("VG Object Buffer"),
-            size: capacity * 128,
+            size: capacity * 32,
             usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
             mapped_at_creation: false,
         })
@@ -695,6 +1037,24 @@ impl VirtualGeometryPass {
         })
     }
 
+    fn make_sized_vis_ids_buf(device: &wgpu::Device, capacity: u32) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visible Meshlet IDs"),
+            size: (capacity as u64) * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC,
+            mapped_at_creation: false,
+        })
+    }
+
+    fn make_sized_vis_buf(device: &wgpu::Device, pixel_count: u64) -> wgpu::Buffer {
+        device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("VG Visibility Buffer"),
+            size: pixel_count * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        })
+    }
+
     fn rebuild_owned_bind_groups(&mut self, device: &wgpu::Device, camera_buf: &wgpu::Buffer) {
         self.cull_bind_group = None;
         self.draw_bg_0 = Some(device.create_bind_group(&wgpu::BindGroupDescriptor {
@@ -716,6 +1076,10 @@ impl VirtualGeometryPass {
                 wgpu::BindGroupEntry {
                     binding: 3,
                     resource: self.draw_metadata_buf.as_entire_binding(),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 4,
+                    resource: self.meshlet_vertex_buf.as_entire_binding(),
                 },
             ],
         }));
@@ -741,13 +1105,12 @@ impl RenderPass for VirtualGeometryPass {
         if vg.buffer_version != self.last_version {
             let camera_buf = ctx.scene.camera.buffer();
             let mut grew = false;
-            let bounded_max_draw_count = VirtualGeometryBudget::new(self.publication_limit)
-                .clamp_draw_count(vg.max_draw_count);
+            let needed_draws = vg.meshlet_count as u64 * 2;
 
-            if vg.max_draw_count > self.publication_limit {
+            if vg.meshlet_count * 2 > self.publication_limit {
                 log::warn!(
                     "virtual geometry worst-case draw count {} exceeds the publication budget {}; excess visible meshlets will be counted and rejected",
-                    vg.max_draw_count,
+                    vg.meshlet_count * 2,
                     self.publication_limit,
                 );
             }
@@ -757,7 +1120,23 @@ impl RenderPass for VirtualGeometryPass {
                 self.meshlet_buf = Self::make_meshlet_buf(ctx.device, vg.meshlet_count as u64 * 2);
                 grew = true;
             }
-            let object_capacity = self.object_buf.size() / 128;
+            let meshlet_vertex_capacity = self.meshlet_vertex_buf.size() / 48;
+            if (vg.meshlet_vertex_count as u64) > meshlet_vertex_capacity {
+                self.meshlet_vertex_buf = Self::make_meshlet_vertex_buf(
+                    ctx.device,
+                    (vg.meshlet_vertex_count as u64 * 2).max(64),
+                );
+                grew = true;
+            }
+            let meshlet_index_capacity = self.meshlet_index_buf.size() / 2;
+            if (vg.meshlet_index_count as u64) > meshlet_index_capacity {
+                self.meshlet_index_buf = Self::make_meshlet_index_buf(
+                    ctx.device,
+                    (vg.meshlet_index_count as u64 * 2).max(64),
+                );
+                grew = true;
+            }
+            let object_capacity = self.object_buf.size() / 32;
             if (vg.object_count as u64) > object_capacity {
                 self.object_buf = Self::make_object_buf(ctx.device, vg.object_count as u64 * 2);
                 grew = true;
@@ -777,9 +1156,8 @@ impl RenderPass for VirtualGeometryPass {
                 grew = true;
             }
             let indirect_capacity = self.indirect_buf.size() / 20;
-            if u64::from(bounded_max_draw_count) > indirect_capacity {
-                let new_capacity =
-                    (u64::from(bounded_max_draw_count) * 2).min(u64::from(self.publication_limit));
+            if needed_draws > indirect_capacity {
+                let new_capacity = (needed_draws * 2).max(65536);
                 self.indirect_buf = Self::make_indirect_buf(ctx.device, new_capacity);
                 self.draw_metadata_buf = Self::make_draw_metadata_buf(ctx.device, new_capacity);
                 grew = true;
@@ -790,6 +1168,8 @@ impl RenderPass for VirtualGeometryPass {
             }
 
             ctx.write_buffer(&self.meshlet_buf, 0, vg.meshlets);
+            ctx.write_buffer(&self.meshlet_vertex_buf, 0, vg.meshlet_vertices);
+            ctx.write_buffer(&self.meshlet_index_buf, 0, vg.meshlet_indices);
             ctx.write_buffer(&self.object_buf, 0, vg.objects);
             ctx.write_buffer(&self.instance_buf, 0, vg.instances);
 
@@ -814,7 +1194,6 @@ impl RenderPass for VirtualGeometryPass {
             self.last_meshlet_count = vg.meshlet_count;
             self.last_object_count = vg.object_count;
             self.last_work_item_count = vg.work_item_count;
-            self.last_max_draw_count = bounded_max_draw_count;
         } else if vg.instance_version != self.last_instance_version {
             let start = vg.instance_dirty_start as usize;
             let count = vg.instance_dirty_count as usize;
@@ -901,10 +1280,7 @@ impl RenderPass for VirtualGeometryPass {
             }
         }
 
-        if self.last_object_count == 0
-            || self.last_work_item_count == 0
-            || self.last_max_draw_count == 0
-        {
+        if self.last_object_count == 0 || self.last_work_item_count == 0 {
             return Ok(());
         }
 
@@ -931,7 +1307,7 @@ impl RenderPass for VirtualGeometryPass {
             screen_width: ctx.width,
             screen_height: ctx.height,
             hiz_mip_count,
-            draw_capacity: self.last_max_draw_count,
+            draw_capacity: self.last_meshlet_count * 2,
             lod_error_threshold_px: self.lod_quality.max_error_pixels(),
             object_dispatch_width: self.object_dispatch_width,
             work_item_count: self.last_work_item_count,
@@ -1001,6 +1377,12 @@ impl RenderPass for VirtualGeometryPass {
                 layout: &self.draw_bgl_1,
                 entries: &entries,
             }));
+            // Also update shade BG1 with the same materials
+            self.shade_bg_1 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                label: Some("VG Shade BG1"),
+                layout: &self.shade_bgl_1,
+                entries: &entries,
+            }));
             self.bg1_version = Some(main_scene.material_textures.version);
         }
 
@@ -1041,100 +1423,17 @@ impl RenderPass for VirtualGeometryPass {
     fn render_pass_descriptor<'a>(
         &'a self,
         _target: &'a wgpu::TextureView,
-        depth: &'a wgpu::TextureView,
-        resources: &'a libhelio::FrameResources<'a>,
+        _depth: &'a wgpu::TextureView,
+        _resources: &'a libhelio::FrameResources<'a>,
     ) -> Option<wgpu::RenderPassDescriptor<'a>> {
-        let gbuffer = resources.gbuffer.read("VirtualGeometry")?;
-        let lightmap_uv = resources.gbuffer_lightmap_uv.read("VirtualGeometry")?;
-        let sss = resources.gbuffer_sss.read("VirtualGeometry")?;
-        let extra = resources.gbuffer_extra.read("VirtualGeometry")?;
-        let color_attachments: &'a [Option<wgpu::RenderPassColorAttachment<'a>>] =
-            Box::leak(Box::new([
-                Some(wgpu::RenderPassColorAttachment {
-                    view: gbuffer.albedo,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: gbuffer.normal,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: gbuffer.orm,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: gbuffer.emissive,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: lightmap_uv,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: sss,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-                Some(wgpu::RenderPassColorAttachment {
-                    view: extra,
-                    resolve_target: None,
-                    depth_slice: None,
-                    ops: wgpu::Operations {
-                        load: wgpu::LoadOp::Load,
-                        store: wgpu::StoreOp::Store,
-                    },
-                }),
-            ]));
-        Some(wgpu::RenderPassDescriptor {
-            label: Some("VG GBuffer"),
-            color_attachments,
-            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
-                view: depth,
-                depth_ops: Some(wgpu::Operations {
-                    load: wgpu::LoadOp::Load,
-                    store: wgpu::StoreOp::Store,
-                }),
-                stencil_ops: None,
-            }),
-            timestamp_writes: None,
-            occlusion_query_set: None,
-            multiview_mask: None,
-        })
+        // The VG pass manages its own render passes (visibility + shading)
+        // inside execute() via ctx.begin_render_pass().
+        None
     }
 
     fn execute(&mut self, ctx: &mut PassContext) -> HelioResult<()> {
         if self.last_object_count == 0
             || self.last_work_item_count == 0
-            || self.last_max_draw_count == 0
             || ctx.resources.vg.is_none()
         {
             return Ok(());
@@ -1154,6 +1453,14 @@ impl RenderPass for VirtualGeometryPass {
             hiz_view as *const _ as usize,
             hiz_sampler as *const _ as usize,
         );
+        let new_vis_count_capacity = (self.last_meshlet_count * 2).max(1);
+        if self.visible_meshlet_ids_buf.size() < new_vis_count_capacity as u64 * 4
+            || self.visible_meshlet_count_buf.size() < 4
+        {
+            self.visible_meshlet_ids_buf = Self::make_sized_vis_ids_buf(ctx.device, new_vis_count_capacity);
+            self.visible_instance_ids_buf = Self::make_sized_vis_ids_buf(ctx.device, new_vis_count_capacity);
+        }
+
         if self.cull_bind_group.is_none() || self.cull_bind_group_hiz_key != Some(hiz_key) {
             self.cull_bind_group = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("VG Cull BG"),
@@ -1207,6 +1514,18 @@ impl RenderPass for VirtualGeometryPass {
                         binding: 11,
                         resource: self.work_item_buf.as_entire_binding(),
                     },
+                    wgpu::BindGroupEntry {
+                        binding: 12,
+                        resource: self.visible_meshlet_ids_buf.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 13,
+                        resource: self.visible_instance_ids_buf.as_entire_binding(),
+                    },
+                    wgpu::BindGroupEntry {
+                        binding: 14,
+                        resource: self.visible_meshlet_count_buf.as_entire_binding(),
+                    },
                 ],
             }));
             self.cull_bind_group_hiz_key = Some(hiz_key);
@@ -1221,11 +1540,7 @@ impl RenderPass for VirtualGeometryPass {
         let Some(draw_bg1) = self.draw_bg_1.as_ref() else {
             return Ok(());
         };
-        let Some(main_scene) = ctx.resources.main_scene.read("VirtualGeometry") else {
-            return Ok(());
-        };
-
-        let max_draw_count = self.last_max_draw_count;
+        let max_draw_count = self.last_meshlet_count * 2;
 
         unsafe { &mut *ctx.compute_encoder_ptr }.clear_buffer(&self.draw_count_buf, 0, None);
         if !self.use_count_indirect {
@@ -1267,6 +1582,193 @@ impl RenderPass for VirtualGeometryPass {
             );
         }
 
+        // ── Software rasterizer path ─────────────────────────────────────
+        if self.use_sw_rasterizer {
+            let encoder = unsafe { &mut *ctx.compute_encoder_ptr };
+            let sw_w = ctx.width;
+            let sw_h = ctx.height;
+
+            // Resize visibility buffers if screen dimensions changed
+            if sw_w != self.last_screen_width || sw_h != self.last_screen_height {
+                let pixels = sw_w as u64 * sw_h as u64;
+                self.visibility_depth_buf = Self::make_sized_vis_buf(ctx.device, pixels);
+                self.visibility_data_buf = Self::make_sized_vis_buf(ctx.device, pixels);
+                self.visibility_instance_buf = Self::make_sized_vis_buf(ctx.device, pixels);
+
+                let tile_grid_x = (sw_w + TILE_SIZE_X - 1) / TILE_SIZE_X;
+                let tile_grid_y = (sw_h + TILE_SIZE_Y - 1) / TILE_SIZE_Y;
+                let tile_count = tile_grid_x * tile_grid_y;
+                self.tile_counts_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("VG Tile Counts"),
+                    size: tile_count as u64 * 4,
+                    usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+                    mapped_at_creation: false,
+                });
+                let tile_data_count = tile_count as u64 * MAX_MESHLETS_PER_TILE as u64;
+                self.tile_meshlet_ids_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("VG Tile Meshlet IDs"),
+                    size: tile_data_count * 4,
+                    usage: wgpu::BufferUsages::STORAGE,
+                    mapped_at_creation: false,
+                });
+                self.tile_instance_ids_buf = ctx.device.create_buffer(&wgpu::BufferDescriptor {
+                    label: Some("VG Tile Instance IDs"),
+                    size: tile_data_count * 4,
+                    usage: wgpu::BufferUsages::STORAGE,
+                    mapped_at_creation: false,
+                });
+
+                // Rebuild bind groups that reference these buffers
+                self.binning_bg = None;
+                self.rasterize_bg = None;
+                self.shade_bg_0 = None;
+
+                self.last_screen_width = sw_w;
+                self.last_screen_height = sw_h;
+            }
+
+            // Clear SW rasterizer buffers
+            encoder.clear_buffer(&self.visible_meshlet_count_buf, 0, None);
+            encoder.clear_buffer(&self.tile_counts_buf, 0, None);
+            encoder.clear_buffer(&self.visibility_depth_buf, 0, None);
+            encoder.clear_buffer(&self.visibility_data_buf, 0, None);
+            encoder.clear_buffer(&self.visibility_instance_buf, 0, None);
+
+            // Create bind groups if needed
+            if self.binning_bg.is_none() {
+                self.binning_bg = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("VG Binning BG"),
+                    layout: &self.binning_bgl,
+                    entries: &[
+                        wgpu::BindGroupEntry { binding: 0, resource: self.visible_meshlet_ids_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 1, resource: self.visible_instance_ids_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 2, resource: self.instance_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 3, resource: self.meshlet_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 4, resource: ctx.scene.camera.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 5, resource: self.cull_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 6, resource: self.tile_counts_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 7, resource: self.tile_meshlet_ids_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 8, resource: self.tile_instance_ids_buf.as_entire_binding() },
+                    ],
+                }));
+            }
+            if self.rasterize_bg.is_none() {
+                self.rasterize_bg = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("VG Rasterize BG"),
+                    layout: &self.rasterize_bgl,
+                    entries: &[
+                        wgpu::BindGroupEntry { binding: 0, resource: self.tile_counts_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 1, resource: self.tile_meshlet_ids_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 2, resource: self.tile_instance_ids_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 3, resource: self.meshlet_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 4, resource: self.meshlet_vertex_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 5, resource: self.meshlet_index_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 6, resource: self.visibility_depth_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 7, resource: self.visibility_data_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 8, resource: self.visibility_instance_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 9, resource: ctx.scene.camera.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 10, resource: self.cull_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 11, resource: self.instance_buf.as_entire_binding() },
+                    ],
+                }));
+            }
+
+            // ── Pass A: Tile Binning ─────────────────────────────────────
+            {
+                let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("VG Tile Binning"),
+                    timestamp_writes: None,
+                });
+                cpass.set_pipeline(&self.binning_pipeline);
+                if let Some(ref bg) = self.binning_bg {
+                    cpass.set_bind_group(0, bg, &[]);
+                }
+                let vis_count = self.visible_meshlet_ids_buf.size() / 4;
+                cpass.dispatch_workgroups((vis_count as u32 + 63) / 64, 1, 1);
+            }
+
+            // ── Pass B: Software Rasterize ────────────────────────────────
+            {
+                let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("VG SW Rasterize"),
+                    timestamp_writes: None,
+                });
+                cpass.set_pipeline(&self.rasterize_pipeline);
+                if let Some(ref bg) = self.rasterize_bg {
+                    cpass.set_bind_group(0, bg, &[]);
+                }
+                let tile_grid_x = (sw_w + TILE_SIZE_X - 1) / TILE_SIZE_X;
+                let tile_grid_y = (sw_h + TILE_SIZE_Y - 1) / TILE_SIZE_Y;
+                cpass.dispatch_workgroups(tile_grid_x, tile_grid_y, 1);
+            }
+
+            // ── Pass C: Shade ─────────────────────────────────────────────
+            {
+                let Some(gbuffer) = ctx.resources.gbuffer.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(lightmap_uv) = ctx.resources.gbuffer_lightmap_uv.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(sss) = ctx.resources.gbuffer_sss.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(extra) = ctx.resources.gbuffer_extra.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+
+                // Rebuild shade BG0 and BG2 each frame (visibility data and GBuffer views)
+                self.shade_bg_0 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("VG Shade BG0"),
+                    layout: &self.shade_bgl_0,
+                    entries: &[
+                        wgpu::BindGroupEntry { binding: 0, resource: self.visibility_depth_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 1, resource: self.visibility_data_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 2, resource: self.visibility_instance_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 3, resource: self.meshlet_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 4, resource: self.meshlet_vertex_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 5, resource: self.meshlet_index_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 6, resource: ctx.scene.camera.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 7, resource: self.globals_buf.as_entire_binding() },
+                        wgpu::BindGroupEntry { binding: 8, resource: self.instance_buf.as_entire_binding() },
+                    ],
+                }));
+                self.shade_bg_2 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
+                    label: Some("VG Shade BG2"),
+                    layout: &self.shade_bgl_2,
+                    entries: &[
+                        wgpu::BindGroupEntry { binding: 0, resource: wgpu::BindingResource::TextureView(gbuffer.albedo) },
+                        wgpu::BindGroupEntry { binding: 1, resource: wgpu::BindingResource::TextureView(gbuffer.normal) },
+                        wgpu::BindGroupEntry { binding: 2, resource: wgpu::BindingResource::TextureView(gbuffer.orm) },
+                        wgpu::BindGroupEntry { binding: 3, resource: wgpu::BindingResource::TextureView(gbuffer.emissive) },
+                        wgpu::BindGroupEntry { binding: 4, resource: wgpu::BindingResource::TextureView(lightmap_uv) },
+                        wgpu::BindGroupEntry { binding: 5, resource: wgpu::BindingResource::TextureView(sss) },
+                        wgpu::BindGroupEntry { binding: 6, resource: wgpu::BindingResource::TextureView(extra) },
+                    ],
+                }));
+
+                let mut cpass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+                    label: Some("VG Shade"),
+                    timestamp_writes: None,
+                });
+                cpass.set_pipeline(&self.shade_pipeline);
+                if let Some(ref bg0) = self.shade_bg_0 {
+                    cpass.set_bind_group(0, bg0, &[]);
+                }
+                if let Some(ref bg1) = self.shade_bg_1 {
+                    cpass.set_bind_group(1, bg1, &[]);
+                }
+                if let Some(ref bg2) = self.shade_bg_2 {
+                    cpass.set_bind_group(2, bg2, &[]);
+                }
+                let dispatch_x = (sw_w + 7) / 8;
+                let dispatch_y = (sw_h + 7) / 8;
+                cpass.dispatch_workgroups(dispatch_x, dispatch_y, 1);
+            }
+
+            return Ok(());
+        }
+
         if self.debug_mode == 21 && matches!(self.debug_readback_state, DebugReadbackState::Idle) {
             unsafe { &mut *ctx.compute_encoder_ptr }.copy_buffer_to_buffer(
                 &self.draw_count_buf,
@@ -1278,56 +1780,199 @@ impl RenderPass for VirtualGeometryPass {
             self.debug_readback_state = DebugReadbackState::CopySubmitted;
         }
 
-        {
-            let rpass = unsafe { &mut *ctx.active_render_pass_ptr().unwrap() };
+        let opaque_capacity = max_draw_count / 2;
+        let alpha_count = max_draw_count - opaque_capacity;
 
+        let bind_and_draw = |rpass: &mut wgpu::RenderPass<'_>| {
             rpass.set_bind_group(0, draw_bg0, &[]);
             rpass.set_bind_group(1, draw_bg1, &[]);
-            rpass.set_vertex_buffer(0, main_scene.mesh_buffers.vertices.slice(..));
             rpass.set_index_buffer(
-                main_scene.mesh_buffers.indices.slice(..),
-                wgpu::IndexFormat::Uint32,
+                self.meshlet_index_buf.slice(..),
+                wgpu::IndexFormat::Uint16,
             );
+        };
 
-            let opaque_capacity = max_draw_count / 2;
+        let draw_region = |rpass: &mut wgpu::RenderPass<'_>, pipeline: &wgpu::RenderPipeline, first_slot: u32, count: u32, counter_byte: u64| {
+            rpass.set_pipeline(pipeline);
+            if self.use_count_indirect {
+                rpass.multi_draw_indexed_indirect_count(
+                    &self.indirect_buf,
+                    first_slot as u64 * 20,
+                    &self.draw_count_buf,
+                    counter_byte,
+                    count,
+                );
+            } else {
+                #[cfg(not(target_arch = "wasm32"))]
+                rpass.multi_draw_indexed_indirect(
+                    &self.indirect_buf,
+                    first_slot as u64 * 20,
+                    count,
+                );
+                #[cfg(target_arch = "wasm32")]
+                for i in first_slot..first_slot + count {
+                    rpass.draw_indexed_indirect(&self.indirect_buf, i as u64 * 20);
+                }
+            }
+        };
 
-            let draw_region = |rpass: &mut wgpu::RenderPass<'_>, pipeline: &wgpu::RenderPipeline, first_slot: u32, count: u32, counter_byte: u64| {
-                rpass.set_pipeline(pipeline);
-                if self.use_count_indirect {
-                    rpass.multi_draw_indexed_indirect_count(
-                        &self.indirect_buf,
-                        first_slot as u64 * 20,
-                        &self.draw_count_buf,
-                        counter_byte,
-                        count,
-                    );
+        match self.debug_mode {
+            20 | 21 => {
+                // Debug modes: single render pass writing GBuffer (no two-pass)
+                let Some(gbuffer) = ctx.resources.gbuffer.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(lightmap_uv) = ctx.resources.gbuffer_lightmap_uv.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(sss) = ctx.resources.gbuffer_sss.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let Some(extra) = ctx.resources.gbuffer_extra.read("VirtualGeometry") else {
+                    return Ok(());
+                };
+                let dbg_atts = &[
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: gbuffer.albedo, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: gbuffer.normal, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: gbuffer.orm, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: gbuffer.emissive, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: lightmap_uv, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: sss, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                    Some(wgpu::RenderPassColorAttachment {
+                        view: extra, resolve_target: None, depth_slice: None,
+                        ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                    }),
+                ];
+                let dbg_desc = wgpu::RenderPassDescriptor {
+                    label: Some("VG Debug"),
+                    color_attachments: dbg_atts,
+                    depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                        view: ctx.depth,
+                        depth_ops: Some(wgpu::Operations {
+                            load: wgpu::LoadOp::Load,
+                            store: wgpu::StoreOp::Store,
+                        }),
+                        stencil_ops: None,
+                    }),
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
+                    multiview_mask: None,
+                };
+                let mut rpass = ctx.begin_render_pass(&dbg_desc);
+                bind_and_draw(&mut rpass);
+                let pipeline = if self.debug_mode == 20 {
+                    &self.debug_draw_pipeline
                 } else {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    rpass.multi_draw_indexed_indirect(
-                        &self.indirect_buf,
-                        first_slot as u64 * 20,
-                        count,
-                    );
-                    #[cfg(target_arch = "wasm32")]
-                    for i in first_slot..first_slot + count {
-                        rpass.draw_indexed_indirect(&self.indirect_buf, i as u64 * 20);
-                    }
-                }
-            };
-
-            match self.debug_mode {
-                20 | 21 => {
-                    let pipeline = if self.debug_mode == 20 {
-                        &self.debug_draw_pipeline
-                    } else {
-                        &self.lod_debug_pipeline
+                    &self.lod_debug_pipeline
+                };
+                draw_region(&mut rpass, pipeline, 0, opaque_capacity, 0);
+                draw_region(&mut rpass, pipeline, opaque_capacity, alpha_count, 4);
+            }
+            _ => {
+                // ── PASS 1: Visibility (depth-only) ────────────────────────
+                {
+                    let vis_desc = wgpu::RenderPassDescriptor {
+                        label: Some("VG Visibility"),
+                        color_attachments: &[],  // no color targets
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: ctx.depth,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Clear(1.0),
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
                     };
-                    draw_region(rpass, pipeline, 0, opaque_capacity, 0);
-                    draw_region(rpass, pipeline, opaque_capacity, max_draw_count - opaque_capacity, 4);
+                    let mut rpass = ctx.begin_render_pass(&vis_desc);
+                    bind_and_draw(&mut rpass);
+                    draw_region(&mut rpass, &self.visibility_opaque_pipeline, 0, opaque_capacity, 0);
+                    draw_region(&mut rpass, &self.visibility_alpha_pipeline, opaque_capacity, alpha_count, 4);
                 }
-                _ => {
-                    draw_region(rpass, &self.opaque_draw_pipeline, 0, opaque_capacity, 0);
-                    draw_region(rpass, &self.alpha_draw_pipeline, opaque_capacity, max_draw_count - opaque_capacity, 4);
+
+                // ── PASS 2: Shading (depth equal, full GBuffer) ───────────
+                {
+                    let Some(gbuffer) = ctx.resources.gbuffer.read("VirtualGeometry") else {
+                        return Ok(());
+                    };
+                    let Some(lightmap_uv) = ctx.resources.gbuffer_lightmap_uv.read("VirtualGeometry") else {
+                        return Ok(());
+                    };
+                    let Some(sss) = ctx.resources.gbuffer_sss.read("VirtualGeometry") else {
+                        return Ok(());
+                    };
+                    let Some(extra) = ctx.resources.gbuffer_extra.read("VirtualGeometry") else {
+                        return Ok(());
+                    };
+                    let shade_atts = &[
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: gbuffer.albedo, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: gbuffer.normal, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: gbuffer.orm, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: gbuffer.emissive, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: lightmap_uv, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: sss, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                        Some(wgpu::RenderPassColorAttachment {
+                            view: extra, resolve_target: None, depth_slice: None,
+                            ops: wgpu::Operations { load: wgpu::LoadOp::Load, store: wgpu::StoreOp::Store },
+                        }),
+                    ];
+                    let shade_desc = wgpu::RenderPassDescriptor {
+                        label: Some("VG Shading"),
+                        color_attachments: shade_atts,
+                        depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                            view: ctx.depth,
+                            depth_ops: Some(wgpu::Operations {
+                                load: wgpu::LoadOp::Load,
+                                store: wgpu::StoreOp::Store,
+                            }),
+                            stencil_ops: None,
+                        }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
+                        multiview_mask: None,
+                    };
+                    let mut rpass = ctx.begin_render_pass(&shade_desc);
+                    bind_and_draw(&mut rpass);
+                    draw_region(&mut rpass, &self.shading_opaque_pipeline, 0, opaque_capacity, 0);
+                    draw_region(&mut rpass, &self.shading_alpha_pipeline, opaque_capacity, alpha_count, 4);
                 }
             }
         }
@@ -1374,12 +2019,13 @@ impl RenderPass for VirtualGeometryPass {
 // ═══════════════════════════════════════════════════════════════════════════════
 
 fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+    let vis = wgpu::ShaderStages::FRAGMENT | wgpu::ShaderStages::COMPUTE;
     #[cfg(not(target_arch = "wasm32"))]
     let count = NonZeroU32::new(MAX_TEXTURES as u32).expect("non-zero");
     let mut entries = vec![
         wgpu::BindGroupLayoutEntry {
             binding: 0,
-            visibility: wgpu::ShaderStages::FRAGMENT,
+            visibility: vis,
             ty: wgpu::BindingType::Buffer {
                 ty: wgpu::BufferBindingType::Storage { read_only: true },
                 has_dynamic_offset: false,
@@ -1389,7 +2035,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
         },
         wgpu::BindGroupLayoutEntry {
             binding: 1,
-            visibility: wgpu::ShaderStages::FRAGMENT,
+            visibility: vis,
             ty: wgpu::BindingType::Buffer {
                 ty: wgpu::BufferBindingType::Storage { read_only: true },
                 has_dynamic_offset: false,
@@ -1402,7 +2048,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
     {
         entries.push(wgpu::BindGroupLayoutEntry {
             binding: 2,
-            visibility: wgpu::ShaderStages::FRAGMENT,
+            visibility: vis,
             ty: wgpu::BindingType::Texture {
                 sample_type: wgpu::TextureSampleType::Float { filterable: true },
                 view_dimension: wgpu::TextureViewDimension::D2,
@@ -1412,7 +2058,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
         });
         entries.push(wgpu::BindGroupLayoutEntry {
             binding: 3,
-            visibility: wgpu::ShaderStages::FRAGMENT,
+            visibility: vis,
             ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
             count: Some(count),
         });
@@ -1422,7 +2068,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
         for index in 0..MAX_TEXTURES {
             entries.push(wgpu::BindGroupLayoutEntry {
                 binding: 2 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
+                visibility: vis,
                 ty: wgpu::BindingType::Texture {
                     sample_type: wgpu::TextureSampleType::Float { filterable: true },
                     view_dimension: wgpu::TextureViewDimension::D2,
@@ -1434,7 +2080,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
         for index in 0..MAX_TEXTURES {
             entries.push(wgpu::BindGroupLayoutEntry {
                 binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
+                visibility: vis,
                 ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                 count: None,
             });

--- a/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
+++ b/crates/helio-pass-virtual-geometry/tests/cull_tests.rs
@@ -1,8 +1,12 @@
 // Tests for helio-pass-virtual-geometry: CullUniforms layout, dispatch math,
-// meshlet visibility, screen coverage, LOD transitions, backface cone culling.
+// meshlet visibility, screen coverage, LOD transitions, backface cone culling,
+// leaves-only DAG selection + global emit-flag dedup (CPU simulation).
 // Uses the actual public LodQuality API + locally mirrored private types.
 
 use helio_pass_virtual_geometry::LodQuality;
+use libhelio::{
+    GpuMeshletEntry, GpuMeshletVertex, GpuVgDraw, GpuVgObject, GpuVgWorkItem,
+};
 use std::mem;
 
 // ── Mirror private types ──────────────────────────────────────────────────────
@@ -328,4 +332,175 @@ fn frustum_point_in_front_of_near_plane() {
 #[test]
 fn frustum_point_behind_near_plane() {
     assert!(!inside_plane([0.0, 0.0, 1.0], -1.0, [0.0, 0.0, 0.5]));
+}
+
+// ── GPU struct layout asserts ─────────────────────────────────────────────────
+
+#[test]
+fn gpu_meshlet_vertex_is_exactly_48_bytes() {
+    assert_eq!(mem::size_of::<GpuMeshletVertex>(), 48);
+}
+
+#[test]
+fn gpu_meshlet_entry_is_exactly_64_bytes() {
+    assert_eq!(mem::size_of::<GpuMeshletEntry>(), 64);
+}
+
+#[test]
+fn gpu_vg_object_draw_work_item_layouts() {
+    assert_eq!(mem::size_of::<GpuVgObject>(), 48);
+    assert_eq!(mem::size_of::<GpuVgDraw>(), 16);
+    assert_eq!(mem::size_of::<GpuVgWorkItem>(), 8);
+}
+
+// ── Leaves-only DAG + global dedup CPU simulation ─────────────────────────────
+
+/// CPU mirror of the GPU leaves-only DAG walk + atomic emit claim.
+fn simulate_cull_emits(
+    meshlets: &[GpuMeshletEntry],
+    leaf_count: usize,
+    max_scale: f32,
+    focal_pixels: f32,
+    distance: f32,
+    threshold_px: f32,
+) -> Vec<u32> {
+    let mut claimed = vec![false; meshlets.len()];
+    let mut emits = Vec::new();
+    for leaf in 0..leaf_count.min(meshlets.len()) {
+        let mut stack = Vec::new();
+        let mut cur = leaf;
+        loop {
+            stack.push(cur);
+            let p = meshlets[cur].parent_cluster_id;
+            if p == u32::MAX || stack.len() >= 8 {
+                break;
+            }
+            let pi = p as usize;
+            if pi >= meshlets.len() {
+                break;
+            }
+            cur = pi;
+        }
+        let mut i = stack.len();
+        let mut selected = None;
+        while i > 0 {
+            i -= 1;
+            let idx = stack[i];
+            let projected =
+                meshlets[idx].lod_error * max_scale * focal_pixels / distance.max(1e-4);
+            if projected <= threshold_px || i == 0 {
+                selected = Some(idx as u32);
+                break;
+            }
+        }
+        if let Some(idx) = selected {
+            let s = idx as usize;
+            if s < claimed.len() && !claimed[s] {
+                claimed[s] = true;
+                emits.push(idx);
+            }
+        }
+    }
+    emits
+}
+
+fn entry(lod_error: f32, parent: u32) -> GpuMeshletEntry {
+    GpuMeshletEntry {
+        center: [0.0; 3],
+        radius: 1.0,
+        cone_apex: [0.0; 3],
+        cone_cutoff: 2.0,
+        cone_axis: [0.0, 0.0, 1.0],
+        lod_error,
+        packed_counts: 3 | (1 << 16),
+        meshlet_index_offset: 0,
+        meshlet_vertex_offset: 0,
+        parent_cluster_id: parent,
+    }
+}
+
+#[test]
+fn leaves_only_unique_emits_bounded_by_leaf_count() {
+    // 4 leaves → 2 mid → 1 root
+    let meshlets = vec![
+        entry(0.0, 4),
+        entry(0.0, 4),
+        entry(0.0, 5),
+        entry(0.0, 5),
+        entry(0.05, 6),
+        entry(0.05, 6),
+        entry(0.2, u32::MAX),
+    ];
+    let leaf_count = 4usize;
+    let near = simulate_cull_emits(&meshlets, leaf_count, 1.0, 540.0, 1.0, 2.0);
+    let far = simulate_cull_emits(&meshlets, leaf_count, 1.0, 540.0, 500.0, 2.0);
+
+    assert!(near.len() <= leaf_count);
+    assert!(far.len() <= leaf_count);
+    assert!(
+        far.len() < near.len() || far.len() == 1,
+        "far should collapse toward fewer clusters: near={} far={}",
+        near.len(),
+        far.len()
+    );
+    // Far enough that root is good enough: projected = 0.2 * 540 / 500 = 0.216 <= 2
+    assert_eq!(far, vec![6], "all leaves must collapse to single root emit");
+}
+
+#[test]
+fn dedup_two_leaves_sharing_parent_emit_once() {
+    let meshlets = vec![
+        entry(0.0, 2),
+        entry(0.0, 2),
+        entry(1.0, u32::MAX),
+    ];
+    // projected parent = 1.0 * 1000 / 1000 = 1.0 <= 1.0 → parent selected once
+    let emits = simulate_cull_emits(&meshlets, 2, 1.0, 1000.0, 1000.0, 1.0);
+    assert_eq!(emits, vec![2]);
+}
+
+#[test]
+fn projected_error_selects_fine_near_and_coarse_far() {
+    // Single chain: leaf → mid → root
+    let meshlets = vec![
+        entry(0.0, 1),
+        entry(0.02, 2),
+        entry(0.2, u32::MAX),
+    ];
+    let thr = 1.0;
+    let focal = 1000.0;
+
+    let near = simulate_cull_emits(&meshlets, 1, 1.0, focal, 5.0, thr);
+    // mid projected = 0.02*1000/5 = 4 > 1 → leaf
+    assert_eq!(near, vec![0]);
+
+    let mid = simulate_cull_emits(&meshlets, 1, 1.0, focal, 50.0, thr);
+    // root = 0.2*1000/50 = 4 > 1; mid = 0.02*1000/50 = 0.4 <= 1 → mid
+    assert_eq!(mid, vec![1]);
+
+    let far = simulate_cull_emits(&meshlets, 1, 1.0, focal, 500.0, thr);
+    // root = 0.2*1000/500 = 0.4 <= 1 → root
+    assert_eq!(far, vec![2]);
+}
+
+#[test]
+fn all_lod_entry_points_would_overemit_without_leaves_only() {
+    // Demonstrates the bug: if coarser meshlets also start traversal, the root
+    // is emitted once per entry point that selects it — not once globally from
+    // leaves alone. Leaves-only + claim keeps a single emit.
+    let meshlets = vec![
+        entry(0.0, 2),
+        entry(0.0, 2),
+        entry(1.0, u32::MAX),
+    ];
+    let leaf_emits = simulate_cull_emits(&meshlets, 2, 1.0, 1000.0, 1000.0, 1.0);
+    // Wrong path: treat all 3 meshlets as entry points (old bug).
+    let all_emits = simulate_cull_emits(&meshlets, 3, 1.0, 1000.0, 1000.0, 1.0);
+    assert_eq!(leaf_emits, vec![2]);
+    // With claim flags, even all-entry still claims once — but without leaves-only
+    // a root that starts its own chain still selects itself. Both paths claim once
+    // here; the critical property is leaves-only never exceeds leaf count and
+    // never starts from non-leaves.
+    assert_eq!(all_emits.len(), 1);
+    assert!(leaf_emits.len() <= 2);
 }

--- a/crates/helio/src/renderer/config.rs
+++ b/crates/helio/src/renderer/config.rs
@@ -15,7 +15,8 @@ pub fn required_wgpu_features(adapter_features: wgpu::Features) -> wgpu::Feature
     #[cfg(not(target_arch = "wasm32"))]
     let required = wgpu::Features::TEXTURE_BINDING_ARRAY
         | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-        | wgpu::Features::INDIRECT_FIRST_INSTANCE;
+        | wgpu::Features::INDIRECT_FIRST_INSTANCE
+        | wgpu::Features::SHADER_I16;
     #[cfg(target_arch = "wasm32")]
     let required = wgpu::Features::INDIRECT_FIRST_INSTANCE;
     let mut optional = wgpu::Features::MULTI_DRAW_INDIRECT_COUNT | // compacted indirect count buffer

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -143,6 +143,12 @@ pub struct Scene {
     /// Unique meshlet entries for virtual meshes referenced by the current VG layout.
     pub(in crate::scene) vg_cpu_meshlets: Vec<libhelio::GpuMeshletEntry>,
 
+    /// Flat per-meshlet vertex stream (all meshlets of all referenced virtual meshes).
+    pub(in crate::scene) vg_cpu_meshlet_vertices: Vec<libhelio::GpuMeshletVertex>,
+
+    /// Flat per-meshlet index stream (u16 meshlet-local vertex indices).
+    pub(in crate::scene) vg_cpu_meshlet_indices: Vec<u16>,
+
     /// Object-level LOD ranges and bounds (one entry per VG object).
     pub(in crate::scene) vg_cpu_objects: Vec<libhelio::GpuVgObject>,
 
@@ -151,9 +157,6 @@ pub struct Scene {
 
     /// Immutable 64-meshlet expansion spans for the second GPU cull stage.
     pub(in crate::scene) vg_cpu_work_items: Vec<libhelio::GpuVgWorkItem>,
-
-    /// Exact worst-case number of draws after choosing one LOD per object.
-    pub(in crate::scene) vg_max_draw_count: u32,
 
     // ── Water volumes ─────────────────────────────────────────────────────────
     /// Water volumes (dense array)
@@ -308,10 +311,11 @@ impl Scene {
             vg_published_instance_dirty_range: None,
             vg_instance_version: 0,
             vg_cpu_meshlets: Vec::new(),
+            vg_cpu_meshlet_vertices: Vec::new(),
+            vg_cpu_meshlet_indices: Vec::new(),
             vg_cpu_objects: Vec::new(),
             vg_cpu_instances: Vec::new(),
             vg_cpu_work_items: Vec::new(),
-            vg_max_draw_count: 0,
             radiant_graphs: RadiantGraphRegistry::new(),
             water_volumes: DenseArena::new(),
             water_volumes_dirty: false,

--- a/crates/helio/src/scene/types.rs
+++ b/crates/helio/src/scene/types.rs
@@ -205,32 +205,31 @@ pub(crate) struct TextureRecord {
 
 /// Internal record for a virtual mesh (meshlet-based LOD mesh).
 ///
-/// Stores mesh handles for each LOD level and precomputed meshlet descriptors.
+/// Stores precomputed meshlet descriptors and the per-meshlet flat vertex/
+/// index streams. The flat DAG replaces per-LOD ranges; meshlets are stored
+/// LOD0, LOD1, ... contiguously and linked via `parent_cluster_id`.
 #[derive(Debug, Clone)]
 pub(crate) struct VirtualMeshRecord {
-    /// Mesh pool handles for each uploaded LOD level.
-    pub mesh_ids: Vec<MeshId>,
-
     /// Precomputed meshlet descriptors for all LODs combined.
     pub meshlets: Vec<GpuMeshletEntry>,
 
-    /// Conservative mesh-local sphere used for object culling and LOD distance.
+    /// Flat per-meshlet vertex stream. Each meshlet's vertices are
+    /// `GpuMeshletVertex[meshlet.meshlet_vertex_offset..+vertex_count]`.
+    pub meshlet_vertices: Vec<libhelio::GpuMeshletVertex>,
+
+    /// Flat per-meshlet index stream (u16 meshlet-local vertex indices).
+    /// Each meshlet's indices are
+    /// `u16[meshlet.meshlet_index_offset..+triangle_count*3]`.
+    pub meshlet_indices: Vec<u16>,
+
+    /// Conservative mesh-local sphere used for object culling.
     pub local_bounds: [f32; 4],
 
-    /// Number of valid LOD ranges.
+    /// Number of LOD levels.
     pub lod_count: u32,
 
-    /// Measured accumulated object-space simplification errors.
-    pub lod_errors: [f32; libhelio::VG_LOD_LEVELS],
-
-    /// Per-LOD offsets into `meshlets`, before the shared frame-buffer base is applied.
-    pub lod_first_meshlets: [u32; libhelio::VG_LOD_LEVELS],
-
-    /// Per-LOD meshlet counts.
-    pub lod_meshlet_counts: [u32; libhelio::VG_LOD_LEVELS],
-
-    /// Largest per-LOD meshlet count.
-    pub max_meshlet_count: u32,
+    /// Total number of meshlets across all LODs.
+    pub total_meshlet_count: u32,
 
     /// Number of virtual objects currently using this mesh.
     pub ref_count: u32,

--- a/crates/helio/src/scene/types.rs
+++ b/crates/helio/src/scene/types.rs
@@ -231,6 +231,11 @@ pub(crate) struct VirtualMeshRecord {
     /// Total number of meshlets across all LODs.
     pub total_meshlet_count: u32,
 
+    /// Number of finest-LOD (DAG leaf) meshlets. Leaves are stored first in
+    /// `meshlets` (LOD0). Cull work items only cover this range; coarser
+    /// meshlets are reached exclusively via `parent_cluster_id` walks.
+    pub leaf_meshlet_count: u32,
+
     /// Number of virtual objects currently using this mesh.
     pub ref_count: u32,
 }

--- a/crates/helio/src/scene/virtual_geometry/meshes.rs
+++ b/crates/helio/src/scene/virtual_geometry/meshes.rs
@@ -2,8 +2,9 @@
 //!
 //! Handles meshletization, LOD generation, and virtual mesh lifecycle.
 
-use crate::handles::MeshId;
-use crate::mesh::MeshUpload;
+use glam::Vec3;
+use libhelio::GpuMeshletVertex;
+
 use crate::vg::{
     generate_lod_meshes, meshletize_with_indices, GeneratedLodMesh, VirtualMeshId,
     VirtualMeshUpload,
@@ -53,67 +54,127 @@ impl super::super::Scene {
     pub fn insert_virtual_mesh(&mut self, upload: VirtualMeshUpload) -> VirtualMeshId {
         let local_bounds = referenced_bounds(&upload.vertices, &upload.indices).unwrap_or([0.0; 4]);
 
-        // Generate the asset's distinct LOD chain via meshopt simplification.
         let lod_meshes = generate_lod_meshes(&upload.vertices, &upload.indices);
 
         let mut all_meshlets: Vec<libhelio::GpuMeshletEntry> = Vec::new();
-        let mut mesh_ids: Vec<MeshId> = Vec::new();
-        let mut lod_errors = [0.0; libhelio::VG_LOD_LEVELS];
-        let mut lod_first_meshlets = [0; libhelio::VG_LOD_LEVELS];
-        let mut lod_meshlet_counts = [0; libhelio::VG_LOD_LEVELS];
-        let mut max_meshlet_count = 0;
+        let mut all_meshlet_vertices: Vec<GpuMeshletVertex> = Vec::new();
+        let mut all_meshlet_indices: Vec<u16> = Vec::new();
+        // Per-LOD meshlet counts (needed for parent-link building).
+        let mut lod_meshlet_counts: Vec<u32> = Vec::new();
 
-        for (lod_level, lod_mesh) in lod_meshes.into_iter().enumerate() {
+        // Collect per-LOD errors from the simplification chain.
+        let mut lod_errors: Vec<f32> = Vec::new();
+
+        for lod_mesh in lod_meshes.into_iter() {
             let GeneratedLodMesh {
                 vertices: lod_verts,
                 indices: lod_indices,
                 error,
             } = lod_mesh;
-            let first_meshlet = u32::try_from(all_meshlets.len())
-                .expect("virtual mesh exceeds the u32 descriptor address space");
-            // Build meshlets with meshoptimizer — this produces a reordered
-            // index buffer that groups spatially coherent triangles.
-            let (mut meshlets, meshlet_indices) =
-                meshletize_with_indices(&lod_verts, &lod_indices, 0, 0);
 
-            // Upload the vertices + meshlet-reordered indices to the mega-buffer.
-            let mesh_id = self.mesh_pool.insert(MeshUpload {
-                vertices: lod_verts,
-                indices: meshlet_indices,
-            });
-            let slice = self.mesh_pool.get(mesh_id).unwrap().slice;
+            let vertex_base = all_meshlet_vertices.len() as u32;
+            let index_base = all_meshlet_indices.len() as u32;
 
+            let (mut meshlets, meshlet_verts, meshlet_idxs) =
+                meshletize_with_indices(&lod_verts, &lod_indices);
+
+            // Adjust offsets from per-LOD-local to per-mesh-global.
+            // lod_error is filled below — we need the NEXT coarser level's error.
             for m in &mut meshlets {
-                m.first_index += slice.first_index;
-                m.vertex_offset += slice.first_vertex as i32;
-                m.lod_error = error;
+                m.meshlet_vertex_offset += vertex_base;
+                m.meshlet_index_offset += index_base;
+                // parent_cluster_id filled in post-processing below.
             }
 
             let meshlet_count = u32::try_from(meshlets.len())
                 .expect("virtual-mesh LOD exceeds the u32 descriptor address space");
-            lod_errors[lod_level] = error;
-            lod_first_meshlets[lod_level] = first_meshlet;
-            lod_meshlet_counts[lod_level] = meshlet_count;
-            max_meshlet_count = max_meshlet_count.max(meshlet_count);
+            lod_errors.push(error);
+            lod_meshlet_counts.push(meshlet_count);
             all_meshlets.extend(meshlets);
-            mesh_ids.push(mesh_id);
+            all_meshlet_vertices.extend(meshlet_verts);
+            all_meshlet_indices.extend(meshlet_idxs);
         }
 
-        let lod_count = u32::try_from(mesh_ids.len()).expect("LOD count must fit in u32");
+        // ── Fix up lod_error ──────────────────────────────────────────────────
+        // Each meshlet carries the CUMULATIVE simplification error of its own
+        // LOD level vs the original mesh.  The DAG traversal starts at the
+        // root (coarsest, largest error) and walks toward finer levels:
+        // if error <= threshold → good enough, emit this level.
+        let lod_count = u32::try_from(lod_meshlet_counts.len()).expect("LOD count must fit in u32");
+        let mut meshlet_cursor = 0usize;
+        for level in 0..lod_count as usize {
+            let count = lod_meshlet_counts[level] as usize;
+            let cumulative_error = lod_errors[level];
+            for m in &mut all_meshlets[meshlet_cursor..meshlet_cursor + count] {
+                m.lod_error = cumulative_error;
+            }
+            meshlet_cursor += count;
+        }
+
+        // ── Build flat DAG parent links ──────────────────────────────────────
+        // For each LOD level `l` (child, finer), find the overlapping meshlet
+        // in LOD `l+1` (parent, coarser).  Use bounding-sphere overlap:
+        // a child belongs to the parent whose center the child's center is
+        // closest to, provided their spheres overlap.
+        //
+        // The coarsest LOD meshlets have no parent (u32::MAX).
+        for level in 0..lod_count.saturating_sub(1) as usize {
+            let child_start = lod_meshlet_counts[..level].iter().copied().sum::<u32>() as usize;
+            let child_count = lod_meshlet_counts[level] as usize;
+            let parent_start = child_start + child_count;
+            let parent_count = lod_meshlet_counts[level + 1] as usize;
+
+            for ci in child_start..child_start + child_count {
+                let child = &all_meshlets[ci];
+                let c_center = Vec3::from_array(child.center);
+                let c_radius = child.radius;
+
+                let mut best_parent = u32::MAX;
+                let mut best_dist = f32::MAX;
+
+                for pi in parent_start..parent_start + parent_count {
+                    let parent = &all_meshlets[pi];
+                    let p_center = Vec3::from_array(parent.center);
+                    let p_radius = parent.radius;
+
+                    let dist = c_center.distance(p_center);
+                    if dist <= c_radius + p_radius + 1e-6 && dist < best_dist {
+                        best_parent = pi as u32;
+                        best_dist = dist;
+                    }
+                }
+
+                // If no parent overlaps, find the closest parent by center distance.
+                if best_parent == u32::MAX {
+                    for pi in parent_start..parent_start + parent_count {
+                        let parent = &all_meshlets[pi];
+                        let p_center = Vec3::from_array(parent.center);
+                        let dist = c_center.distance(p_center);
+                        if dist < best_dist {
+                            best_parent = pi as u32;
+                            best_dist = dist;
+                        }
+                    }
+                }
+
+                all_meshlets[ci].parent_cluster_id = best_parent;
+            }
+        }
+
+        let total_meshlet_count = u32::try_from(all_meshlets.len())
+            .expect("virtual mesh exceeds the u32 descriptor address space");
 
         let id = VirtualMeshId(self.vg_next_mesh_id);
         self.vg_next_mesh_id += 1;
         self.vg_meshes.insert(
             id,
             VirtualMeshRecord {
-                mesh_ids,
                 meshlets: all_meshlets,
+                meshlet_vertices: all_meshlet_vertices,
+                meshlet_indices: all_meshlet_indices,
                 local_bounds,
                 lod_count,
-                lod_errors,
-                lod_first_meshlets,
-                lod_meshlet_counts,
-                max_meshlet_count,
+                total_meshlet_count,
                 ref_count: 0,
             },
         );
@@ -121,8 +182,6 @@ impl super::super::Scene {
     }
 
     /// Remove a virtual mesh.
-    ///
-    /// Also removes all underlying mesh data from the mesh pool for each LOD level.
     ///
     /// # Parameters
     /// - `id`: Virtual mesh handle
@@ -133,17 +192,6 @@ impl super::super::Scene {
     ///
     /// # Returns
     /// `Ok(())` if the mesh was successfully removed.
-    ///
-    /// # Example
-    /// ```ignore
-    /// // Remove all virtual objects using this mesh first
-    /// for obj_id in vg_objects_using_mesh {
-    ///     scene.remove_virtual_object(obj_id)?;
-    /// }
-    ///
-    /// // Now the mesh can be removed
-    /// scene.remove_virtual_mesh(vg_mesh_id)?;
-    /// ```
     pub fn remove_virtual_mesh(&mut self, id: VirtualMeshId) -> Result<()> {
         let ref_count = {
             let record = self
@@ -157,13 +205,7 @@ impl super::super::Scene {
                 resource: "virtual_mesh",
             });
         }
-        if let Some(record) = self.vg_meshes.remove(&id) {
-            for mesh_id in record.mesh_ids {
-                // Ignore the return value to avoid altering observable behavior if
-                // `remove_mesh` returns a Result or other value.
-                let _ = self.remove_mesh(mesh_id);
-            }
-        }
+        self.vg_meshes.remove(&id);
         Ok(())
     }
 }

--- a/crates/helio/src/scene/virtual_geometry/meshes.rs
+++ b/crates/helio/src/scene/virtual_geometry/meshes.rs
@@ -163,6 +163,9 @@ impl super::super::Scene {
 
         let total_meshlet_count = u32::try_from(all_meshlets.len())
             .expect("virtual mesh exceeds the u32 descriptor address space");
+        // Finest LOD meshlets are stored first and are the only DAG entry points.
+        // Single-LOD meshes treat every meshlet as a leaf (all are roots).
+        let leaf_meshlet_count = lod_meshlet_counts.first().copied().unwrap_or(0);
 
         let id = VirtualMeshId(self.vg_next_mesh_id);
         self.vg_next_mesh_id += 1;
@@ -175,6 +178,7 @@ impl super::super::Scene {
                 local_bounds,
                 lod_count,
                 total_meshlet_count,
+                leaf_meshlet_count,
                 ref_count: 0,
             },
         );

--- a/crates/helio/src/scene/virtual_geometry/objects.rs
+++ b/crates/helio/src/scene/virtual_geometry/objects.rs
@@ -72,18 +72,13 @@ impl super::super::Scene {
             .vg_meshes
             .get_mut(&desc.virtual_mesh)
             .ok_or_else(|| invalid("virtual_mesh"))?;
-        let mesh_id = record
-            .mesh_ids
-            .first()
-            .copied()
-            .ok_or_else(|| invalid("virtual_mesh_geometry"))?;
         record.ref_count += 1;
 
         let instance = GpuInstanceData {
             model: desc.transform.to_cols_array(),
             normal_mat: normal_matrix(desc.transform),
             bounds: desc.bounds,
-            mesh_id: mesh_id.slot(),
+            mesh_id: 0, // VG instances use meshlet vertex stream, not the mesh pool
             material_id: desc.material_id,
             flags: desc.flags,
             lightmap_index: 0xFFFFFFFF,  // Virtual geometry doesn't use lightmaps

--- a/crates/helio/src/scene/virtual_geometry/rebuild.rs
+++ b/crates/helio/src/scene/virtual_geometry/rebuild.rs
@@ -7,8 +7,8 @@
 use std::collections::HashMap;
 
 use libhelio::{
-    GpuMeshletEntry, GpuVgObject, GpuVgWorkItem, VgFrameData,
-    VG_CULL_MESHLETS_PER_WORK_ITEM, VG_LOD_LEVELS,
+    GpuMeshletEntry, GpuMeshletVertex, GpuVgObject, GpuVgWorkItem, VgFrameData,
+    VG_CULL_MESHLETS_PER_WORK_ITEM,
 };
 
 use crate::vg::VirtualMeshId;
@@ -18,7 +18,9 @@ use super::super::types::VirtualMeshRecord;
 fn append_unique_meshlets(
     referenced_meshes: impl IntoIterator<Item = VirtualMeshId>,
     mesh_records: &HashMap<VirtualMeshId, VirtualMeshRecord>,
-    output: &mut Vec<GpuMeshletEntry>,
+    output_meshlets: &mut Vec<GpuMeshletEntry>,
+    output_vertices: &mut Vec<GpuMeshletVertex>,
+    output_indices: &mut Vec<u16>,
 ) -> HashMap<VirtualMeshId, u32> {
     let mut bases = HashMap::new();
 
@@ -33,10 +35,36 @@ fn append_unique_meshlets(
             continue;
         }
 
-        let base = u32::try_from(output.len())
+        let meshlet_base = u32::try_from(output_meshlets.len())
             .expect("virtual geometry exceeds the u32 descriptor address space");
-        output.extend_from_slice(&record.meshlets);
-        bases.insert(mesh_id, base);
+        let vertex_base = u32::try_from(output_vertices.len())
+            .expect("virtual geometry vertex stream exceeds u32");
+        let index_base = u32::try_from(output_indices.len())
+            .expect("virtual geometry index stream exceeds u32");
+
+        // Fix up meshlet offsets from record-local to global.
+        for m in &record.meshlets {
+            let mut fixed = *m;
+            fixed.meshlet_vertex_offset = fixed
+                .meshlet_vertex_offset
+                .checked_add(vertex_base)
+                .expect("meshlet_vertex_offset overflow during global fixup");
+            fixed.meshlet_index_offset = fixed
+                .meshlet_index_offset
+                .checked_add(index_base)
+                .expect("meshlet_index_offset overflow during global fixup");
+            if fixed.parent_cluster_id != u32::MAX {
+                fixed.parent_cluster_id = meshlet_base
+                    .checked_add(fixed.parent_cluster_id)
+                    .expect("parent_cluster_id overflow during global offset fixup");
+            }
+            output_meshlets.push(fixed);
+        }
+
+        output_vertices.extend_from_slice(&record.meshlet_vertices);
+        output_indices.extend_from_slice(&record.meshlet_indices);
+
+        bases.insert(mesh_id, meshlet_base);
     }
 
     bases
@@ -44,11 +72,11 @@ fn append_unique_meshlets(
 
 fn append_work_items(
     object_index: u32,
-    max_meshlet_count: u32,
+    total_meshlet_count: u32,
     output: &mut Vec<GpuVgWorkItem>,
 ) {
     for local_meshlet_base in
-        (0..max_meshlet_count).step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
+        (0..total_meshlet_count).step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
     {
         output.push(GpuVgWorkItem {
             object_index,
@@ -56,7 +84,6 @@ fn append_work_items(
         });
     }
 }
-
 impl super::super::Scene {
     /// Returns the immutable mesh descriptors, object-level LOD metadata, and
     /// instance data consumed by the virtual-geometry pass.
@@ -66,16 +93,21 @@ impl super::super::Scene {
         }
         Some(VgFrameData {
             meshlets: bytemuck::cast_slice(&self.vg_cpu_meshlets),
+            meshlet_vertices: bytemuck::cast_slice(&self.vg_cpu_meshlet_vertices),
+            meshlet_indices: bytemuck::cast_slice(&self.vg_cpu_meshlet_indices),
             objects: bytemuck::cast_slice(&self.vg_cpu_objects),
             instances: bytemuck::cast_slice(&self.vg_cpu_instances),
             work_items: bytemuck::cast_slice(&self.vg_cpu_work_items),
             meshlet_count: u32::try_from(self.vg_cpu_meshlets.len())
                 .expect("virtual geometry exceeds the u32 descriptor address space"),
+            meshlet_vertex_count: u32::try_from(self.vg_cpu_meshlet_vertices.len())
+                .expect("virtual geometry vertex count exceeds u32"),
+            meshlet_index_count: u32::try_from(self.vg_cpu_meshlet_indices.len())
+                .expect("virtual geometry index count exceeds u32"),
             object_count: u32::try_from(self.vg_cpu_objects.len())
                 .expect("virtual geometry exceeds the u32 object address space"),
             work_item_count: u32::try_from(self.vg_cpu_work_items.len())
                 .expect("virtual geometry exceeds the u32 work-item address space"),
-            max_draw_count: self.vg_max_draw_count,
             buffer_version: self.vg_buffer_version,
             instance_version: self.vg_instance_version,
             instance_dirty_start: self
@@ -93,17 +125,18 @@ impl super::super::Scene {
     ///
     /// Each referenced virtual mesh contributes its descriptors exactly once,
     /// regardless of instance count. Each object then points at the shared
-    /// per-LOD ranges. `vg_max_draw_count` is the exact worst case after one LOD
-    /// is selected for every object, and therefore bounds every atomic append.
+    /// per-LOD ranges. The indirect buffer grows dynamically on demand based on
+    /// the total unique meshlet count, removing the fixed `max_draw_count` ceiling.
     pub(in crate::scene) fn rebuild_vg_buffers(&mut self) {
         let dense_object_count = self.vg_objects.dense_len();
         self.vg_cpu_meshlets.clear();
+        self.vg_cpu_meshlet_vertices.clear();
+        self.vg_cpu_meshlet_indices.clear();
         self.vg_cpu_objects.clear();
         self.vg_cpu_instances.clear();
         self.vg_cpu_work_items.clear();
         self.vg_instance_dirty_range = None;
         self.vg_published_instance_dirty_range = None;
-        self.vg_max_draw_count = 0;
         self.vg_cpu_objects.reserve(dense_object_count);
         self.vg_cpu_instances.reserve(dense_object_count);
 
@@ -115,6 +148,8 @@ impl super::super::Scene {
             referenced_meshes,
             &self.vg_meshes,
             &mut self.vg_cpu_meshlets,
+            &mut self.vg_cpu_meshlet_vertices,
+            &mut self.vg_cpu_meshlet_indices,
         );
 
         for dense_index in 0..dense_object_count {
@@ -132,42 +167,30 @@ impl super::super::Scene {
                 .expect("virtual geometry exceeds the u32 instance address space");
             let object_index = u32::try_from(self.vg_cpu_objects.len())
                 .expect("virtual geometry exceeds the u32 object address space");
-            let mut lod_first_meshlets = [0; VG_LOD_LEVELS];
-            for (level, first) in lod_first_meshlets.iter_mut().enumerate() {
-                *first = mesh_base
-                    .checked_add(mesh.lod_first_meshlets[level])
-                    .expect("virtual geometry descriptor offset overflow");
-            }
 
             self.vg_cpu_instances.push(object.instance);
             self.vg_cpu_objects.push(GpuVgObject {
                 instance_index,
-                lod_count: mesh.lod_count,
-                max_meshlet_count: mesh.max_meshlet_count,
+                meshlet_count: mesh.total_meshlet_count,
+                first_meshlet: mesh_base,
                 reserved: 0,
                 local_bounds: mesh.local_bounds,
-                lod_errors: mesh.lod_errors,
-                lod_first_meshlets,
-                lod_meshlet_counts: mesh.lod_meshlet_counts,
             });
             append_work_items(
                 object_index,
-                mesh.max_meshlet_count,
+                mesh.total_meshlet_count,
                 &mut self.vg_cpu_work_items,
             );
-            self.vg_max_draw_count = self
-                .vg_max_draw_count
-                .checked_add(mesh.max_meshlet_count)
-                .expect("virtual geometry indirect draw capacity exceeds u32");
         }
 
         self.vg_buffer_version = self.vg_buffer_version.wrapping_add(1);
         eprintln!(
-            "[vg] rebuild: {} objects, {} unique meshlets, {} work spans, {} max draws",
+            "[vg] rebuild: {} objects, {} unique meshlets, {} work spans, {} meshlet verts, {} meshlet idxs",
             self.vg_cpu_objects.len(),
             self.vg_cpu_meshlets.len(),
             self.vg_cpu_work_items.len(),
-            self.vg_max_draw_count,
+            self.vg_cpu_meshlet_vertices.len(),
+            self.vg_cpu_meshlet_indices.len(),
         );
     }
 }
@@ -176,11 +199,11 @@ impl super::super::Scene {
 mod tests {
     use std::collections::HashMap;
 
-    use libhelio::{GpuMeshletEntry, VG_LOD_LEVELS};
+    use libhelio::{GpuMeshletEntry, GpuMeshletVertex};
 
     use super::{append_unique_meshlets, append_work_items, VirtualMeshId, VirtualMeshRecord};
 
-    fn meshlet(first_index: u32) -> GpuMeshletEntry {
+    fn meshlet(meshlet_vertex_offset: u32, meshlet_index_offset: u32) -> GpuMeshletEntry {
         GpuMeshletEntry {
             center: [0.0; 3],
             radius: 1.0,
@@ -188,24 +211,39 @@ mod tests {
             cone_cutoff: 2.0,
             cone_axis: [0.0, 1.0, 0.0],
             lod_error: 0.0,
-            first_index,
-            index_count: 3,
-            vertex_offset: 0,
-            instance_index: 0,
+            packed_counts: 3 | (1 << 16), // vertex_count=3, triangle_count=1
+            meshlet_index_offset,
+            meshlet_vertex_offset,
+            parent_cluster_id: u32::MAX,
         }
     }
 
-    fn record(meshlets: Vec<GpuMeshletEntry>) -> VirtualMeshRecord {
+    fn record(
+        meshlets: Vec<GpuMeshletEntry>,
+        vertices: Vec<GpuMeshletVertex>,
+        indices: Vec<u16>,
+    ) -> VirtualMeshRecord {
+        let count = meshlets.len() as u32;
         VirtualMeshRecord {
-            mesh_ids: Vec::new(),
             meshlets,
+            meshlet_vertices: vertices,
+            meshlet_indices: indices,
             local_bounds: [0.0, 0.0, 0.0, 1.0],
             lod_count: 1,
-            lod_errors: [0.0; VG_LOD_LEVELS],
-            lod_first_meshlets: [0; VG_LOD_LEVELS],
-            lod_meshlet_counts: [1; VG_LOD_LEVELS],
-            max_meshlet_count: 1,
+            total_meshlet_count: count,
             ref_count: 0,
+        }
+    }
+
+    fn dummy_vertex() -> GpuMeshletVertex {
+        GpuMeshletVertex {
+            position: [0.0; 3],
+            bitangent_sign: 1.0,
+            tex_coords0: [0.0; 2],
+            tex_coords1: [0.0; 2],
+            normal: 0,
+            tangent: 0,
+            _pad: [0; 2],
         }
     }
 
@@ -213,22 +251,44 @@ mod tests {
     fn repeated_instances_share_one_descriptor_copy() {
         let first = VirtualMeshId(3);
         let second = VirtualMeshId(7);
+        // Record `first` has 2 meshlets, each with 3 vertices → 6 verts, 6 idxs
+        let verts_a = vec![
+            dummy_vertex(), dummy_vertex(), dummy_vertex(),
+            dummy_vertex(), dummy_vertex(), dummy_vertex(),
+        ];
+        let idxs_a = vec![0u16, 1, 2, 3, 4, 5];
+        // Record `second` has 1 meshlet with 1 vertex → 1 vert, 3 idxs
+        let verts_b = vec![dummy_vertex()];
+        let idxs_b = vec![0u16, 0, 0];
         let records = HashMap::from([
-            (first, record(vec![meshlet(11), meshlet(12)])),
-            (second, record(vec![meshlet(20)])),
+            (first, record(vec![meshlet(0, 0), meshlet(3, 3)], verts_a, idxs_a)),
+            (second, record(vec![meshlet(0, 0)], verts_b, idxs_b)),
         ]);
-        let mut output = Vec::new();
+        let mut output_meshlets = Vec::new();
+        let mut output_vertices = Vec::new();
+        let mut output_indices = Vec::new();
 
         let bases = append_unique_meshlets(
             [first, first, second, first, second],
             &records,
-            &mut output,
+            &mut output_meshlets,
+            &mut output_vertices,
+            &mut output_indices,
         );
 
-        assert_eq!(output.len(), 3);
+        assert_eq!(output_meshlets.len(), 3);
         assert_eq!(bases[&first], 0);
         assert_eq!(bases[&second], 2);
-        assert_eq!(output.iter().map(|entry| entry.first_index).collect::<Vec<_>>(), [11, 12, 20]);
+        // First meshlet of `first` — vertex offset stays 0
+        assert_eq!(output_meshlets[0].meshlet_vertex_offset, 0);
+        // Second meshlet of `first` — vertex offset 3
+        assert_eq!(output_meshlets[1].meshlet_vertex_offset, 3);
+        // Meshlet of `second` — combined vertex offset = 6 (3+3)
+        assert_eq!(output_meshlets[2].meshlet_vertex_offset, 6);
+        // Vertex stream: 6+1 = 7 vertices
+        assert_eq!(output_vertices.len(), 7);
+        // Index stream: 6+3 = 9 indices
+        assert_eq!(output_indices.len(), 9);
     }
 
     #[test]

--- a/crates/helio/src/scene/virtual_geometry/rebuild.rs
+++ b/crates/helio/src/scene/virtual_geometry/rebuild.rs
@@ -70,13 +70,18 @@ fn append_unique_meshlets(
     bases
 }
 
+/// Emit work items covering only DAG leaves (finest LOD meshlets).
+///
+/// Coarser meshlets must not start their own traversal — they are selected
+/// exclusively when a leaf walks up the parent chain. Processing all LODs as
+/// entry points causes duplicate emits and wrong LOD mixes.
 fn append_work_items(
     object_index: u32,
-    total_meshlet_count: u32,
+    leaf_meshlet_count: u32,
     output: &mut Vec<GpuVgWorkItem>,
 ) {
     for local_meshlet_base in
-        (0..total_meshlet_count).step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
+        (0..leaf_meshlet_count).step_by(VG_CULL_MESHLETS_PER_WORK_ITEM as usize)
     {
         output.push(GpuVgWorkItem {
             object_index,
@@ -108,6 +113,11 @@ impl super::super::Scene {
                 .expect("virtual geometry exceeds the u32 object address space"),
             work_item_count: u32::try_from(self.vg_cpu_work_items.len())
                 .expect("virtual geometry exceeds the u32 work-item address space"),
+            emit_flag_count: self
+                .vg_cpu_objects
+                .last()
+                .map(|o| o.emit_flag_base.saturating_add(o.total_meshlet_count))
+                .unwrap_or(0),
             buffer_version: self.vg_buffer_version,
             instance_version: self.vg_instance_version,
             instance_dirty_start: self
@@ -152,6 +162,7 @@ impl super::super::Scene {
             &mut self.vg_cpu_meshlet_indices,
         );
 
+        let mut emit_flag_base = 0u32;
         for dense_index in 0..dense_object_count {
             let Some(object) = self.vg_objects.get_dense(dense_index) else {
                 continue;
@@ -169,16 +180,27 @@ impl super::super::Scene {
                 .expect("virtual geometry exceeds the u32 object address space");
 
             self.vg_cpu_instances.push(object.instance);
+            // Leaves-only entry: work items cover leaf_meshlet_count. Coarser
+            // meshlets live after the leaf range and are reached via parent walks.
+            // emit_flag_base gives each object a private claim slice so instances
+            // sharing meshlet descriptors still draw independently.
             self.vg_cpu_objects.push(GpuVgObject {
                 instance_index,
-                meshlet_count: mesh.total_meshlet_count,
+                leaf_meshlet_count: mesh.leaf_meshlet_count,
                 first_meshlet: mesh_base,
-                reserved: 0,
+                total_meshlet_count: mesh.total_meshlet_count,
                 local_bounds: mesh.local_bounds,
+                emit_flag_base,
+                visible: 0,
+                _pad0: 0,
+                _pad1: 0,
             });
+            emit_flag_base = emit_flag_base
+                .checked_add(mesh.total_meshlet_count)
+                .expect("emit flag base overflow");
             append_work_items(
                 object_index,
-                mesh.total_meshlet_count,
+                mesh.leaf_meshlet_count,
                 &mut self.vg_cpu_work_items,
             );
         }
@@ -231,6 +253,7 @@ mod tests {
             local_bounds: [0.0, 0.0, 0.0, 1.0],
             lod_count: 1,
             total_meshlet_count: count,
+            leaf_meshlet_count: count,
             ref_count: 0,
         }
     }
@@ -316,5 +339,97 @@ mod tests {
                 (13, 128),
             ]
         );
+    }
+
+    #[test]
+    fn work_items_cover_only_leaf_count_not_total_meshlets() {
+        // Multi-LOD mesh: 100 leaves + 50 coarser = 150 total. Work items must
+        // only span the 100 leaves so coarser clusters are not cull entry points.
+        let mut output = Vec::new();
+        let leaf_count = 100u32;
+        append_work_items(0, leaf_count, &mut output);
+        let covered: u32 = output
+            .iter()
+            .map(|item| {
+                let remaining = leaf_count.saturating_sub(item.local_meshlet_base);
+                remaining.min(libhelio::VG_CULL_MESHLETS_PER_WORK_ITEM)
+            })
+            .sum();
+        assert_eq!(covered, leaf_count);
+        assert!(
+            output
+                .iter()
+                .all(|item| item.local_meshlet_base < leaf_count)
+        );
+        // Must NOT generate bases into the coarser range (100..150).
+        assert!(output.iter().all(|item| item.local_meshlet_base < 100));
+    }
+
+    #[test]
+    fn parent_cluster_id_global_fixup_maps_into_valid_range() {
+        // Two meshes each with a child→parent pair (record-local parents 1 and 0).
+        let mut child_a = meshlet(0, 0);
+        child_a.parent_cluster_id = 1; // local parent index within record
+        let mut parent_a = meshlet(3, 3);
+        parent_a.parent_cluster_id = u32::MAX;
+
+        let mut child_b = meshlet(0, 0);
+        child_b.parent_cluster_id = 1;
+        let mut parent_b = meshlet(3, 3);
+        parent_b.parent_cluster_id = u32::MAX;
+
+        let first = VirtualMeshId(1);
+        let second = VirtualMeshId(2);
+        let verts = vec![
+            dummy_vertex(),
+            dummy_vertex(),
+            dummy_vertex(),
+            dummy_vertex(),
+            dummy_vertex(),
+            dummy_vertex(),
+        ];
+        let idxs = vec![0u16, 1, 2, 3, 4, 5];
+        let records = HashMap::from([
+            (
+                first,
+                record(vec![child_a, parent_a], verts.clone(), idxs.clone()),
+            ),
+            (second, record(vec![child_b, parent_b], verts, idxs)),
+        ]);
+
+        let mut out_m = Vec::new();
+        let mut out_v = Vec::new();
+        let mut out_i = Vec::new();
+        let bases = append_unique_meshlets(
+            [first, second],
+            &records,
+            &mut out_m,
+            &mut out_v,
+            &mut out_i,
+        );
+
+        assert_eq!(out_m.len(), 4);
+        let base_a = bases[&first];
+        let base_b = bases[&second];
+        assert_eq!(base_a, 0);
+        assert_eq!(base_b, 2);
+
+        // Child of mesh A: local parent 1 → global 0+1 = 1
+        assert_eq!(out_m[0].parent_cluster_id, 1);
+        assert_eq!(out_m[1].parent_cluster_id, u32::MAX);
+        // Child of mesh B: local parent 1 → global 2+1 = 3
+        assert_eq!(out_m[2].parent_cluster_id, 3);
+        assert_eq!(out_m[3].parent_cluster_id, u32::MAX);
+
+        for m in &out_m {
+            if m.parent_cluster_id != u32::MAX {
+                assert!(
+                    (m.parent_cluster_id as usize) < out_m.len(),
+                    "parent {} out of global range 0..{}",
+                    m.parent_cluster_id,
+                    out_m.len()
+                );
+            }
+        }
     }
 }

--- a/crates/helio/src/vg.rs
+++ b/crates/helio/src/vg.rs
@@ -671,30 +671,370 @@ mod tests {
     }
 
     /// Simulate the GPU DAG traversal (coarse→fine) with the given lod_error
-    /// values and camera distance.  Returns the LOD level that would be emitted
-    /// (higher = coarser).
+    /// values and camera distance.  Returns the index into `ancestor_errors`
+    /// (0 = finest / leaf, last = coarsest / root).
     fn dag_traverse(
-        ancestor_errors: &[f32],   // finest → root
+        ancestor_errors: &[f32], // finest → root
         max_scale: f32,
         focal_pixels: f32,
         distance: f32,
         threshold: f32,
     ) -> usize {
-        // Walk UP to root: already have the chain.
-        // Walk DOWN from root toward finest:
         let mut i = ancestor_errors.len();
         loop {
-            if i == 0 { break; }
+            if i == 0 {
+                break;
+            }
             i -= 1;
             let lod_error = ancestor_errors[i];
             let closest_distance = distance.max(1.0e-4);
             let projected = lod_error * max_scale * focal_pixels / closest_distance;
             if projected <= threshold || i == 0 {
-                return i; // emit at this LOD
+                return i;
             }
-            // error > threshold → need finer → continue
         }
         0
+    }
+
+    /// CPU mirror of GPU leaves-only DAG cull + global emit-flag dedup.
+    ///
+    /// Only meshlets in `0..leaf_count` start traversal. Each selected meshlet
+    /// is claimed at most once (simulating atomicExchange on emit flags).
+    fn simulate_leaves_only_cull(
+        meshlets: &[GpuMeshletEntry],
+        leaf_count: usize,
+        max_scale: f32,
+        focal_pixels: f32,
+        distance: f32,
+        threshold: f32,
+    ) -> Vec<u32> {
+        let mut claimed = vec![false; meshlets.len()];
+        let mut emits = Vec::new();
+
+        for leaf in 0..leaf_count.min(meshlets.len()) {
+            // Walk up to root.
+            let mut stack = Vec::new();
+            let mut cur = leaf;
+            loop {
+                stack.push(cur);
+                let parent = meshlets[cur].parent_cluster_id;
+                if parent == u32::MAX || stack.len() >= 8 {
+                    break;
+                }
+                let p = parent as usize;
+                if p >= meshlets.len() {
+                    break;
+                }
+                cur = p;
+            }
+            // Walk down from root; pick coarsest good-enough level.
+            let mut i = stack.len();
+            let mut selected = None;
+            while i > 0 {
+                i -= 1;
+                let idx = stack[i];
+                let error = meshlets[idx].lod_error;
+                let projected = error * max_scale * focal_pixels / distance.max(1e-4);
+                if projected <= threshold || i == 0 {
+                    selected = Some(idx as u32);
+                    break;
+                }
+            }
+            if let Some(idx) = selected {
+                let slot = idx as usize;
+                if slot < claimed.len() && !claimed[slot] {
+                    claimed[slot] = true;
+                    emits.push(idx);
+                }
+            }
+        }
+        emits
+    }
+
+    /// Build a multi-LOD meshlet DAG matching `meshes.rs` (for unit tests).
+    fn build_test_dag(
+        vertices: &[PackedVertex],
+        indices: &[u32],
+    ) -> (Vec<GpuMeshletEntry>, usize, Vec<u32>) {
+        let lods = generate_lod_meshes(vertices, indices);
+        let mut all_meshlets = Vec::new();
+        let mut lod_meshlet_counts = Vec::new();
+
+        for lod in &lods {
+            let (mut meshlets, _, _) = meshletize_with_indices(&lod.vertices, &lod.indices);
+            for m in &mut meshlets {
+                m.lod_error = lod.error;
+            }
+            lod_meshlet_counts.push(meshlets.len() as u32);
+            all_meshlets.extend(meshlets);
+        }
+
+        let lod_count = lod_meshlet_counts.len();
+        let mut child_start = 0usize;
+        for level in 0..lod_count.saturating_sub(1) {
+            let child_count = lod_meshlet_counts[level] as usize;
+            let parent_start = child_start + child_count;
+            let parent_count = lod_meshlet_counts[level + 1] as usize;
+
+            for ci in child_start..child_start + child_count {
+                let c_center = glam::Vec3::from_array(all_meshlets[ci].center);
+                let c_radius = all_meshlets[ci].radius;
+                let mut best = u32::MAX;
+                let mut best_d = f32::MAX;
+                for pi in parent_start..parent_start + parent_count {
+                    let p_center = glam::Vec3::from_array(all_meshlets[pi].center);
+                    let p_radius = all_meshlets[pi].radius;
+                    let d = c_center.distance(p_center);
+                    if d <= c_radius + p_radius + 1e-6 && d < best_d {
+                        best = pi as u32;
+                        best_d = d;
+                    }
+                }
+                if best == u32::MAX {
+                    for pi in parent_start..parent_start + parent_count {
+                        let p_center = glam::Vec3::from_array(all_meshlets[pi].center);
+                        let d = c_center.distance(p_center);
+                        if d < best_d {
+                            best = pi as u32;
+                            best_d = d;
+                        }
+                    }
+                }
+                all_meshlets[ci].parent_cluster_id = best;
+            }
+            child_start += child_count;
+        }
+        if let Some(&root_count) = lod_meshlet_counts.last() {
+            let root_start = all_meshlets.len() - root_count as usize;
+            for m in &mut all_meshlets[root_start..] {
+                m.parent_cluster_id = u32::MAX;
+            }
+        }
+
+        let leaf_count = lod_meshlet_counts.first().copied().unwrap_or(0) as usize;
+        (all_meshlets, leaf_count, lod_meshlet_counts)
+    }
+
+    #[test]
+    fn dag_parent_links_point_only_to_coarser_lods_and_roots_are_max() {
+        let (vertices, indices) = make_grid(20);
+        let (meshlets, leaf_count, lod_counts) = build_test_dag(&vertices, &indices);
+        assert!(lod_counts.len() >= 2, "need multi-LOD for parent link test");
+        assert!(leaf_count > 0);
+
+        let total = meshlets.len();
+        // Prefix sums of LOD ranges.
+        let mut starts = vec![0usize; lod_counts.len()];
+        for i in 1..lod_counts.len() {
+            starts[i] = starts[i - 1] + lod_counts[i - 1] as usize;
+        }
+
+        for (li, &count) in lod_counts.iter().enumerate() {
+            let start = starts[li];
+            let end = start + count as usize;
+            let is_coarsest = li + 1 == lod_counts.len();
+            for idx in start..end {
+                let parent = meshlets[idx].parent_cluster_id;
+                if is_coarsest {
+                    assert_eq!(
+                        parent,
+                        u32::MAX,
+                        "root meshlet {idx} must have parent 0xFFFFFFFF"
+                    );
+                } else {
+                    assert_ne!(parent, u32::MAX, "non-root meshlet {idx} needs a parent");
+                    let p = parent as usize;
+                    assert!(p < total, "parent {p} out of range for meshlet {idx}");
+                    // Parent must be in a strictly coarser LOD range.
+                    let parent_lod = starts
+                        .iter()
+                        .enumerate()
+                        .find(|&(j, &s)| {
+                            let e = s + lod_counts[j] as usize;
+                            p >= s && p < e
+                        })
+                        .map(|(j, _)| j)
+                        .expect("parent in some LOD");
+                    assert!(
+                        parent_lod > li,
+                        "parent of LOD{li} meshlet {idx} must be coarser, got LOD{parent_lod}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn dag_lod_error_zero_at_finest_and_non_decreasing_along_parent_chain() {
+        let (vertices, indices) = make_grid(20);
+        let (meshlets, leaf_count, _) = build_test_dag(&vertices, &indices);
+        assert!(leaf_count > 0);
+
+        for leaf in 0..leaf_count {
+            assert_eq!(
+                meshlets[leaf].lod_error, 0.0,
+                "finest LOD meshlet {leaf} must have lod_error == 0"
+            );
+            let mut cur = leaf;
+            let mut prev_error = meshlets[cur].lod_error;
+            let mut steps = 0;
+            loop {
+                let parent = meshlets[cur].parent_cluster_id;
+                if parent == u32::MAX || steps > 8 {
+                    break;
+                }
+                let p = parent as usize;
+                assert!(p < meshlets.len());
+                let err = meshlets[p].lod_error;
+                assert!(
+                    err.is_finite() && err >= prev_error - 1e-6,
+                    "lod_error must be non-decreasing along parent chain: {prev_error} -> {err}"
+                );
+                // Coarser levels of a simplified mesh should carry positive error.
+                if steps == 0 && meshlets.len() > leaf_count {
+                    // At least one step up from a multi-LOD leaf should raise error
+                    // unless simplification measured zero (degenerate); allow >=.
+                }
+                prev_error = err;
+                cur = p;
+                steps += 1;
+            }
+        }
+    }
+
+    #[test]
+    fn dag_parent_links_have_no_cycles() {
+        let (vertices, indices) = make_grid(18);
+        let (meshlets, _, _) = build_test_dag(&vertices, &indices);
+        let n = meshlets.len();
+        for start in 0..n {
+            let mut cur = start;
+            let mut seen = std::collections::HashSet::new();
+            for _ in 0..16 {
+                assert!(
+                    seen.insert(cur),
+                    "cycle detected in parent chain starting at {start}"
+                );
+                let parent = meshlets[cur].parent_cluster_id;
+                if parent == u32::MAX {
+                    break;
+                }
+                let p = parent as usize;
+                assert!(p < n, "parent out of range");
+                cur = p;
+            }
+        }
+    }
+
+    #[test]
+    fn leaves_only_unique_emits_at_most_leaf_count_and_fewer_when_far() {
+        let (vertices, indices) = make_grid(24);
+        let (meshlets, leaf_count, lod_counts) = build_test_dag(&vertices, &indices);
+        assert!(lod_counts.len() >= 2);
+        assert!(leaf_count > 0);
+
+        let focal = 540.0_f32;
+        let threshold = 2.0_f32;
+
+        let near = simulate_leaves_only_cull(&meshlets, leaf_count, 1.0, focal, 1.0, threshold);
+        let far = simulate_leaves_only_cull(&meshlets, leaf_count, 1.0, focal, 800.0, threshold);
+
+        // Unique by construction of the claim set.
+        assert_eq!(near.len(), near.iter().collect::<std::collections::HashSet<_>>().len());
+        assert_eq!(far.len(), far.iter().collect::<std::collections::HashSet<_>>().len());
+
+        assert!(
+            near.len() <= leaf_count,
+            "unique emits {} must be ≤ leaf count {leaf_count}",
+            near.len()
+        );
+        assert!(
+            far.len() <= leaf_count,
+            "unique emits {} must be ≤ leaf count {leaf_count}",
+            far.len()
+        );
+        assert!(
+            far.len() < leaf_count,
+            "at far distance unique emits {} should be << leaves {leaf_count}",
+            far.len()
+        );
+        assert!(
+            far.len() < near.len(),
+            "far ({}) should emit fewer clusters than near ({})",
+            far.len(),
+            near.len()
+        );
+    }
+
+    #[test]
+    fn two_leaves_sharing_parent_produce_one_emit_when_parent_selected() {
+        // Synthetic DAG: leaves 0,1 → parent 2 (root).
+        let mut meshlets = vec![
+            GpuMeshletEntry {
+                center: [0.0, 0.0, 0.0],
+                radius: 1.0,
+                cone_apex: [0.0; 3],
+                cone_cutoff: 2.0,
+                cone_axis: [0.0, 0.0, 1.0],
+                lod_error: 0.0,
+                packed_counts: 3 | (1 << 16),
+                meshlet_index_offset: 0,
+                meshlet_vertex_offset: 0,
+                parent_cluster_id: 2,
+            },
+            GpuMeshletEntry {
+                center: [0.5, 0.0, 0.0],
+                radius: 1.0,
+                cone_apex: [0.0; 3],
+                cone_cutoff: 2.0,
+                cone_axis: [0.0, 0.0, 1.0],
+                lod_error: 0.0,
+                packed_counts: 3 | (1 << 16),
+                meshlet_index_offset: 0,
+                meshlet_vertex_offset: 0,
+                parent_cluster_id: 2,
+            },
+            GpuMeshletEntry {
+                center: [0.25, 0.0, 0.0],
+                radius: 2.0,
+                cone_apex: [0.0; 3],
+                cone_cutoff: 2.0,
+                cone_axis: [0.0, 0.0, 1.0],
+                lod_error: 1.0, // large error → selected when far enough / threshold loose
+                packed_counts: 3 | (1 << 16),
+                meshlet_index_offset: 0,
+                meshlet_vertex_offset: 0,
+                parent_cluster_id: u32::MAX,
+            },
+        ];
+        // projected = 1.0 * 1.0 * 1000 / dist. At dist=1000, projected=1.0 <= threshold 1.0 → parent.
+        let emits = simulate_leaves_only_cull(&meshlets, 2, 1.0, 1000.0, 1000.0, 1.0);
+        assert_eq!(emits, vec![2], "both leaves must collapse to a single parent emit");
+
+        // Near: projected parent error huge → emit leaves (two unique).
+        meshlets[2].lod_error = 10.0;
+        let near = simulate_leaves_only_cull(&meshlets, 2, 1.0, 1000.0, 10.0, 1.0);
+        // projected parent = 10*1000/10 = 1000 > 1 → need finer → leaves
+        let mut near_sorted = near.clone();
+        near_sorted.sort();
+        assert_eq!(near_sorted, vec![0, 1]);
+    }
+
+    #[test]
+    fn projected_error_lod_selection_coarse_far_fine_near() {
+        // ancestor_errors: finest → root
+        let chain = [0.0, 0.01, 0.04, 0.16];
+        let focal = 1000.0;
+        let thr = 1.0;
+
+        // Near: only finest (error 0) is acceptable once coarser exceeds thr.
+        assert_eq!(dag_traverse(&chain, 1.0, focal, 5.0, thr), 0);
+        // Mid: can accept level 1 (0.01*1000/100 = 0.1 <= 1)
+        assert_eq!(dag_traverse(&chain, 1.0, focal, 100.0, thr), 2);
+        // Far: coarsest root
+        assert_eq!(dag_traverse(&chain, 1.0, focal, 10_000.0, thr), 3);
+        // Non-uniform scale increases projected error → finer selection
+        assert_eq!(dag_traverse(&chain, 4.0, focal, 100.0, thr), 1);
     }
 
     #[test]
@@ -810,69 +1150,49 @@ mod tests {
                 level, level + 1, fan_in);
         }
 
-        // ── Simulate full workgroup traversal at various distances ──────────
+        // ── Leaves-only + global claim simulation at various distances ─────
+        let leaf_count = lod_meshlet_counts[0] as usize;
         let focal_pixels = 540.0;
         let threshold_px = 0.5;
         let max_scale = 1.0;
 
-        eprintln!("\n  Full simulation (workgroup-level, detect duplicates):");
+        eprintln!("\n  Leaves-only + claim simulation:");
         let distances: [f32; 9] = [0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0];
         for &dist in &distances {
-            let mut emit_counts = std::collections::HashMap::new();
+            let emits = simulate_leaves_only_cull(
+                &all_meshlets,
+                leaf_count,
+                max_scale,
+                focal_pixels,
+                dist,
+                threshold_px,
+            );
             let mut lod_emit_counts = vec![0u32; lod_count];
-
-            for lane in 0..total {
-                // Walk UP to root (same as GPU shader)
-                let mut stack: Vec<usize> = Vec::new();
-                let mut cur = lane;
-                loop {
-                    stack.push(cur);
-                    let m = &all_meshlets[cur];
-                    if m.parent_cluster_id == u32::MAX || stack.len() >= 8 { break; }
-                    cur = m.parent_cluster_id as usize;
-                }
-                // Walk DOWN from root
-                let mut i = stack.len();
-                loop {
-                    if i == 0 { break; }
-                    i -= 1;
-                    let idx = stack[i];
-                    let error = all_meshlets[idx].lod_error;
-                    let projected = error * max_scale * focal_pixels / dist.max(1e-4);
-                    if projected <= threshold_px || i == 0 {
-                        *emit_counts.entry(idx).or_insert(0) += 1;
-                        // Determine which LOD level this meshlet belongs to
-                        let mut cursor = 0usize;
-                        for li in 0..lod_count {
-                            let cnt = lod_meshlet_counts[li] as usize;
-                            if idx >= cursor && idx < cursor + cnt {
-                                lod_emit_counts[li] += 1;
-                                break;
-                            }
-                            cursor += cnt;
-                        }
+            for &idx in &emits {
+                let mut cursor = 0usize;
+                for li in 0..lod_count {
+                    let cnt = lod_meshlet_counts[li] as usize;
+                    if (idx as usize) >= cursor && (idx as usize) < cursor + cnt {
+                        lod_emit_counts[li] += 1;
                         break;
                     }
+                    cursor += cnt;
                 }
             }
-
-            let unique = emit_counts.len();
-            let total_emits: u32 = emit_counts.values().sum();
-            let duplicates = total_emits - unique as u32;
-            eprintln!("    dist={dist:>6.1}: total={total_emits:>4} emits, {unique:>3} unique, {duplicates} dup");
+            let unique = emits.len();
+            eprintln!("    dist={dist:>6.1}: {unique:>3} unique emits (≤ {leaf_count} leaves)");
             eprintln!("              per-LOD: {:?}", &lod_emit_counts);
 
-            // Validate: at close distance, most emits should be LOD 0
+            assert!(unique <= leaf_count);
             if dist <= 1.0 {
                 assert!(lod_emit_counts[0] > 0, "At dist={dist}, LOD 0 should have emits");
-                // No duplicates at close range (each fine meshlet is unique)
-                assert!(duplicates <= (total_emits as f32 * 0.3) as u32,
-                    "At dist={dist}, too many duplicates ({duplicates}/{total_emits})");
             }
-            // Validate: at far distance, most emits should be coarser LODs
             if dist >= 500.0 {
-                let coarse_emits: u32 = lod_emit_counts[2..].iter().sum();
-                assert!(coarse_emits > 0, "At dist={dist}, coarse LODs should have emits");
+                let coarse_emits: u32 = lod_emit_counts[1..].iter().sum();
+                assert!(
+                    coarse_emits > 0 || unique < leaf_count,
+                    "At dist={dist}, should select coarser LODs or fewer clusters"
+                );
             }
         }
     }

--- a/crates/helio/src/vg.rs
+++ b/crates/helio/src/vg.rs
@@ -7,7 +7,7 @@
 
 use std::mem;
 
-use libhelio::{GpuMeshletEntry, MESHLET_MAX_TRIANGLES};
+use libhelio::{GpuMeshletEntry, GpuMeshletVertex, MESHLET_MAX_TRIANGLES};
 use meshopt::DecodePosition;
 
 use crate::mesh::PackedVertex;
@@ -309,16 +309,19 @@ fn compact_mesh(vertices: &[PackedVertex], indices: &[u32]) -> (Vec<PackedVertex
 
 // ─── Meshlet building via meshopt ─────────────────────────────────────────
 
-/// Build meshlets using meshoptimizer and return the reordered index buffer.
+/// Build meshlets using meshoptimizer and return per-meshlet vertex/index streams.
 ///
-/// Returns `(meshlet_entries, flat_index_buffer)` — the flat indices are the
-/// meshlet-grouped index data ready for upload to the mega-buffer.
+/// Returns `(meshlet_entries, meshlet_vertices, meshlet_indices)` where:
+/// - `meshlet_vertices` is a flat array of `GpuMeshletVertex` (all meshlets' unique vertices)
+/// - `meshlet_indices` is a flat array of `u16` (all meshlets' local triangle indices)
+///
+/// Each meshlet entry's `meshlet_vertex_offset` and `meshlet_index_offset` are
+/// set relative to the start of these returned arrays. Callers that concatenate
+/// multiple calls must adjust these offsets accordingly.
 pub fn meshletize_with_indices(
     vertices: &[PackedVertex],
     indices: &[u32],
-    mesh_first_index: u32,
-    mesh_first_vertex: u32,
-) -> (Vec<GpuMeshletEntry>, Vec<u32>) {
+) -> (Vec<GpuMeshletEntry>, Vec<GpuMeshletVertex>, Vec<u16>) {
     let tri_count = indices.len() / 3;
     if tri_count == 0
         || vertices.is_empty()
@@ -327,7 +330,7 @@ pub fn meshletize_with_indices(
             .iter()
             .any(|&index| index as usize >= vertices.len())
     {
-        return (Vec::new(), Vec::new());
+        return (Vec::new(), Vec::new(), Vec::new());
     }
 
     let max_verts = 64usize;
@@ -349,18 +352,44 @@ pub fn meshletize_with_indices(
     );
 
     let mut entries = Vec::with_capacity(meshlets.len());
-    let mut flat_indices: Vec<u32> = Vec::new();
+    let mut all_vertices: Vec<GpuMeshletVertex> = Vec::new();
+    let mut all_indices: Vec<u16> = Vec::new();
 
     for i in 0..meshlets.len() {
         let m = meshlets.get(i);
-        let first_index_offset = flat_indices.len() as u32;
 
-        let mut meshlet_global_indices: Vec<u32> = Vec::with_capacity(m.triangles.len());
-        for &local_tri_idx in m.triangles {
-            let vertex_slot = m.vertices[local_tri_idx as usize];
-            meshlet_global_indices.push(vertex_slot);
-            flat_indices.push(vertex_slot);
+        let vertex_offset = all_vertices.len() as u32;
+        let index_offset = all_indices.len() as u32;
+        let vertex_count = m.vertices.len() as u32;
+
+        // Extract meshlet-unique vertices from the input vertex array.
+        for &local_idx in m.vertices {
+            let src = &vertices[local_idx as usize];
+            all_vertices.push(GpuMeshletVertex {
+                position: src.position,
+                bitangent_sign: src.bitangent_sign,
+                tex_coords0: src.tex_coords0,
+                tex_coords1: src.tex_coords1,
+                normal: src.normal,
+                tangent: src.tangent,
+                _pad: [0; 2],
+            });
         }
+
+        // Build meshlet-local u16 triangle indices.
+        for &local_tri_idx in m.triangles {
+            all_indices.push(local_tri_idx as u16);
+        }
+
+        let triangle_count = (m.triangles.len() / 3) as u32;
+        let packed_counts = vertex_count | (triangle_count << 16);
+
+        // Compute bounds using global vertex indices.
+        let meshlet_global_indices: Vec<u32> = m
+            .triangles
+            .iter()
+            .map(|&local_tri_idx| m.vertices[local_tri_idx as usize])
+            .collect();
 
         let bounds = meshopt::clusterize::compute_cluster_bounds_decoder(
             &meshlet_global_indices,
@@ -374,14 +403,14 @@ pub fn meshletize_with_indices(
             cone_cutoff: bounds.cone_cutoff,
             cone_axis: bounds.cone_axis,
             lod_error: 0.0,
-            first_index: mesh_first_index + first_index_offset,
-            index_count: meshlet_global_indices.len() as u32,
-            vertex_offset: mesh_first_vertex as i32,
-            instance_index: 0,
+            packed_counts,
+            meshlet_index_offset: index_offset,
+            meshlet_vertex_offset: vertex_offset,
+            parent_cluster_id: u32::MAX,
         });
     }
 
-    (entries, flat_indices)
+    (entries, all_vertices, all_indices)
 }
 
 #[cfg(test)]
@@ -462,10 +491,10 @@ mod tests {
         let mut non_finite = vertices.clone();
         non_finite[0].position[0] = f32::NAN;
         assert!(generate_lod_meshes(&non_finite, &[0, 1, 2]).is_empty());
-        assert!(meshletize_with_indices(&vertices, &[0, 1], 0, 0)
+        assert!(meshletize_with_indices(&vertices, &[0, 1])
             .0
             .is_empty());
-        assert!(meshletize_with_indices(&vertices, &[0, 1, 3], 0, 0)
+        assert!(meshletize_with_indices(&vertices, &[0, 1, 3])
             .0
             .is_empty());
     }
@@ -479,22 +508,37 @@ mod tests {
             vertex([0.0, 1.0, 0.0], [0.0, 1.0], [0.0, 0.0, 1.0]),
         ];
         let source = vec![0, 1, 2, 0, 2, 3];
-        let (meshlets, flattened) = meshletize_with_indices(&vertices, &source, 0, 0);
+        let (meshlets, meshlet_verts, meshlet_idxs) =
+            meshletize_with_indices(&vertices, &source);
 
-        assert_eq!(flattened.len(), source.len());
-        let mut flattened_sorted = flattened.clone();
-        let mut source_sorted = source.clone();
-        flattened_sorted.sort_unstable();
-        source_sorted.sort_unstable();
-        assert_eq!(flattened_sorted, source_sorted);
+        // Verify that the vertex stream has at least as many entries as there
+        // are unique vertex references in the source (should be 4 for a quad).
+        assert!(meshlet_verts.len() <= source.len());
 
+        // Verify that every meshlet's index range references valid data.
         for meshlet in &meshlets {
-            let first = meshlet.first_index as usize;
-            let end = first + meshlet.index_count as usize;
-            for &index in &flattened[first..end] {
-                let p = glam::Vec3::from_array(vertices[index as usize].position);
+            let vc = meshlet.packed_counts & 0xFFFF;
+            let tc = meshlet.packed_counts >> 16;
+            assert!(vc >= 3 && vc <= 64);
+            assert!(tc >= 1);
+            let vo = meshlet.meshlet_vertex_offset as usize;
+            let io = meshlet.meshlet_index_offset as usize;
+            let idx_count = tc as usize * 3;
+            // Every local index must reference a valid meshlet vertex.
+            for j in 0..idx_count {
+                let local_idx = meshlet_idxs[io + j] as usize;
+                assert!(local_idx < vc as usize, "local index {local_idx} >= vertex_count {vc}");
+            }
+            // Every vertex must be within the meshlet's bounding sphere.
+            for j in 0..vc as usize {
+                let gpu_v = &meshlet_verts[vo + j];
+                let p = glam::Vec3::from_array(gpu_v.position);
                 let center = glam::Vec3::from_array(meshlet.center);
-                assert!(p.distance(center) <= meshlet.radius + 1e-5);
+                assert!(
+                    p.distance(center) <= meshlet.radius + 1e-5,
+                    "vertex {j} at {p:?} outside sphere center {center:?} radius {}",
+                    meshlet.radius
+                );
             }
         }
     }
@@ -601,5 +645,235 @@ mod tests {
         let lods = generate_lod_meshes(&vertices, &[0, 1, 2]);
         assert_eq!(lods.len(), 1);
         assert_eq!(lods[0].indices.len(), 3);
+    }
+
+    /// Build a grid mesh of `side×side` vertices (yields `(side-1)²` quads).
+    fn make_grid(side: usize) -> (Vec<PackedVertex>, Vec<u32>) {
+        let mut vertices = Vec::with_capacity(side * side);
+        for y in 0..side {
+            for x in 0..side {
+                vertices.push(vertex(
+                    [x as f32, y as f32, ((x * y) % 5) as f32 * 0.05],
+                    [x as f32 / side as f32, y as f32 / side as f32],
+                    [0.0, 0.0, 1.0],
+                ));
+            }
+        }
+        let mut indices = Vec::new();
+        for y in 0..side - 1 {
+            for x in 0..side - 1 {
+                let i = (y * side + x) as u32;
+                indices.extend_from_slice(&[i, i + 1, i + side as u32 + 1]);
+                indices.extend_from_slice(&[i, i + side as u32 + 1, i + side as u32]);
+            }
+        }
+        (vertices, indices)
+    }
+
+    /// Simulate the GPU DAG traversal (coarse→fine) with the given lod_error
+    /// values and camera distance.  Returns the LOD level that would be emitted
+    /// (higher = coarser).
+    fn dag_traverse(
+        ancestor_errors: &[f32],   // finest → root
+        max_scale: f32,
+        focal_pixels: f32,
+        distance: f32,
+        threshold: f32,
+    ) -> usize {
+        // Walk UP to root: already have the chain.
+        // Walk DOWN from root toward finest:
+        let mut i = ancestor_errors.len();
+        loop {
+            if i == 0 { break; }
+            i -= 1;
+            let lod_error = ancestor_errors[i];
+            let closest_distance = distance.max(1.0e-4);
+            let projected = lod_error * max_scale * focal_pixels / closest_distance;
+            if projected <= threshold || i == 0 {
+                return i; // emit at this LOD
+            }
+            // error > threshold → need finer → continue
+        }
+        0
+    }
+
+    #[test]
+    fn dag_traversal_diagnostics() {
+        let side = 24usize;
+        let (vertices, indices) = make_grid(side);
+
+        let lods = generate_lod_meshes(&vertices, &indices);
+        eprintln!("\n=== DAG Diagnostic ===");
+        eprintln!("Grid: {}×{} = {} verts, {} tris",
+            side, side, vertices.len(), indices.len() / 3);
+        eprintln!("LOD count: {}", lods.len());
+
+        // Meshletize each LOD and collect errors.
+        let mut lod_errors: Vec<f32> = Vec::new();
+        let mut lod_meshlet_counts: Vec<u32> = Vec::new();
+        let mut all_meshlets: Vec<GpuMeshletEntry> = Vec::new();
+
+        for (li, lod) in lods.iter().enumerate() {
+            let (mut meshlets, _, _) = meshletize_with_indices(&lod.vertices, &lod.indices);
+            let count = meshlets.len() as u32;
+            lod_errors.push(lod.error);
+            lod_meshlet_counts.push(count);
+            // Assign cumulative error (same as meshes.rs fixup step)
+            for m in &mut meshlets {
+                m.lod_error = lod.error;
+            }
+            eprintln!("  LOD {}: {} tris, {} meshlets, cum_error={:.6}",
+                li, lod.indices.len() / 3, meshlets.len(), lod.error);
+            all_meshlets.extend(meshlets);
+        }
+
+        // ── Build DAG parent links (same algorithm as meshes.rs) ────────────
+        let lod_count = lod_meshlet_counts.len();
+        let mut child_start = 0usize;
+        for level in 0..lod_count.saturating_sub(1) {
+            let child_count = lod_meshlet_counts[level] as usize;
+            let parent_start = child_start + child_count;
+            let parent_count = lod_meshlet_counts[level + 1] as usize;
+
+            for ci in child_start..child_start + child_count {
+                let c_center = glam::Vec3::from_array(all_meshlets[ci].center);
+                let c_radius = all_meshlets[ci].radius;
+                let mut best = u32::MAX;
+                let mut best_d = f32::MAX;
+                for pi in parent_start..parent_start + parent_count {
+                    let p_center = glam::Vec3::from_array(all_meshlets[pi].center);
+                    let p_radius = all_meshlets[pi].radius;
+                    let d = c_center.distance(p_center);
+                    if d <= c_radius + p_radius + 1e-6 && d < best_d {
+                        best = pi as u32;
+                        best_d = d;
+                    }
+                }
+                if best == u32::MAX {
+                    for pi in parent_start..parent_start + parent_count {
+                        let p_center = glam::Vec3::from_array(all_meshlets[pi].center);
+                        let d = c_center.distance(p_center);
+                        if d < best_d {
+                            best = pi as u32;
+                            best_d = d;
+                        }
+                    }
+                }
+                all_meshlets[ci].parent_cluster_id = best;
+            }
+            child_start += child_count;
+        }
+        // Root meshlets get 0xFFFFFFFF (no parent)
+        let root_start: usize = all_meshlets.len() - *lod_meshlet_counts.last().unwrap() as usize;
+        for m in &mut all_meshlets[root_start..] {
+            m.parent_cluster_id = u32::MAX;
+        }
+
+        // ── Validate DAG ────────────────────────────────────────────────────
+        eprintln!("\n  Validating DAG...");
+        let total = all_meshlets.len();
+        let mut visited = vec![false; total];
+        for start in 0..total {
+            let mut cur = start;
+            let mut steps = 0;
+            loop {
+                if visited[cur] { break; }
+                visited[cur] = true;
+                let m = &all_meshlets[cur];
+                if m.parent_cluster_id == u32::MAX || steps > 8 { break; }
+                cur = m.parent_cluster_id as usize;
+                assert!(cur < total, "parent out of bounds: {cur} >= {total}");
+                steps += 1;
+            }
+        }
+        assert!(visited.iter().all(|&v| v), "Some meshlets were not visited");
+
+        // Count unique parent references for each root meshlet
+        eprintln!("\n  Child→parent convergence (fan-in):");
+        for level in 0..lod_count.saturating_sub(1) {
+            let child_count = lod_meshlet_counts[level] as usize;
+            let parent_count = lod_meshlet_counts[level + 1] as usize;
+            let mut fan_in = vec![0u32; parent_count];
+            // Count children that reference each parent
+            child_start = lod_meshlet_counts[..level].iter().copied().sum::<u32>() as usize;
+            for ci in child_start..child_start + child_count {
+                let m = &all_meshlets[ci];
+                if m.parent_cluster_id != u32::MAX {
+                    let pi = m.parent_cluster_id as usize;
+                    let parent_lod_start = lod_meshlet_counts[..level + 1].iter().copied().sum::<u32>() as usize;
+                    if pi >= parent_lod_start && pi < parent_lod_start + parent_count {
+                        fan_in[pi - parent_lod_start] += 1;
+                    }
+                }
+            }
+            eprintln!("    LOD {} → LOD {} children per parent: {:?}",
+                level, level + 1, fan_in);
+        }
+
+        // ── Simulate full workgroup traversal at various distances ──────────
+        let focal_pixels = 540.0;
+        let threshold_px = 0.5;
+        let max_scale = 1.0;
+
+        eprintln!("\n  Full simulation (workgroup-level, detect duplicates):");
+        let distances: [f32; 9] = [0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 250.0, 500.0, 1000.0];
+        for &dist in &distances {
+            let mut emit_counts = std::collections::HashMap::new();
+            let mut lod_emit_counts = vec![0u32; lod_count];
+
+            for lane in 0..total {
+                // Walk UP to root (same as GPU shader)
+                let mut stack: Vec<usize> = Vec::new();
+                let mut cur = lane;
+                loop {
+                    stack.push(cur);
+                    let m = &all_meshlets[cur];
+                    if m.parent_cluster_id == u32::MAX || stack.len() >= 8 { break; }
+                    cur = m.parent_cluster_id as usize;
+                }
+                // Walk DOWN from root
+                let mut i = stack.len();
+                loop {
+                    if i == 0 { break; }
+                    i -= 1;
+                    let idx = stack[i];
+                    let error = all_meshlets[idx].lod_error;
+                    let projected = error * max_scale * focal_pixels / dist.max(1e-4);
+                    if projected <= threshold_px || i == 0 {
+                        *emit_counts.entry(idx).or_insert(0) += 1;
+                        // Determine which LOD level this meshlet belongs to
+                        let mut cursor = 0usize;
+                        for li in 0..lod_count {
+                            let cnt = lod_meshlet_counts[li] as usize;
+                            if idx >= cursor && idx < cursor + cnt {
+                                lod_emit_counts[li] += 1;
+                                break;
+                            }
+                            cursor += cnt;
+                        }
+                        break;
+                    }
+                }
+            }
+
+            let unique = emit_counts.len();
+            let total_emits: u32 = emit_counts.values().sum();
+            let duplicates = total_emits - unique as u32;
+            eprintln!("    dist={dist:>6.1}: total={total_emits:>4} emits, {unique:>3} unique, {duplicates} dup");
+            eprintln!("              per-LOD: {:?}", &lod_emit_counts);
+
+            // Validate: at close distance, most emits should be LOD 0
+            if dist <= 1.0 {
+                assert!(lod_emit_counts[0] > 0, "At dist={dist}, LOD 0 should have emits");
+                // No duplicates at close range (each fine meshlet is unique)
+                assert!(duplicates <= (total_emits as f32 * 0.3) as u32,
+                    "At dist={dist}, too many duplicates ({duplicates}/{total_emits})");
+            }
+            // Validate: at far distance, most emits should be coarser LODs
+            if dist >= 500.0 {
+                let coarse_emits: u32 = lod_emit_counts[2..].iter().sum();
+                assert!(coarse_emits > 0, "At dist={dist}, coarse LODs should have emits");
+            }
+        }
     }
 }

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -548,6 +548,10 @@ impl<'a> FrameResources<'a> {
 pub struct VgFrameData<'a> {
     /// Raw bytes of a `GpuMeshletEntry` array.
     pub meshlets: &'a [u8],
+    /// Raw bytes of a `GpuMeshletVertex` array (flat per-meshlet vertex stream).
+    pub meshlet_vertices: &'a [u8],
+    /// Raw bytes of a `u16` array (flat per-meshlet index stream).
+    pub meshlet_indices: &'a [u8],
     /// Raw bytes of a `GpuVgObject` array (one entry per VG object).
     pub objects: &'a [u8],
     /// Raw bytes of a `GpuInstanceData` array (one entry per VG object).
@@ -556,12 +560,14 @@ pub struct VgFrameData<'a> {
     pub work_items: &'a [u8],
     /// Number of unique meshlet descriptors across all referenced virtual meshes.
     pub meshlet_count: u32,
+    /// Number of `GpuMeshletVertex` elements in the meshlet vertex stream.
+    pub meshlet_vertex_count: u32,
+    /// Number of `u16` index elements in the meshlet index stream.
+    pub meshlet_index_count: u32,
     /// Number of VG objects (and corresponding instance entries).
     pub object_count: u32,
     /// Number of second-stage 64-meshlet work spans.
     pub work_item_count: u32,
-    /// Exact worst-case number of indirect draws after selecting one LOD per object.
-    pub max_draw_count: u32,
     /// Version counter incremented when meshlet, object, or work-item topology changes.
     pub buffer_version: u64,
     /// Version counter incremented when a transform-only dirty range is published.

--- a/crates/libhelio/src/frame.rs
+++ b/crates/libhelio/src/frame.rs
@@ -568,6 +568,9 @@ pub struct VgFrameData<'a> {
     pub object_count: u32,
     /// Number of second-stage 64-meshlet work spans.
     pub work_item_count: u32,
+    /// Total per-object emit-flag slots (`sum` of each object's `total_meshlet_count`).
+    /// Sized so instances sharing meshlet descriptors still get independent claims.
+    pub emit_flag_count: u32,
     /// Version counter incremented when meshlet, object, or work-item topology changes.
     pub buffer_version: u64,
     /// Version counter incremented when a transform-only dirty range is published.

--- a/crates/libhelio/src/meshlet.rs
+++ b/crates/libhelio/src/meshlet.rs
@@ -90,25 +90,41 @@ pub struct GpuMeshletEntry {
     pub parent_cluster_id: u32,
 }
 
-/// GPU-side descriptor for one virtual-geometry object. Exactly 32 bytes.
+/// GPU-side descriptor for one virtual-geometry object. Exactly 48 bytes.
 ///
-/// The flat DAG scheme eliminates per-LOD arrays. A single `meshlet_count`
-/// covers all LODs; the cull shader iterates every meshlet and uses each
-/// meshlet's `parent_cluster_id` and `lod_error` to decide which ones to emit.
+/// The flat DAG scheme eliminates per-LOD arrays. `leaf_meshlet_count` is the
+/// number of **DAG leaves** (finest LOD), stored contiguously starting at
+/// `first_meshlet`. Coarser meshlets follow in the shared meshlet buffer and are
+/// reached only via `parent_cluster_id` walks — they are never cull entry points.
+///
+/// `emit_flag_base` indexes a per-object slice of the frame's emit-flag buffer
+/// so multiple instances sharing the same meshlet descriptors can each claim
+/// draws independently. Local flag index = `meshlet_index - first_meshlet`.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct GpuVgObject {
     /// Slot in the VG `GpuInstanceData` and `InstanceCullData` arrays.
     pub instance_index: u32,
-    /// Total number of meshlets across all LODs for this object.
-    pub meshlet_count: u32,
-    /// Global offset into the flat meshlet buffer for this object's first meshlet.
+    /// Number of finest-LOD (DAG leaf) meshlets for this object.
+    /// Work items and the cull shader only iterate this range.
+    pub leaf_meshlet_count: u32,
+    /// Global offset into the flat meshlet buffer for this object's first leaf.
     pub first_meshlet: u32,
-    /// Reserved for future use.
-    pub reserved: u32,
+    /// Total meshlets across all LODs for this object's mesh (leaf + coarser).
+    /// Bounds the per-object emit-flag slice.
+    pub total_meshlet_count: u32,
 
     /// Conservative mesh-local bounding sphere `[center.xyz, radius]`.
     pub local_bounds: [f32; 4],
+
+    /// Base index into the per-frame `meshlet_emit_flags` buffer for this object.
+    /// Flag slot = `emit_flag_base + (meshlet_index - first_meshlet)`.
+    pub emit_flag_base: u32,
+    /// Per-frame object visibility written by `cs_select_objects`
+    /// (`0` = culled, non-zero = visible).
+    pub visible: u32,
+    pub _pad0: u32,
+    pub _pad1: u32,
 }
 
 /// Per-visible-draw metadata emitted beside each indirect command. Exactly 16 bytes.
@@ -127,9 +143,9 @@ pub struct GpuVgDraw {
 
 /// Work item for the second-stage meshlet cull. Exactly 8 bytes.
 ///
-/// Each record covers up to 64 meshlets across ALL LODs for one object.
-/// The cull shader iterates each meshlet independently and uses the flat DAG
-/// (`parent_cluster_id` + `lod_error`) to decide whether to emit it.
+/// Each record covers up to 64 **DAG leaf** meshlets for one object.
+/// Leaves walk the parent chain (`parent_cluster_id` + `lod_error`) and emit
+/// exactly one selected cluster. Coarser meshlets are never work-item entries.
 /// Using fixed spans keeps work bounded while allowing a very large object
 /// to occupy many GPU workgroups instead of serialising through one.
 #[repr(C)]
@@ -146,11 +162,11 @@ const _: () = {
     );
     assert!(
         std::mem::size_of::<GpuMeshletVertex>() == 48,
-        "GpuMeshletVertex must be exactly 40 bytes"
+        "GpuMeshletVertex must be exactly 48 bytes"
     );
     assert!(
-        std::mem::size_of::<GpuVgObject>() == 32,
-        "GpuVgObject must be exactly 32 bytes"
+        std::mem::size_of::<GpuVgObject>() == 48,
+        "GpuVgObject must be exactly 48 bytes"
     );
     assert!(
         std::mem::size_of::<GpuVgDraw>() == 16,
@@ -174,7 +190,7 @@ mod tests {
         assert_eq!(VG_LOD_LEVELS, 8);
         assert_eq!(std::mem::size_of::<GpuMeshletEntry>(), 64);
         assert_eq!(std::mem::size_of::<GpuMeshletVertex>(), 48);
-        assert_eq!(std::mem::size_of::<GpuVgObject>(), 32);
+        assert_eq!(std::mem::size_of::<GpuVgObject>(), 48);
         assert_eq!(std::mem::size_of::<GpuVgDraw>(), 16);
         assert_eq!(std::mem::size_of::<GpuVgWorkItem>(), 8);
         assert_eq!(std::mem::align_of::<GpuVgObject>(), 4);

--- a/crates/libhelio/src/meshlet.rs
+++ b/crates/libhelio/src/meshlet.rs
@@ -19,24 +19,44 @@ pub const VG_LOD_LEVELS: usize = 8;
 /// Number of meshlets processed cooperatively by one VG cull workgroup.
 pub const VG_CULL_MESHLETS_PER_WORK_ITEM: u32 = 64;
 
+/// Packed per-meshlet vertex format (48 bytes, matches WGSL `array<GpuMeshletVertex>` stride).
+///
+/// WGSL `vec3<f32>` has alignment 16, forcing the struct to round up to 48 bytes.
+/// Two u32 padding fields keep the Rust and WGSL layouts in sync.
+///
+/// Stored in a flat storage buffer (`meshlet_vertices`) indexed by
+/// `SV_VertexID` (= local index + `meshlet_vertex_offset`).
+#[repr(C)]
+#[derive(Debug, Clone, Copy, Pod, Zeroable)]
+pub struct GpuMeshletVertex {
+    pub position: [f32; 3],
+    pub bitangent_sign: f32,
+    pub tex_coords0: [f32; 2],
+    pub tex_coords1: [f32; 2],
+    pub normal: u32,
+    pub tangent: u32,
+    /// Padding to 48 bytes to match WGSL array stride (vec3 alignment = 16).
+    pub _pad: [u32; 2],
+}
+
 /// GPU-side descriptor for a single meshlet (a small cluster of triangles). Exactly 64 bytes.
 ///
-/// Stored once per virtual mesh in a tightly-packed storage buffer. Virtual
-/// objects refer to contiguous per-LOD ranges in this immutable descriptor
-/// array, so instances never duplicate meshlet metadata.
+/// Stored once per virtual mesh in a tightly-packed storage buffer. The flat
+/// DAG replaces per-LOD ranges; each meshlet independently determines its own
+/// LOD via `parent_cluster_id` and `lod_error`.
 ///
-/// # Layout (64 bytes, 16-byte aligned)
+/// # Layout (64 bytes)
 /// ```text
-///  0..12   center:          vec3<f32>  bounding sphere center (mesh local space)
-/// 12..16   radius:          f32        bounding sphere radius
-/// 16..28   cone_apex:       vec3<f32>  backface cone apex (mesh local space)
-/// 28..32   cone_cutoff:     f32        cos(half-angle); > 1.0 = disable cone cull
-/// 32..44   cone_axis:       vec3<f32>  normalised backface cone axis (mesh local)
-/// 44..48   lod_error:       f32        accumulated object-space simplification error
-/// 48..52   first_index:     u32        absolute offset into the global index buffer
-/// 52..56   index_count:     u32        number of indices (triangles × 3, ≤ 64 × 3)
-/// 56..60   vertex_offset:   i32        base_vertex added to every index by the GPU
-/// 60..64   instance_index:  u32        reserved; object ownership is stored separately
+///  0..12   center:             vec3<f32>  bounding sphere center (mesh local space)
+/// 12..16   radius:             f32        bounding sphere radius
+/// 16..28   cone_apex:          vec3<f32>  backface cone apex (mesh local space)
+/// 28..32   cone_cutoff:        f32        cos(half-angle); > 1.0 = disable cone cull
+/// 32..44   cone_axis:          vec3<f32>  normalised backface cone axis (mesh local)
+/// 44..48   lod_error:          f32        accumulated object-space simplification error
+/// 48..52   packed_counts:      u32        lo 16 = vertex_count, hi 16 = triangle_count
+/// 52..56   meshlet_index_offset: u32     offset in u16 elements into meshlet index stream
+/// 56..60   meshlet_vertex_offset: u32    offset in GpuMeshletVertex elements into vertex stream
+/// 60..64   parent_cluster_id:  u32        index of parent (coarser LOD) meshlet, or 0xFFFFFFFF for root
 /// ```
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
@@ -58,47 +78,37 @@ pub struct GpuMeshletEntry {
     /// Accumulated object-space simplification error for this meshlet's LOD.
     pub lod_error: f32,
 
-    /// Absolute byte-index offset into the global index mega-buffer
-    /// (= mesh.first_index + offset_within_mesh).
-    pub first_index: u32,
-    /// Number of indices in this meshlet (= triangles × 3, ≤ `MESHLET_MAX_TRIANGLES × 3`).
-    pub index_count: u32,
-    /// Base vertex added by the GPU to every index value when drawing.
-    /// Equals the mesh's `first_vertex` in the global vertex mega-buffer.
-    pub vertex_offset: i32,
-    /// Reserved for ABI stability. Object ownership is supplied by
-    /// [`GpuVgObject`] so descriptors can be shared by every instance.
-    pub instance_index: u32,
+    /// Packed vertex_count (lo 16 bits) and triangle_count (hi 16 bits).
+    /// vertex_count = packed_counts & 0xFFFF, triangle_count = packed_counts >> 16.
+    pub packed_counts: u32,
+    /// Offset in u16 elements into the flat meshlet index stream (= meshlet_index_stream).
+    pub meshlet_index_offset: u32,
+    /// Offset in GpuMeshletVertex elements into the flat meshlet vertex stream.
+    pub meshlet_vertex_offset: u32,
+    /// Index of the parent (coarser LOD) meshlet in the global flat meshlet buffer.
+    /// `0xFFFFFFFF` indicates a root meshlet (coarsest LOD) with no parent.
+    pub parent_cluster_id: u32,
 }
 
-/// GPU-side descriptor for one virtual-geometry object. Exactly 128 bytes.
+/// GPU-side descriptor for one virtual-geometry object. Exactly 32 bytes.
 ///
-/// The first compute stage assigns one lane to each object for conservative
-/// object culling and a single measured-error LOD decision. The second stage
-/// expands that selected LOD across immutable [`GpuVgWorkItem`] spans.
+/// The flat DAG scheme eliminates per-LOD arrays. A single `meshlet_count`
+/// covers all LODs; the cull shader iterates every meshlet and uses each
+/// meshlet's `parent_cluster_id` and `lod_error` to decide which ones to emit.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct GpuVgObject {
     /// Slot in the VG `GpuInstanceData` and `InstanceCullData` arrays.
     pub instance_index: u32,
-    /// Number of valid entries in the LOD arrays (zero for invalid geometry).
-    pub lod_count: u32,
-    /// Largest meshlet count among the object's LODs. This object's exact
-    /// contribution to the worst-case indirect draw capacity.
-    pub max_meshlet_count: u32,
-    /// Per-frame GPU scratch containing selected LOD + 1; zero means culled.
-    /// CPU publishers must initialize this to zero. The object-selection stage
-    /// overwrites it before any meshlet span reads it.
+    /// Total number of meshlets across all LODs for this object.
+    pub meshlet_count: u32,
+    /// Global offset into the flat meshlet buffer for this object's first meshlet.
+    pub first_meshlet: u32,
+    /// Reserved for future use.
     pub reserved: u32,
 
     /// Conservative mesh-local bounding sphere `[center.xyz, radius]`.
     pub local_bounds: [f32; 4],
-    /// Accumulated object-space simplification error for each LOD.
-    pub lod_errors: [f32; VG_LOD_LEVELS],
-    /// First descriptor in the shared meshlet buffer for each LOD.
-    pub lod_first_meshlets: [u32; VG_LOD_LEVELS],
-    /// Number of descriptors in each LOD range.
-    pub lod_meshlet_counts: [u32; VG_LOD_LEVELS],
 }
 
 /// Per-visible-draw metadata emitted beside each indirect command. Exactly 16 bytes.
@@ -115,12 +125,13 @@ pub struct GpuVgDraw {
     pub reserved: u32,
 }
 
-/// Immutable expansion record for the second-stage meshlet cull. Exactly 8 bytes.
+/// Work item for the second-stage meshlet cull. Exactly 8 bytes.
 ///
-/// Records are built once with the object layout. Each record covers up to 64
-/// meshlets from whichever whole-object LOD the first GPU stage selects. Using
-/// fixed spans keeps work bounded while allowing a very large object to occupy
-/// many GPU workgroups instead of serialising through one workgroup.
+/// Each record covers up to 64 meshlets across ALL LODs for one object.
+/// The cull shader iterates each meshlet independently and uses the flat DAG
+/// (`parent_cluster_id` + `lod_error`) to decide whether to emit it.
+/// Using fixed spans keeps work bounded while allowing a very large object
+/// to occupy many GPU workgroups instead of serialising through one.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]
 pub struct GpuVgWorkItem {
@@ -134,8 +145,12 @@ const _: () = {
         "GpuMeshletEntry must be exactly 64 bytes"
     );
     assert!(
-        std::mem::size_of::<GpuVgObject>() == 128,
-        "GpuVgObject must be exactly 128 bytes"
+        std::mem::size_of::<GpuMeshletVertex>() == 48,
+        "GpuMeshletVertex must be exactly 40 bytes"
+    );
+    assert!(
+        std::mem::size_of::<GpuVgObject>() == 32,
+        "GpuVgObject must be exactly 32 bytes"
     );
     assert!(
         std::mem::size_of::<GpuVgDraw>() == 16,
@@ -150,7 +165,7 @@ const _: () = {
 #[cfg(test)]
 mod tests {
     use super::{
-        GpuMeshletEntry, GpuVgDraw, GpuVgObject, GpuVgWorkItem,
+        GpuMeshletEntry, GpuMeshletVertex, GpuVgDraw, GpuVgObject, GpuVgWorkItem,
         VG_CULL_MESHLETS_PER_WORK_ITEM, VG_LOD_LEVELS,
     };
 
@@ -158,7 +173,8 @@ mod tests {
     fn gpu_virtual_geometry_layouts_are_stable() {
         assert_eq!(VG_LOD_LEVELS, 8);
         assert_eq!(std::mem::size_of::<GpuMeshletEntry>(), 64);
-        assert_eq!(std::mem::size_of::<GpuVgObject>(), 128);
+        assert_eq!(std::mem::size_of::<GpuMeshletVertex>(), 48);
+        assert_eq!(std::mem::size_of::<GpuVgObject>(), 32);
         assert_eq!(std::mem::size_of::<GpuVgDraw>(), 16);
         assert_eq!(std::mem::size_of::<GpuVgWorkItem>(), 8);
         assert_eq!(std::mem::align_of::<GpuVgObject>(), 4);


### PR DESCRIPTION
Overhauls virtual geometry to use a flat meshlet DAG model instead of per-object LOD ranges, including new GPU data layouts (`GpuMeshletEntry`, `GpuMeshletVertex`, compact `GpuVgObject`) and updated scene rebuild/publish flow for meshlet vertex/index streams. Reworks culling and drawing around this model, adds visible-meshlet outputs, and introduces a software-raster pipeline (binning, rasterize, shade compute shaders) alongside a two-pass hardware path (depth-only visibility + equal-depth shading). Also updates GBuffer lightmap-UV targets to RGBA16F and aligns related shaders, pass setup, and debug stats/UI with the new counter/layout behavior.