### PR TITLE
Add an opt-in planetary voxel pass to the external default graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2951,6 +2951,7 @@ dependencies = [
  "helio-pass-occlusion-cull",
  "helio-pass-perf-overlay",
  "helio-pass-planar-reflection",
+ "helio-pass-planetary-voxel",
  "helio-pass-postprocess",
  "helio-pass-radiance-cascades",
  "helio-pass-shadow",
@@ -2968,6 +2969,7 @@ dependencies = [
  "helio-pass-voxel-mesh",
  "helio-pass-water-sim",
  "image",
+ "pollster 0.4.0",
  "wgpu 30.0.0",
 ]
 

--- a/crates/helio-default-graphs/Cargo.toml
+++ b/crates/helio-default-graphs/Cargo.toml
@@ -29,6 +29,7 @@ helio-pass-light-cull = { path = "../passes/3d/helio-pass-light-cull" }
 helio-pass-occlusion-cull = { path = "../passes/3d/helio-pass-occlusion-cull" }
 helio-pass-perf-overlay = { path = "../passes/3d/helio-pass-perf-overlay" }
 helio-pass-planar-reflection = { path = "../passes/3d/helio-pass-planar-reflection" }
+helio-pass-planetary-voxel = { path = "../passes/3d/helio-pass-planetary-voxel" }
 helio-pass-postprocess = { path = "../passes/3d/helio-pass-postprocess" }
 helio-pass-shadow = { path = "../passes/3d/helio-pass-shadow" }
 helio-pass-shadow-cull = { path = "../passes/3d/helio-pass-shadow-cull" }
@@ -46,3 +47,6 @@ helio-pass-virtual-geometry = { path = "../passes/3d/helio-pass-virtual-geometry
 helio-pass-water-sim = { path = "../passes/3d/helio-pass-water-sim" }
 helio-pass-voxel-mesh = { path = "../passes/3d/helio-pass-voxel-mesh" }
 helio-pass-dof = { path = "../passes/3d/helio-pass-dof" }
+
+[dev-dependencies]
+pollster = { workspace = true }

--- a/crates/helio-default-graphs/src/lib.rs
+++ b/crates/helio-default-graphs/src/lib.rs
@@ -25,6 +25,9 @@ use helio_pass_perf_overlay::{
 };
 use helio_pass_planar_reflection::PlanarReflectionPass;
 use helio_pass_dof::DofPass;
+use helio_pass_planetary_voxel::{
+    PlanetaryRenderError, PlanetaryVoxelRenderConfig, PlanetaryVoxelRenderPass,
+};
 use helio_pass_postprocess::{PostProcessPass, PostProcessVolumeBlendPass};
 use helio_pass_radiance_cascades::RadianceCascadesPass;
 use helio_pass_shadow::ShadowPass;
@@ -392,7 +395,9 @@ pub fn build_default_graph(
         true,
         debug_overlay,
         None,
+        None,
     )
+    .expect("the default graph has no fallible optional pass")
 }
 
 pub fn build_default_graph_with_user_effects(
@@ -417,7 +422,9 @@ pub fn build_default_graph_with_user_effects(
         true,
         debug_overlay,
         Some(user_effects),
+        None,
     )
+    .expect("the default graph has no fallible optional pass")
 }
 
 pub fn build_default_graph_external(
@@ -441,6 +448,42 @@ pub fn build_default_graph_external(
         false,
         debug_overlay,
         None,
+        None,
+    )
+    .expect("the default graph has no fallible optional pass")
+}
+
+/// Build the externally-owned default graph with one graph-owned planetary
+/// voxel pass composited after deferred lighting.
+///
+/// This is additive: existing default-graph builders never allocate the
+/// planetary cache. The bounded configuration is retained by the graph
+/// rebuilder, so a renderer resize recreates the same pass and callers can
+/// rediscover it through [`helio::Renderer::find_pass_mut`].
+#[allow(clippy::too_many_arguments)]
+pub fn build_default_graph_external_with_planetary_voxels(
+    device: &Arc<wgpu::Device>,
+    queue: &Arc<wgpu::Queue>,
+    scene: &Scene,
+    config: RendererConfig,
+    debug_state: Arc<std::sync::Mutex<DebugDrawState>>,
+    debug_camera_buf: &wgpu::Buffer,
+    cull_stats_buf: &wgpu::Buffer,
+    debug_overlay: Option<&Arc<std::sync::Mutex<DebugOverlayState>>>,
+    planetary_config: PlanetaryVoxelRenderConfig,
+) -> Result<RenderGraph, PlanetaryRenderError> {
+    build_default_graph_internal(
+        device,
+        queue,
+        scene,
+        config,
+        debug_state,
+        debug_camera_buf,
+        cull_stats_buf,
+        false,
+        debug_overlay,
+        None,
+        Some(planetary_config),
     )
 }
 
@@ -455,7 +498,8 @@ fn build_default_graph_internal(
     owns_device: bool,
     debug_overlay: Option<&Arc<std::sync::Mutex<DebugOverlayState>>>,
     user_effects: Option<&'static str>,
-) -> RenderGraph {
+    planetary_config: Option<PlanetaryVoxelRenderConfig>,
+) -> Result<RenderGraph, PlanetaryRenderError> {
     let iw = config.internal_width();
     let ih = config.internal_height();
 
@@ -524,6 +568,18 @@ fn build_default_graph_internal(
     graph.add_pass(Box::new(deferred_light_pass));
     graph.add_pass(Box::new(PerfOverlayCostAnalyzerPass::new(perf.clone())));
     graph.add_pass(Box::new(PerfOverlayAnalyzerPass::new(perf.clone())));
+
+    // Planetary terrain owns an independent bounded cache but composes into
+    // the same pre-AA color/depth targets as other post-lighting geometry.
+    // Keep it opt-in so existing applications pay no allocation or pass cost.
+    if let Some(planetary_config) = planetary_config {
+        graph.add_pass(Box::new(PlanetaryVoxelRenderPass::new_composited(
+            device,
+            queue,
+            config.surface_format,
+            planetary_config,
+        )?));
+    }
 
     // Voxel mesh pass — real triangles with depth testing, composited over
     // deferred lighting. When no voxel volumes are present the pass is a no-op
@@ -629,12 +685,14 @@ fn build_default_graph_internal(
                 owns_device,
                 overlay_owned.as_ref(),
                 effect_snippet,
+                planetary_config,
             )
+            .expect("a previously validated planetary graph configuration must rebuild")
         },
     );
     graph.set_graph_data(rebuilder);
 
-    graph
+    Ok(graph)
 }
 
 pub fn build_fxaa_graph(

--- a/crates/helio-default-graphs/tests/planetary_extension.rs
+++ b/crates/helio-default-graphs/tests/planetary_extension.rs
@@ -1,0 +1,167 @@
+use std::sync::{Arc, Mutex};
+
+use helio::{
+    required_experimental_features, required_wgpu_features, required_wgpu_limits,
+    DebugCameraUniform, DebugDrawState, GraphRebuilder, RendererConfig, Scene,
+};
+use helio_default_graphs::{
+    build_default_graph_external, build_default_graph_external_with_planetary_voxels,
+};
+use helio_pass_deferred_light::DeferredLightPass;
+use helio_pass_planetary_voxel::{
+    PlanetaryVoxelGpuConfig, PlanetaryVoxelRenderConfig, PlanetaryVoxelRenderPass,
+    TransvoxelGpuExtractorConfig, TransvoxelGpuTransitionExtractorConfig,
+};
+use helio_pass_voxel_mesh::VoxelMeshPass;
+
+#[test]
+fn planetary_extension_is_opt_in_ordered_and_preserved_by_rebuild() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: planetary default graph extension");
+            return;
+        };
+        let features = required_wgpu_features(adapter.features());
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Planetary Default Graph Extension Device"),
+                required_features: features,
+                required_limits: required_wgpu_limits(adapter.limits()),
+                experimental_features: required_experimental_features(adapter.features()),
+                ..Default::default()
+            })
+            .await
+            .expect("Helio-compatible adapter must create a device");
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let scene = Scene::new(Arc::clone(&device), Arc::clone(&queue));
+        let config = RendererConfig::new(32, 32, wgpu::TextureFormat::Rgba8UnormSrgb);
+        let debug_state = Arc::new(Mutex::new(DebugDrawState::default()));
+        let debug_camera = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Extension Debug Camera"),
+            size: core::mem::size_of::<DebugCameraUniform>() as u64,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let cull_stats = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Planetary Extension Cull Stats"),
+            size: 32,
+            usage: wgpu::BufferUsages::STORAGE
+                | wgpu::BufferUsages::COPY_SRC
+                | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        let default_graph = build_default_graph_external(
+            &device,
+            &queue,
+            &scene,
+            config,
+            Arc::clone(&debug_state),
+            &debug_camera,
+            &cull_stats,
+            None,
+        );
+        assert!(default_graph
+            .find_pass::<PlanetaryVoxelRenderPass>()
+            .is_none());
+        let default_dependency_result = default_graph.validate_dependencies();
+
+        let planetary_config = test_planetary_config();
+        let mut graph = build_default_graph_external_with_planetary_voxels(
+            &device,
+            &queue,
+            &scene,
+            config,
+            Arc::clone(&debug_state),
+            &debug_camera,
+            &cull_stats,
+            None,
+            planetary_config,
+        )
+        .expect("bounded planetary graph configuration must build");
+        assert_planetary_pass_contract(&graph, planetary_config, &default_dependency_result);
+
+        let rebuilder = graph
+            .take_graph_data::<GraphRebuilder>()
+            .expect("default graph carries its resize rebuilder");
+        let rebuilt = rebuilder(
+            &device,
+            &queue,
+            &scene,
+            RendererConfig::new(48, 24, config.surface_format),
+            debug_state,
+            &debug_camera,
+            &cull_stats,
+        );
+        assert_planetary_pass_contract(&rebuilt, planetary_config, &default_dependency_result);
+    });
+}
+
+fn assert_planetary_pass_contract(
+    graph: &helio_core::RenderGraph,
+    expected_config: PlanetaryVoxelRenderConfig,
+    expected_dependency_result: &Result<(), String>,
+) {
+    assert_same_dependency_result(&graph.validate_dependencies(), expected_dependency_result);
+    let deferred = graph
+        .pass_index_of::<DeferredLightPass>()
+        .expect("default graph contains deferred lighting");
+    let planetary = graph
+        .pass_index_of::<PlanetaryVoxelRenderPass>()
+        .expect("opt-in graph contains the planetary pass");
+    let voxel = graph
+        .pass_index_of::<VoxelMeshPass>()
+        .expect("default graph contains the retained voxel mesh pass");
+    assert!(deferred < planetary && planetary < voxel);
+    assert_eq!(
+        graph
+            .find_pass::<PlanetaryVoxelRenderPass>()
+            .expect("planetary pass remains discoverable")
+            .config(),
+        expected_config
+    );
+}
+
+fn assert_same_dependency_result(actual: &Result<(), String>, expected: &Result<(), String>) {
+    match (actual, expected) {
+        (Ok(()), Ok(())) => {}
+        (Err(actual), Err(expected)) => assert_eq!(
+            actual.split("Available:").next(),
+            expected.split("Available:").next(),
+            "the opt-in pass must not change the first dependency-validation failure"
+        ),
+        _ => panic!("the opt-in pass must not add a dependency-validation regression"),
+    }
+}
+
+fn test_planetary_config() -> PlanetaryVoxelRenderConfig {
+    PlanetaryVoxelRenderConfig {
+        residency: PlanetaryVoxelGpuConfig::new(2, 8, 8, 2, 4, 2)
+            .expect("test residency configuration is valid"),
+        max_pending_surfaces: 2,
+        regular: TransvoxelGpuExtractorConfig::new(1_024, 2_048)
+            .expect("test regular extraction configuration is valid"),
+        transition: TransvoxelGpuTransitionExtractorConfig::new(512, 1_536)
+            .expect("test transition extraction configuration is valid"),
+        max_surface_bytes: 16 * 1024 * 1024,
+    }
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}

--- a/crates/helio-default-graphs/tests/planetary_extension.rs
+++ b/crates/helio-default-graphs/tests/planetary_extension.rs
@@ -138,8 +138,9 @@ fn assert_same_dependency_result(actual: &Result<(), String>, expected: &Result<
 
 fn test_planetary_config() -> PlanetaryVoxelRenderConfig {
     PlanetaryVoxelRenderConfig {
-        residency: PlanetaryVoxelGpuConfig::new(2, 8, 8, 2, 4, 2)
+        residency: PlanetaryVoxelGpuConfig::new(2, 8, 8, 2, 4)
             .expect("test residency configuration is valid"),
+        max_surface_pages: 2,
         max_pending_surfaces: 2,
         regular: TransvoxelGpuExtractorConfig::new(1_024, 2_048)
             .expect("test regular extraction configuration is valid"),

--- a/crates/passes/3d/helio-pass-planetary-voxel/src/lib.rs
+++ b/crates/passes/3d/helio-pass-planetary-voxel/src/lib.rs
@@ -1,9 +1,8 @@
 //! Bounded GPU residency for the production planetary voxel path.
 //!
-//! This crate is opt-in and is not registered in Helio's default graph. The
-//! current milestone owns only shared page buffers, lookup tables, update
-//! ordering, lifecycle rebuilds, and validation. Surface extraction and draws
-//! are deliberately separate promotion gates.
+//! This crate is opt-in and is never registered by Helio's existing default
+//! graph builders. The dedicated planetary external-graph builder may attach
+//! one composited pass when a caller explicitly supplies a bounded config.
 
 mod config;
 mod extraction;

--- a/crates/passes/3d/helio-pass-planetary-voxel/src/render.rs
+++ b/crates/passes/3d/helio-pass-planetary-voxel/src/render.rs
@@ -676,6 +676,10 @@ fn drain_invalidated_surface_requests(
 }
 
 impl PlanetaryVoxelRenderPass {
+    pub const fn config(&self) -> PlanetaryVoxelRenderConfig {
+        self.config
+    }
+
     pub fn new(
         device: &wgpu::Device,
         queue: &wgpu::Queue,


### PR DESCRIPTION
## Summary

- add a dedicated external default-graph builder that attaches exactly one graph-owned `PlanetaryVoxelRenderPass`
- keep every existing default-graph builder unchanged and allocation-free for planetary terrain
- place planetary compositing after deferred lighting and before the retained voxel-mesh pass
- retain the bounded planetary configuration in the resize rebuilder and expose the pass configuration for integration audits
- add a real headless-WGPU regression covering opt-in behavior, ordering, pass discovery, configuration, and resize rebuilds
- update the regression to the current bounded surface-cache API from Helio #183

## Why

Pulsar currently cannot feed its canonical terrain stream into the actual Helio render graph. The rendering adapter owns a separate residency cache, while the graph owns no planetary pass. This additive API establishes one graph-owned cache without changing existing callers or making planetary resources part of the normal default graph.

Closes #180
Supports #168

## Validation

Validated after rebasing onto current `main` (`98576014`):

- `cargo test -p helio-default-graphs --test planetary_extension --locked -- --nocapture` - 1 passed (real headless WGPU)
- `cargo test -p helio-pass-planetary-voxel --lib --locked -- --nocapture` - 71 passed
- `cargo clippy -p helio-pass-planetary-voxel -p helio-default-graphs --all-targets --no-deps --locked -- -D warnings -A clippy::too_many_arguments`
- `cargo check -p examples --bin voxel_demo --bin voxel_demo_raymarch --bin planet_voxel_demo --locked --message-format short`
- `rustfmt --check --edition 2021 crates/helio-default-graphs/tests/planetary_extension.rs`
- `git diff --check`

The default-graph crate has established `too_many_arguments` APIs, so that lint remains explicitly allowed while every other strict lint is denied. Repository-wide formatting still reports pre-existing current-main drift outside this PR's diff; the changed regression and diff-level whitespace checks are clean. Dependency warnings printed during builds are outside the changed targets.

## Integration boundary

This PR preserves the pass and its bounded configuration across graph rebuilds. A rebuild intentionally creates a fresh disposable GPU cache; the Pulsar follow-up must replay canonical residency/surface state after resize or device rebuild. This PR does not introduce a second state authority and does not yet claim live planet integration.