### PR TITLE
Enable Apple Vulkan portability for Helio XR

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-wgpu = { version = "30.0.0", default-features = true, features = ["vulkan", "metal", "dx12", "gles", "webgpu", "wgsl"] }
+wgpu = { version = "30.0.0", default-features = true, features = ["vulkan", "vulkan-portability", "metal", "dx12", "gles", "webgpu", "wgsl"] }
 blade-graphics = { git = "https://github.com/tristanpoland/blade", rev = "d85bd14a78ed7729abc298906e87332257674a02" }
 blade-macros =   { git = "https://github.com/tristanpoland/blade", rev = "d85bd14a78ed7729abc298906e87332257674a02" }
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/helio-xr/Cargo.toml
+++ b/crates/helio-xr/Cargo.toml
@@ -18,7 +18,7 @@ openxr = { version = "0.21", features = [] }
 libloading = "0.9"
 # Matches the ash version wgpu-hal 30.0.0 is built against. Only the handle
 # types / `vk::Handle` trait are used to convert raw u64 handles.
-ash = { version = "0.38", default-features = false }
+ash = { version = "0.38", default-features = false, features = ["loaded"] }
 wgpu = { workspace = true }
 glam = { workspace = true }
 log = { workspace = true }


### PR DESCRIPTION
## Summary

- enable wgpu 30's declared `vulkan-portability` backend so Helio XR's Vulkan HAL types exist on Apple targets
- enable ash's `loaded` feature because `helio-xr` directly calls `ash::Entry::load()`
- preserve the existing Vulkan/OpenXR implementation without adding a stub or fallback path

Closes #184

## Validation

- `cargo check -p helio-xr --all-targets --locked`
- `cargo test -p helio-xr --lib --locked` - 3 passed
- `cargo tree -p helio-xr -e features --locked` - confirms `wgpu/vulkan-portability` and `ash/loaded`
- `cargo check --workspace --all-targets --locked`
- `git diff --check`

The workspace check completes with pre-existing warnings outside this two-line manifest change. Pulsar's macOS CI will provide the downstream Apple target gate after its Helio pin is advanced to this commit.