### PR TITLE
Add portable material and deferred-light capability tiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2934,6 +2934,7 @@ dependencies = [
 name = "helio-default-graphs"
 version = "0.1.0"
 dependencies = [
+ "glam 0.33.2",
  "helio",
  "helio-core",
  "helio-foliage-core",

--- a/crates/helio-default-graphs/Cargo.toml
+++ b/crates/helio-default-graphs/Cargo.toml
@@ -50,3 +50,4 @@ helio-pass-dof = { path = "../passes/3d/helio-pass-dof" }
 
 [dev-dependencies]
 pollster = { workspace = true }
+glam = { workspace = true }

--- a/crates/helio-default-graphs/tests/limited_native.rs
+++ b/crates/helio-default-graphs/tests/limited_native.rs
@@ -1,0 +1,198 @@
+use std::sync::{Arc, Mutex};
+
+use glam::Vec3;
+use helio::{
+    required_wgpu_limits, Camera, DebugCameraUniform, DebugDrawState, MaterialBindingMode,
+    Renderer, RendererConfig, Scene, BINDLESS_MATERIAL_FEATURES, EXPANDED_MATERIAL_TEXTURE_RESERVE,
+    MAX_MATERIAL_TEXTURES,
+};
+use helio_default_graphs::build_default_graph_external;
+
+const PORTABLE_SAMPLED_TEXTURE_LIMIT: u32 = 16;
+
+#[test]
+fn default_graph_renders_on_a_native_non_bindless_device_at_the_16_texture_boundary() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: limited native default graph");
+            return;
+        };
+        if !adapter
+            .features()
+            .contains(wgpu::Features::INDIRECT_FIRST_INSTANCE)
+        {
+            eprintln!("GPU_VALIDATION_SKIPPED_MISSING_INDIRECT_FIRST_INSTANCE: limited native default graph");
+            return;
+        }
+
+        let mut limits = required_wgpu_limits(adapter.limits());
+        limits.max_sampled_textures_per_shader_stage = PORTABLE_SAMPLED_TEXTURE_LIMIT;
+        limits.max_samplers_per_shader_stage = limits
+            .max_samplers_per_shader_stage
+            .min(PORTABLE_SAMPLED_TEXTURE_LIMIT);
+        run_default_graph(
+            adapter,
+            wgpu::Features::INDIRECT_FIRST_INSTANCE,
+            limits,
+            MaterialBindingMode::Expanded,
+            PORTABLE_SAMPLED_TEXTURE_LIMIT as usize - EXPANDED_MATERIAL_TEXTURE_RESERVE,
+            "Limited Native",
+        )
+        .await;
+    });
+}
+
+#[test]
+fn default_graph_retains_the_bindless_material_tier_when_supported() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: bindless native default graph");
+            return;
+        };
+        let required_features =
+            wgpu::Features::INDIRECT_FIRST_INSTANCE | BINDLESS_MATERIAL_FEATURES;
+        if !adapter.features().contains(required_features) {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_BINDLESS_TIER: bindless native default graph");
+            return;
+        }
+        let limits = required_wgpu_limits(adapter.limits());
+        let expected_max = MAX_MATERIAL_TEXTURES
+            .min(limits.max_sampled_textures_per_shader_stage as usize)
+            .min(limits.max_samplers_per_shader_stage as usize);
+        run_default_graph(
+            adapter,
+            required_features,
+            limits,
+            MaterialBindingMode::BindingArray,
+            expected_max,
+            "Bindless Native",
+        )
+        .await;
+    });
+}
+
+async fn run_default_graph(
+    adapter: wgpu::Adapter,
+    required_features: wgpu::Features,
+    required_limits: wgpu::Limits,
+    expected_mode: MaterialBindingMode,
+    expected_max_textures: usize,
+    label: &'static str,
+) {
+    let (device, queue) = adapter
+        .request_device(&wgpu::DeviceDescriptor {
+            label: Some(label),
+            required_features,
+            required_limits,
+            experimental_features: wgpu::ExperimentalFeatures::disabled(),
+            ..Default::default()
+        })
+        .await
+        .expect("the selected native material capability tier must create a device");
+    let device = Arc::new(device);
+    let queue = Arc::new(queue);
+    let validation_scope = device.push_error_scope(wgpu::ErrorFilter::Validation);
+
+    let scene = Scene::new(Arc::clone(&device), Arc::clone(&queue));
+    assert_eq!(scene.material_binding_config().mode, expected_mode);
+    assert_eq!(
+        scene.material_binding_config().max_textures,
+        expected_max_textures
+    );
+
+    let config = RendererConfig::new(32, 32, wgpu::TextureFormat::Rgba8Unorm);
+    let debug_state = Arc::new(Mutex::new(DebugDrawState::default()));
+    let debug_camera = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Limited Native Debug Camera"),
+        size: core::mem::size_of::<DebugCameraUniform>() as u64,
+        usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let cull_stats = device.create_buffer(&wgpu::BufferDescriptor {
+        label: Some("Limited Native Cull Stats"),
+        size: 32,
+        usage: wgpu::BufferUsages::STORAGE
+            | wgpu::BufferUsages::COPY_SRC
+            | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let graph = build_default_graph_external(
+        &device,
+        &queue,
+        &scene,
+        config,
+        Arc::clone(&debug_state),
+        &debug_camera,
+        &cull_stats,
+        None,
+    );
+
+    #[allow(deprecated)]
+    let mut renderer = Renderer::new_with_external_device(
+        Arc::clone(&device),
+        Arc::clone(&queue),
+        config.surface_format,
+        config.width,
+        config.height,
+        config.render_scale,
+        config,
+        scene,
+        graph,
+        debug_state,
+        debug_camera,
+        cull_stats,
+    );
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Limited Native Render Target"),
+        size: wgpu::Extent3d {
+            width: config.width,
+            height: config.height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: config.surface_format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    let target_view = target.create_view(&Default::default());
+    let camera = Camera::perspective_look_at(
+        Vec3::new(0.0, 1.0, 3.0),
+        Vec3::ZERO,
+        Vec3::Y,
+        60.0_f32.to_radians(),
+        1.0,
+        0.1,
+        100.0,
+    );
+
+    renderer
+        .render(&camera, &target_view)
+        .expect("the complete selected-tier default graph must render");
+    let _ = device.poll(wgpu::PollType::wait_indefinitely());
+    let validation_error = validation_scope.pop().await;
+    assert!(
+        validation_error.is_none(),
+        "selected-tier default graph validation failed: {validation_error:?}"
+    );
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}

--- a/crates/helio/src/lib.rs
+++ b/crates/helio/src/lib.rs
@@ -37,6 +37,10 @@ pub use material::{
     MaterialAsset, MaterialTextureRef, MaterialTextures, TextureSamplerDesc, TextureTransform,
     TextureUpload, MAX_TEXTURES,
 };
+pub use libhelio::{
+    MaterialBindingConfig, MaterialBindingMode, BINDLESS_MATERIAL_FEATURES,
+    MAX_MATERIAL_TEXTURES,
+};
 pub use mesh::{MeshBuffers, MeshSlice, MeshUpload, PackedVertex, SectionedMeshUpload};
 pub use picking::{PickHit, ScenePicker};
 pub use quark_commands::{register_helio_commands, HelioAction, HelioCommandBridge};

--- a/crates/helio/src/lib.rs
+++ b/crates/helio/src/lib.rs
@@ -39,7 +39,7 @@ pub use material::{
 };
 pub use libhelio::{
     MaterialBindingConfig, MaterialBindingMode, BINDLESS_MATERIAL_FEATURES,
-    MAX_MATERIAL_TEXTURES,
+    EXPANDED_MATERIAL_TEXTURE_RESERVE, MAX_MATERIAL_TEXTURES,
 };
 pub use mesh::{MeshBuffers, MeshSlice, MeshUpload, PackedVertex, SectionedMeshUpload};
 pub use picking::{PickHit, ScenePicker};

--- a/crates/helio/src/material.rs
+++ b/crates/helio/src/material.rs
@@ -6,10 +6,7 @@ use crate::{GpuMaterial, TextureId};
 /// WebGPU baseline guarantees only 16; native Vulkan/D3D12 supports 256.
 /// Mobile GPUs (Apple, Android/Adreno) get the same conservative cap as wasm —
 /// their shader compilers/descriptor limits choke on a 256-wide binding array.
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android")))]
-pub const MAX_TEXTURES: usize = 256;
-#[cfg(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android"))]
-pub const MAX_TEXTURES: usize = 16;
+pub const MAX_TEXTURES: usize = libhelio::MAX_MATERIAL_TEXTURES;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct TextureSamplerDesc {
@@ -203,4 +200,3 @@ impl GpuMaterialTextures {
         }
     }
 }
-

--- a/crates/helio/src/radiant/shader_cache.rs
+++ b/crates/helio/src/radiant/shader_cache.rs
@@ -39,14 +39,19 @@ impl RadiantShaderCache {
         key: RadiantShaderKey,
         template: &super::template::RadiantTemplate,
         graph_wgsl: &str,
-        max_textures: usize,
+        material_binding: libhelio::MaterialBindingConfig,
         label: &str,
     ) -> &wgpu::ShaderModule {
         if !self.modules.contains_key(&key) {
-            let source = template.build_shader_source(graph_wgsl, max_textures);
-            #[cfg(target_arch = "wasm32")]
-            let source =
-                super::template::RadiantTemplate::apply_webgpu_fixups(&source, max_textures);
+            let source = template.build_shader_source(graph_wgsl, material_binding.max_textures);
+            let source = if material_binding.uses_binding_arrays() {
+                source
+            } else {
+                super::template::RadiantTemplate::apply_webgpu_fixups(
+                    &source,
+                    material_binding.max_textures,
+                )
+            };
             let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
                 label: Some(label),
                 source: wgpu::ShaderSource::Wgsl(source.into()),

--- a/crates/helio/src/renderer/config.rs
+++ b/crates/helio/src/renderer/config.rs
@@ -1,4 +1,5 @@
 use crate::material::MAX_TEXTURES;
+use libhelio::BINDLESS_MATERIAL_FEATURES;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum RenderMode {
@@ -51,16 +52,15 @@ pub fn select_hdr_surface_format(
 }
 
 pub fn required_wgpu_features(adapter_features: wgpu::Features) -> wgpu::Features {
-    #[cfg(not(target_arch = "wasm32"))]
-    let required = wgpu::Features::TEXTURE_BINDING_ARRAY
-        | wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING
-        | wgpu::Features::INDIRECT_FIRST_INSTANCE;
-    #[cfg(target_arch = "wasm32")]
     let required = wgpu::Features::INDIRECT_FIRST_INSTANCE;
     let mut optional = wgpu::Features::MULTI_DRAW_INDIRECT_COUNT | // compacted indirect count buffer
         wgpu::Features::TIMESTAMP_QUERY | // GPU profiling timestamp queries
         wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS | // GPU profiling timestamps via encoder
         wgpu::Features::VERTEX_WRITABLE_STORAGE;
+    #[cfg(not(target_arch = "wasm32"))]
+    if adapter_features.contains(BINDLESS_MATERIAL_FEATURES) {
+        optional |= BINDLESS_MATERIAL_FEATURES;
+    }
     // Request ray tracing if available (native only, requires Vulkan)
     #[cfg(not(target_arch = "wasm32"))]
     {
@@ -109,6 +109,7 @@ pub fn required_experimental_features(adapter_features: wgpu::Features) -> wgpu:
 #[cfg(test)]
 mod tests {
     use super::{required_wgpu_features, RendererConfig};
+    use libhelio::BINDLESS_MATERIAL_FEATURES;
 
     #[test]
     fn indirect_first_instance_is_required_even_when_adapter_does_not_report_it() {
@@ -121,6 +122,18 @@ mod tests {
         let requested = required_wgpu_features(wgpu::Features::empty());
         assert!(!requested.contains(wgpu::Features::MULTI_DRAW_INDIRECT_COUNT));
         assert!(!requested.contains(wgpu::Features::TIMESTAMP_QUERY));
+    }
+
+    #[test]
+    fn complete_material_binding_array_capability_is_requested_together() {
+        let requested = required_wgpu_features(BINDLESS_MATERIAL_FEATURES);
+        assert!(requested.contains(BINDLESS_MATERIAL_FEATURES));
+    }
+
+    #[test]
+    fn partial_material_binding_array_capability_is_not_requested() {
+        let requested = required_wgpu_features(wgpu::Features::TEXTURE_BINDING_ARRAY);
+        assert!(!requested.intersects(BINDLESS_MATERIAL_FEATURES));
     }
 
     #[test]

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -366,7 +366,7 @@ impl Renderer {
 
         let mut texture_views = ArrayVec::<&wgpu::TextureView, { crate::material::MAX_TEXTURES }>::new();
         let mut samplers = ArrayVec::<&wgpu::Sampler, { crate::material::MAX_TEXTURES }>::new();
-        for slot in 0..crate::material::MAX_TEXTURES {
+        for slot in 0..self.scene.material_binding_config().max_textures {
             texture_views.push(self.scene.texture_view_for_slot(slot));
             samplers.push(self.scene.texture_sampler_for_slot(slot));
         }

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -49,6 +49,9 @@ pub struct Scene {
     /// Texture binding version (increments on add/remove)
     pub(in crate::scene) texture_binding_version: u64,
 
+    /// Material texture representation and capacity selected for this device.
+    pub(in crate::scene) material_binding: libhelio::MaterialBindingConfig,
+
     /// Material texture storage buffer (GPU-side texture descriptors)
     pub(in crate::scene) material_textures: GrowableBuffer<crate::material::GpuMaterialTextures>,
 
@@ -286,6 +289,7 @@ impl Scene {
     /// let scene = Scene::new(device, queue);
     /// ```
     pub fn new(device: Arc<wgpu::Device>, queue: Arc<wgpu::Queue>) -> Self {
+        let material_binding = libhelio::MaterialBindingConfig::for_device(&device);
         helio_core::upload::record_upload_bytes(4);
         let placeholder_texture = device.create_texture_with_data(
             &queue,
@@ -323,6 +327,7 @@ impl Scene {
             gpu_scene: GpuScene::new(device.clone(), queue.clone()),
             textures: SparsePool::new(),
             texture_binding_version: 0,
+            material_binding,
             material_textures: GrowableBuffer::new(
                 device,
                 256,

--- a/crates/helio/src/scene/errors.rs
+++ b/crates/helio/src/scene/errors.rs
@@ -24,8 +24,8 @@ pub enum SceneError {
 
     /// The scene's texture capacity has been exceeded.
     ///
-    /// The scene can hold a maximum of [`crate::MAX_TEXTURES`] textures.
-    #[error("scene texture capacity exceeded")]
+    /// The capacity is selected from the device's complete material binding tier.
+    #[error("scene texture capacity exceeded for the active material binding tier")]
     TextureCapacityExceeded,
 
     /// An operation was rejected because of an incompatible resource state.
@@ -50,4 +50,3 @@ pub type Result<T> = std::result::Result<T, SceneError>;
 pub(super) fn invalid(resource: &'static str) -> SceneError {
     SceneError::InvalidHandle { resource }
 }
-

--- a/crates/helio/src/scene/resources/textures.rs
+++ b/crates/helio/src/scene/resources/textures.rs
@@ -5,13 +5,12 @@
 //!
 //! # Capacity Limits
 //!
-//! The scene supports a maximum of [`MAX_TEXTURES`](crate::material::MAX_TEXTURES) (16384)
-//! concurrent textures due to bindless array limits.
+//! The scene capacity is selected from the active device's material binding tier.
 
 use wgpu::util::DeviceExt;
 
 use crate::handles::TextureId;
-use crate::material::{TextureUpload, MAX_TEXTURES};
+use crate::material::TextureUpload;
 
 use super::super::errors::{invalid, Result, SceneError};
 use super::super::types::TextureRecord;
@@ -57,7 +56,9 @@ impl super::super::Scene {
     /// })?;
     /// ```
     pub fn insert_texture(&mut self, texture: TextureUpload) -> Result<TextureId> {
-        if !self.textures.has_free_slot() && self.textures.slot_len() >= MAX_TEXTURES {
+        if !self.textures.has_free_slot()
+            && self.textures.slot_len() >= self.material_binding.max_textures
+        {
             return Err(SceneError::TextureCapacityExceeded);
         }
 
@@ -152,6 +153,11 @@ impl super::super::Scene {
         self.texture_binding_version
     }
 
+    /// Material binding representation shared by every pass for this scene.
+    pub fn material_binding_config(&self) -> libhelio::MaterialBindingConfig {
+        self.material_binding
+    }
+
     /// Get the texture view for a given slot index.
     ///
     /// Returns the placeholder white texture view if the slot is invalid or empty.
@@ -186,4 +192,3 @@ impl super::super::Scene {
             .unwrap_or(&self.placeholder_sampler)
     }
 }
-

--- a/crates/libhelio/src/material.rs
+++ b/crates/libhelio/src/material.rs
@@ -2,6 +2,165 @@
 
 use bytemuck::{Pod, Zeroable};
 
+/// Maximum scene material textures exposed by Helio on this platform.
+#[cfg(not(any(
+    target_arch = "wasm32",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+)))]
+pub const MAX_MATERIAL_TEXTURES: usize = 256;
+#[cfg(any(
+    target_arch = "wasm32",
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "android"
+))]
+pub const MAX_MATERIAL_TEXTURES: usize = 16;
+
+/// Native features required by Helio's descriptor-indexed material table.
+/// The pair is one capability; a partial feature set always uses the complete
+/// baseline binding implementation.
+pub const BINDLESS_MATERIAL_FEATURES: wgpu::Features = wgpu::Features::TEXTURE_BINDING_ARRAY
+    .union(wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING);
+
+/// GPU material texture binding implementation selected for one device.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaterialBindingMode {
+    BindingArray,
+    Expanded,
+}
+
+/// One authoritative material binding contract shared by the scene and every
+/// pass that reads material textures.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MaterialBindingConfig {
+    pub mode: MaterialBindingMode,
+    pub max_textures: usize,
+}
+
+impl MaterialBindingConfig {
+    pub fn for_device(device: &wgpu::Device) -> Self {
+        Self::from_capabilities(device.features(), device.limits())
+    }
+
+    /// Select the material binding representation from adapter/device capabilities.
+    ///
+    /// Keeping this decision pure lets device creation, scene capacity, and pass
+    /// construction share one auditable capability contract.
+    pub fn from_capabilities(features: wgpu::Features, limits: wgpu::Limits) -> Self {
+        #[cfg(not(target_arch = "wasm32"))]
+        let mode = if features.contains(BINDLESS_MATERIAL_FEATURES) {
+            MaterialBindingMode::BindingArray
+        } else {
+            MaterialBindingMode::Expanded
+        };
+        #[cfg(target_arch = "wasm32")]
+        let mode = MaterialBindingMode::Expanded;
+
+        let stage_limit = limits
+            .max_sampled_textures_per_shader_stage
+            .min(limits.max_samplers_per_shader_stage) as usize;
+        let binding_limit = match mode {
+            MaterialBindingMode::BindingArray => usize::MAX,
+            MaterialBindingMode::Expanded => {
+                (limits.max_bindings_per_bind_group as usize).saturating_sub(2) / 2
+            }
+        };
+        let max_textures = MAX_MATERIAL_TEXTURES.min(stage_limit).min(binding_limit);
+        assert!(
+            max_textures > 0,
+            "Helio requires at least one sampled texture and sampler binding"
+        );
+        Self { mode, max_textures }
+    }
+
+    pub fn uses_binding_arrays(self) -> bool {
+        self.mode == MaterialBindingMode::BindingArray
+    }
+
+    pub fn append_layout_entries(
+        self,
+        entries: &mut Vec<wgpu::BindGroupLayoutEntry>,
+        first_binding: u32,
+        visibility: wgpu::ShaderStages,
+    ) {
+        let texture_entry = |binding, count| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility,
+            ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+            },
+            count,
+        };
+        let sampler_entry = |binding, count| wgpu::BindGroupLayoutEntry {
+            binding,
+            visibility,
+            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+            count,
+        };
+
+        match self.mode {
+            MaterialBindingMode::BindingArray => {
+                let count = std::num::NonZeroU32::new(self.max_textures as u32)
+                    .expect("material texture table is non-empty");
+                entries.push(texture_entry(first_binding, Some(count)));
+                entries.push(sampler_entry(first_binding + 1, Some(count)));
+            }
+            MaterialBindingMode::Expanded => {
+                for index in 0..self.max_textures as u32 {
+                    entries.push(texture_entry(first_binding + index, None));
+                }
+                for index in 0..self.max_textures as u32 {
+                    entries.push(sampler_entry(
+                        first_binding + self.max_textures as u32 + index,
+                        None,
+                    ));
+                }
+            }
+        }
+    }
+
+    pub fn append_bind_group_entries<'a>(
+        self,
+        entries: &mut Vec<wgpu::BindGroupEntry<'a>>,
+        first_binding: u32,
+        texture_views: &'a [&'a wgpu::TextureView],
+        samplers: &'a [&'a wgpu::Sampler],
+    ) {
+        assert_eq!(texture_views.len(), self.max_textures);
+        assert_eq!(samplers.len(), self.max_textures);
+        match self.mode {
+            MaterialBindingMode::BindingArray => {
+                entries.push(wgpu::BindGroupEntry {
+                    binding: first_binding,
+                    resource: wgpu::BindingResource::TextureViewArray(texture_views),
+                });
+                entries.push(wgpu::BindGroupEntry {
+                    binding: first_binding + 1,
+                    resource: wgpu::BindingResource::SamplerArray(samplers),
+                });
+            }
+            MaterialBindingMode::Expanded => {
+                for (index, view) in texture_views.iter().enumerate() {
+                    entries.push(wgpu::BindGroupEntry {
+                        binding: first_binding + index as u32,
+                        resource: wgpu::BindingResource::TextureView(view),
+                    });
+                }
+                for (index, sampler) in samplers.iter().enumerate() {
+                    entries.push(wgpu::BindGroupEntry {
+                        binding: first_binding + self.max_textures as u32 + index as u32,
+                        resource: wgpu::BindingResource::Sampler(sampler),
+                    });
+                }
+            }
+        }
+    }
+}
+
 /// Material workflow discriminant.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,7 +194,9 @@ pub const MATERIAL_CLASS_CUSTOM: u32 = 0xFFFF;
 
 /// GPU material data. 112 bytes.
 ///
-/// All texture indices reference the global bindless texture array.
+/// All texture indices reference the global material texture table. Depending
+/// on device capabilities, that table is either descriptor-indexed or expanded
+/// into ordinary texture/sampler bindings.
 /// If a texture is not present, the index is u32::MAX.
 ///
 /// # WGSL equivalent
@@ -87,3 +248,58 @@ impl GpuMaterial {
     pub const NO_TEXTURE: u32 = u32::MAX;
 }
 
+#[cfg(test)]
+mod material_binding_tests {
+    use super::{
+        MaterialBindingConfig, MaterialBindingMode, BINDLESS_MATERIAL_FEATURES,
+        MAX_MATERIAL_TEXTURES,
+    };
+
+    fn limits(sampled_textures: u32, samplers: u32, bindings: u32) -> wgpu::Limits {
+        wgpu::Limits {
+            max_sampled_textures_per_shader_stage: sampled_textures,
+            max_samplers_per_shader_stage: samplers,
+            max_bindings_per_bind_group: bindings,
+            ..wgpu::Limits::default()
+        }
+    }
+
+    #[test]
+    fn missing_or_partial_binding_array_features_select_expanded_bindings() {
+        for features in [
+            wgpu::Features::empty(),
+            wgpu::Features::TEXTURE_BINDING_ARRAY,
+            wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING,
+        ] {
+            let config = MaterialBindingConfig::from_capabilities(features, limits(16, 16, 64));
+            assert_eq!(config.mode, MaterialBindingMode::Expanded);
+            assert_eq!(config.max_textures, 16.min(MAX_MATERIAL_TEXTURES));
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn complete_binding_array_feature_pair_selects_descriptor_indexing() {
+        let config = MaterialBindingConfig::from_capabilities(
+            BINDLESS_MATERIAL_FEATURES,
+            limits(256, 256, 8),
+        );
+        assert_eq!(config.mode, MaterialBindingMode::BindingArray);
+        assert_eq!(config.max_textures, MAX_MATERIAL_TEXTURES.min(256));
+    }
+
+    #[test]
+    fn expanded_binding_count_is_bounded_by_texture_sampler_pairs() {
+        let config =
+            MaterialBindingConfig::from_capabilities(wgpu::Features::empty(), limits(64, 64, 22));
+        assert_eq!(config.mode, MaterialBindingMode::Expanded);
+        assert_eq!(config.max_textures, 10);
+
+        let mut entries = Vec::new();
+        config.append_layout_entries(&mut entries, 2, wgpu::ShaderStages::FRAGMENT);
+        assert_eq!(entries.len(), 20);
+        assert_eq!(entries.first().map(|entry| entry.binding), Some(2));
+        assert_eq!(entries.last().map(|entry| entry.binding), Some(21));
+        assert!(entries.iter().all(|entry| entry.count.is_none()));
+    }
+}

--- a/crates/libhelio/src/material.rs
+++ b/crates/libhelio/src/material.rs
@@ -24,6 +24,11 @@ pub const MAX_MATERIAL_TEXTURES: usize = 16;
 pub const BINDLESS_MATERIAL_FEATURES: wgpu::Features = wgpu::Features::TEXTURE_BINDING_ARRAY
     .union(wgpu::Features::SAMPLED_TEXTURE_AND_STORAGE_BUFFER_ARRAY_NON_UNIFORM_INDEXING);
 
+/// Sampled-texture slots reserved for non-material inputs in the most
+/// constrained material-consuming stage. Decal collection reads depth plus
+/// four G-buffer textures alongside the material table.
+pub const EXPANDED_MATERIAL_TEXTURE_RESERVE: usize = 5;
+
 /// GPU material texture binding implementation selected for one device.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MaterialBindingMode {
@@ -58,9 +63,14 @@ impl MaterialBindingConfig {
         #[cfg(target_arch = "wasm32")]
         let mode = MaterialBindingMode::Expanded;
 
-        let stage_limit = limits
-            .max_sampled_textures_per_shader_stage
-            .min(limits.max_samplers_per_shader_stage) as usize;
+        let sampled_texture_limit = limits.max_sampled_textures_per_shader_stage as usize;
+        let sampler_limit = limits.max_samplers_per_shader_stage as usize;
+        let stage_limit = match mode {
+            MaterialBindingMode::BindingArray => sampled_texture_limit.min(sampler_limit),
+            MaterialBindingMode::Expanded => sampled_texture_limit
+                .saturating_sub(EXPANDED_MATERIAL_TEXTURE_RESERVE)
+                .min(sampler_limit),
+        };
         let binding_limit = match mode {
             MaterialBindingMode::BindingArray => usize::MAX,
             MaterialBindingMode::Expanded => {
@@ -252,7 +262,7 @@ impl GpuMaterial {
 mod material_binding_tests {
     use super::{
         MaterialBindingConfig, MaterialBindingMode, BINDLESS_MATERIAL_FEATURES,
-        MAX_MATERIAL_TEXTURES,
+        EXPANDED_MATERIAL_TEXTURE_RESERVE, MAX_MATERIAL_TEXTURES,
     };
 
     fn limits(sampled_textures: u32, samplers: u32, bindings: u32) -> wgpu::Limits {
@@ -273,7 +283,10 @@ mod material_binding_tests {
         ] {
             let config = MaterialBindingConfig::from_capabilities(features, limits(16, 16, 64));
             assert_eq!(config.mode, MaterialBindingMode::Expanded);
-            assert_eq!(config.max_textures, 16.min(MAX_MATERIAL_TEXTURES));
+            assert_eq!(
+                config.max_textures,
+                (16 - EXPANDED_MATERIAL_TEXTURE_RESERVE).min(MAX_MATERIAL_TEXTURES)
+            );
         }
     }
 

--- a/crates/passes/3d/helio-pass-decal/src/lib.rs
+++ b/crates/passes/3d/helio-pass-decal/src/lib.rs
@@ -2,19 +2,12 @@ use helio_core::graph::ResourceBuilder;
 use helio_core::{PassContext, PrepareContext, RenderPass, Result as HelioResult};
 use std::sync::Arc;
 
-/// Size of the scene's bindless texture table. Must match `helio::material::MAX_TEXTURES`,
-/// which the renderer uses to size the per-frame view/sampler arrays.
-/// Capped at 16 on wasm32, Apple native Metal, and Android; 256 on other desktop backends.
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android")))]
-const MAX_TEXTURES: usize = 256;
-#[cfg(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android"))]
-const MAX_TEXTURES: usize = 16;
-
 #[repr(C)]
 #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
 struct DecalGlobals { decal_count: u32, _pad0: u32, _pad1: u32, _pad2: u32 }
 
 pub struct DecalPass {
+    material_binding: libhelio::MaterialBindingConfig,
     collect_pipeline: wgpu::ComputePipeline,
     apply_pipeline: wgpu::ComputePipeline,
     bgl_collect: wgpu::BindGroupLayout,
@@ -40,7 +33,8 @@ impl DecalPass {
     /// from `main_scene`), so this pass owns no texture state of its own.
     pub fn new(device: &wgpu::Device, _queue: &wgpu::Queue, _decal_buf: &wgpu::Buffer,
                _camera_buf: &wgpu::Buffer, _w: u32, _h: u32) -> Self {
-        let collect_src = decal_collect_source();
+        let material_binding = libhelio::MaterialBindingConfig::for_device(device);
+        let collect_src = decal_collect_source(material_binding);
         let collect_mod = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Decal Collect"),
             source: wgpu::ShaderSource::Wgsl(collect_src.into()),
@@ -73,7 +67,7 @@ impl DecalPass {
                 bgl_entry_tex_storage(11, wgpu::StorageTextureAccess::WriteOnly, wgpu::TextureFormat::Rgba16Float),
             ],
         });
-        let bgl_textures = create_decal_texture_bgl(device);
+        let bgl_textures = create_decal_texture_bgl(device, material_binding);
         let collect_pl = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("Decal Collect PL"),
             bind_group_layouts: &[Some(&bgl_collect), Some(&bgl_textures)],
@@ -110,6 +104,7 @@ impl DecalPass {
         });
 
         Self {
+            material_binding,
             collect_pipeline, apply_pipeline, bgl_collect, bgl_apply, bgl_textures,
             bg_collect: None, bg_apply: None, bg_textures: None,
             bg_collect_key: None, bg_apply_key: None, bg_textures_version: None,
@@ -146,68 +141,37 @@ fn make_temp(device: &wgpu::Device, format: wgpu::TextureFormat, label: &str, si
 ///
 /// The WGSL is written against the 256-entry native table; on wasm the arrays are
 /// rewritten to individual bindings (baseline WebGPU has no `binding_array`), and
-/// elsewhere the declared length is resized to match [`MAX_TEXTURES`] — the BGL and
+/// elsewhere the declared length is resized to match the selected material tier — the BGL and
 /// the shader must agree exactly or `create_bind_group` fails validation.
-fn decal_collect_source() -> String {
+fn decal_collect_source(material_binding: libhelio::MaterialBindingConfig) -> String {
     let src = include_str!("../shaders/decal_collect.wgsl");
-    #[cfg(target_arch = "wasm32")]
-    {
-        libhelio::shader::apply_webgpu_decal_bindings(src, MAX_TEXTURES)
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
+    if material_binding.uses_binding_arrays() {
         src.replace(
             "binding_array<texture_2d<f32>, 256>",
-            &format!("binding_array<texture_2d<f32>, {MAX_TEXTURES}>"),
+            &format!(
+                "binding_array<texture_2d<f32>, {}>",
+                material_binding.max_textures
+            ),
         )
         .replace(
             "binding_array<sampler, 256>",
-            &format!("binding_array<sampler, {MAX_TEXTURES}>"),
+            &format!(
+                "binding_array<sampler, {}>",
+                material_binding.max_textures
+            ),
         )
+    } else {
+        libhelio::shader::apply_webgpu_decal_bindings(src, material_binding.max_textures)
     }
 }
 
 /// BGL for group 1: the scene's bindless texture table, shared with the GBuffer pass.
-fn create_decal_texture_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    #[allow(unused_mut)]
+fn create_decal_texture_bgl(
+    device: &wgpu::Device,
+    material_binding: libhelio::MaterialBindingConfig,
+) -> wgpu::BindGroupLayout {
     let mut entries: Vec<wgpu::BindGroupLayoutEntry> = Vec::new();
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let count = std::num::NonZeroU32::new(MAX_TEXTURES as u32);
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 0, visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-                sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                view_dimension: wgpu::TextureViewDimension::D2, multisampled: false,
-            },
-            count,
-        });
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 1, visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-            count,
-        });
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        for index in 0..MAX_TEXTURES as u32 {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: index, visibility: wgpu::ShaderStages::COMPUTE,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2, multisampled: false,
-                },
-                count: None,
-            });
-        }
-        for index in 0..MAX_TEXTURES as u32 {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: MAX_TEXTURES as u32 + index, visibility: wgpu::ShaderStages::COMPUTE,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            });
-        }
-    }
+    material_binding.append_layout_entries(&mut entries, 0, wgpu::ShaderStages::COMPUTE);
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("Decal Textures BGL"), entries: &entries,
     })
@@ -274,7 +238,10 @@ impl RenderPass for DecalPass {
         let tex_version = main_scene.material_textures.version;
         if self.bg_textures_version != Some(tex_version) || self.bg_textures.is_none() {
             self.bg_textures = Some(build_texture_bind_group(
-                ctx.device, &self.bgl_textures, &main_scene.material_textures,
+                ctx.device,
+                &self.bgl_textures,
+                &main_scene.material_textures,
+                self.material_binding,
             ));
             self.bg_textures_version = Some(tex_version);
         }
@@ -324,35 +291,15 @@ fn build_texture_bind_group(
     device: &wgpu::Device,
     layout: &wgpu::BindGroupLayout,
     textures: &libhelio::MaterialTextureBindings,
+    material_binding: libhelio::MaterialBindingConfig,
 ) -> wgpu::BindGroup {
-    #[allow(unused_mut)]
     let mut entries: Vec<wgpu::BindGroupEntry> = Vec::new();
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        entries.push(wgpu::BindGroupEntry {
-            binding: 0,
-            resource: wgpu::BindingResource::TextureViewArray(textures.texture_views),
-        });
-        entries.push(wgpu::BindGroupEntry {
-            binding: 1,
-            resource: wgpu::BindingResource::SamplerArray(textures.samplers),
-        });
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        for (index, view) in textures.texture_views.iter().enumerate() {
-            entries.push(wgpu::BindGroupEntry {
-                binding: index as u32,
-                resource: wgpu::BindingResource::TextureView(view),
-            });
-        }
-        for (index, sampler) in textures.samplers.iter().enumerate() {
-            entries.push(wgpu::BindGroupEntry {
-                binding: MAX_TEXTURES as u32 + index as u32,
-                resource: wgpu::BindingResource::Sampler(sampler),
-            });
-        }
-    }
+    material_binding.append_bind_group_entries(
+        &mut entries,
+        0,
+        textures.texture_views,
+        textures.samplers,
+    );
     device.create_bind_group(&wgpu::BindGroupDescriptor {
         label: Some("Decal Textures BG"), layout, entries: &entries,
     })
@@ -374,7 +321,10 @@ mod tests {
     #[test]
     fn webgpu_fixup_rewrites_every_binding_array_in_the_real_shader() {
         let src = include_str!("../shaders/decal_collect.wgsl");
-        let fixed = libhelio::shader::apply_webgpu_decal_bindings(src, super::MAX_TEXTURES);
+        let fixed = libhelio::shader::apply_webgpu_decal_bindings(
+            src,
+            libhelio::MAX_MATERIAL_TEXTURES.min(16),
+        );
 
         assert!(
             !fixed.contains("binding_array"),

--- a/crates/passes/3d/helio-pass-deferred-light/shaders/deferred_lighting.wgsl
+++ b/crates/passes/3d/helio-pass-deferred-light/shaders/deferred_lighting.wgsl
@@ -1063,25 +1063,6 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
         return vec4<f32>(sf, sf, sf, 1.0);
     }
 
-    // ── Debug modes 30/31: SSR diagnosis ─────────────────────────────────────
-    // Use these as a PAIR. SsrPass writes (0,0,0,0) when the ray found nothing,
-    // and (colour, confidence) when it hit — so comparing the two separates the
-    // two very different reasons a reflection can be absent:
-    //
-    //   31 black  + 30 black  → the march found no hit (traversal/geometry).
-    //   31 colour + 30 black  → a hit was found and then faded away by a
-    //                           confidence term (back-face/facing/edge/distance).
-    //
-    // Without this pair the two are indistinguishable in the final image: both
-    // just look like missing reflection, and tuning is guesswork.
-    if globals.debug_mode == 30u {
-        let a = textureLoad(ssr_tex, pix, 0).a;
-        return vec4<f32>(a, a, a, 1.0);
-    }
-    if globals.debug_mode == 31u {
-        return vec4<f32>(textureLoad(ssr_tex, pix, 0).rgb, 1.0);
-    }
-
     // ── Debug mode 11: light-space projection for first light face 0 ─────────
     // Orange gradient = pixel is inside the light frustum, depth = ndc.z.
     // Dark blue = pixel is outside the frustum (w<=0 or uv out of [0,1]).
@@ -1200,60 +1181,8 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
     // so neither do we.  This convention matches Unreal Engine's lightmap pipeline.
     let lightmap_indirect = lightmap_sample * albedo;
 
-    // ── Indirect specular: SSR + environment cubemap ──────────────────────────
-    let R            = reflect(-V, N);
-    let env_lod      = roughness * ENV_MAX_LOD;  // approx mip from roughness (WebGPU: textureSample not allowed in non-uniform flow)
-    // Parallax-corrected, influence-blended captures, falling back to the
-    // skylight where none reach. Rougher surfaces pull from higher mips of the
-    // pre-filtered chain, so reflection blur tracks roughness.
-    var spec_ind = vec3<f32>(0.0);
-    if globals.enable_env_reflections != 0u {
-        let env_sample = sample_reflection_environment(world_pos, R, env_lod);
-        let env_brdf   = env_brdf_approx(NdV, roughness);
-        spec_ind = env_sample * (F0 * env_brdf.x + env_brdf.y);
-    }
-
-    // ── SSR composite ────────────────────────────────────────────────────
-    // Blend screen-space reflections over the cubemap fallback, weighted by
-    // the trace's confidence.
-    //
-    // Alpha IS the blend weight. SsrPass folds every validity term into it —
-    // edge, viewer-facing, back-face, ray distance, and roughness — precisely
-    // so this composite can dissolve an untrustworthy reflection back into
-    // the probe.
-    // On targets without reflection support SsrPass never ran, so ssr_tex is
-    // the 1×1 black fallback; the flag makes that explicit rather than relying
-    // on the fallback's alpha.
-    let ssr_hit      = textureLoad(ssr_tex, pix, 0);
-    if globals.enable_reflections != 0u && ssr_hit.a > 0.0 {
-        let ssr_sample = ssr_hit.rgb * F_ibl;
-        spec_ind = mix(spec_ind, ssr_sample, ssr_hit.a);
-    }
-
-    // ── Planar reflection composite ──────────────────────────────────────
-    // Planar reflections are more accurate on their native surfaces (floors,
-    // mirrors, water) than SSR or the cubemap. They are blended on top of
-    // whatever SSR found, with their own confidence weighting.
-    //
-    // The planar trace runs *before* deferred lighting (like SSR), so its
-    // output is unlit scene colour — multiply by F_ibl to match the IBL
-    // fallback's energy level, exactly as SSR does above.
-    let planar_hit    = textureLoad(planar_tex, pix, 0);
-    if globals.enable_reflections != 0u && planar_hit.a > 0.0 {
-        let planar_sample = planar_hit.rgb * F_ibl;
-        spec_ind = mix(spec_ind, planar_sample, planar_hit.a);
-    }
-
-    // ── RC-enhanced specular (rough surfaces) ────────────────────────────
-    // Radiance cascades store irradiance from the scene's GI. For rough
-    // surfaces (roughness > 0.6), a single SSR trace or ray query cannot
-    // converge the full glossy lobe, so we fall back to the RC irradiance
-    // as a broad directional wash.  This prevents rough reflections from
-    // going black when SSR misses.
-    if globals.has_rc_gi > 0u && roughness > 0.6 {
-        let rc_spec = sample_rc_specular(world_pos, R, roughness, N);
-        spec_ind = mix(spec_ind, rc_spec, smoothstep(0.6, 0.9, roughness) * 0.4);
-    }
+    // Indirect specular is composed by fs_reflection in a second draw. This
+    // keeps both fragment stages within the WebGPU baseline texture limit.
 
     // ── INDIRECT LIGHTING ────────────────────────────────────────────────────
     // Hemisphere ambient is shadow-INDEPENDENT.  Shadow maps only affect direct
@@ -1294,8 +1223,8 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
     //   • For un-lightmapped surfaces the normal dynamic path applies AO to the
     //     hemisphere/RC ambient term as usual.
     let lo_final      = Lo * (1.0 - lm_weight);          // suppress Lo for baked pixels
-    let indirect_dyn  = (ambient_final + spec_ind) * ao_combined;  // AO on dynamic GI
-    let indirect_bake =  lightmap_indirect + spec_ind;              // no AO on lightmap
+    let indirect_dyn  = ambient_final * ao_combined;  // AO on dynamic GI
+    let indirect_bake = lightmap_indirect;            // no AO on lightmap
     let indirect      = select(indirect_dyn, indirect_bake, has_lightmap);
     var color         = lo_final + indirect;
     color        += emissive;               // emissive from G-buffer
@@ -1327,4 +1256,86 @@ fn fs_main(in: VSOut) -> @location(0) vec4<f32> {
 
     // Tonemapping & bloom handled by PostProcessPass — write raw HDR linear.
     return vec4<f32>(color, alpha);
+}
+
+// Reflection composition is deliberately isolated from base lighting so neither
+// fragment entry point exceeds the WebGPU baseline of 16 sampled textures.
+// The normal path is additively blended over fs_main; SSR debug modes use the
+// companion replacement pipeline.
+@fragment
+fn fs_reflection(in: VSOut) -> @location(0) vec4<f32> {
+    let pix = vec2<i32>(i32(in.clip_pos.x), i32(in.clip_pos.y));
+    let depth = textureLoad(gbuf_depth, pix, 0);
+    if depth >= 1.0 { discard; }
+
+    let ssr_hit = textureLoad(ssr_tex, pix, 0);
+    if globals.debug_mode == 30u {
+        return vec4<f32>(vec3<f32>(ssr_hit.a), 1.0);
+    }
+    if globals.debug_mode == 31u {
+        return vec4<f32>(ssr_hit.rgb, 1.0);
+    }
+
+    // These modes replace lighting with another diagnostic in fs_main.
+    if globals.debug_mode == 1u || globals.debug_mode == 2u
+        || globals.debug_mode == 4u || globals.debug_mode == 5u
+        || globals.debug_mode == 10u || globals.debug_mode == 11u
+        || globals.debug_mode == 20u || globals.debug_mode == 21u {
+        return vec4<f32>(0.0);
+    }
+
+    let normal_r = textureLoad(gbuf_normal, pix, 0);
+    let orm_r = textureLoad(gbuf_orm, pix, 0);
+    let emissive_r = textureLoad(gbuf_emissive, pix, 0);
+    let N = normalize(normal_r.xyz);
+    let roughness = orm_r.g;
+    let F0 = clamp(
+        vec3<f32>(normal_r.w, orm_r.a, emissive_r.a),
+        vec3<f32>(0.0),
+        vec3<f32>(0.999),
+    );
+
+    let screen_size = vec2<f32>(textureDimensions(gbuf_normal));
+    let screen_uv = in.clip_pos.xy / screen_size;
+    let ao_combined = orm_r.r * textureSample(screen_ao, screen_ao_samp, screen_uv).r;
+    let lightmap_uv = textureLoad(gbuf_lightmap_uv, pix, 0).rg;
+    let is_vg = lightmap_uv.x < -1.5;
+    let has_lightmap = !is_vg && lightmap_uv.x >= 0.0;
+
+    let ndc_xy = vec2<f32>(screen_uv.x * 2.0 - 1.0, 1.0 - screen_uv.y * 2.0);
+    let world_h = cameras[0].view_proj_inv * vec4<f32>(ndc_xy, depth, 1.0);
+    let world_pos = world_h.xyz / world_h.w;
+    let V = normalize(cameras[0].position_near.xyz - world_pos);
+    let NdV = max(dot(N, V), 0.0);
+    let F_ibl = fresnel_schlick_roughness(NdV, F0, roughness);
+    let R = reflect(-V, N);
+
+    var spec_ind = vec3<f32>(0.0);
+    if globals.enable_env_reflections != 0u {
+        let env_lod = roughness * ENV_MAX_LOD;
+        let env_sample = sample_reflection_environment(world_pos, R, env_lod);
+        let env_brdf = env_brdf_approx(NdV, roughness);
+        spec_ind = env_sample * (F0 * env_brdf.x + env_brdf.y);
+    }
+
+    if globals.enable_reflections != 0u && ssr_hit.a > 0.0 {
+        spec_ind = mix(spec_ind, ssr_hit.rgb * F_ibl, ssr_hit.a);
+    }
+
+    let planar_hit = textureLoad(planar_tex, pix, 0);
+    if globals.enable_reflections != 0u && planar_hit.a > 0.0 {
+        spec_ind = mix(spec_ind, planar_hit.rgb * F_ibl, planar_hit.a);
+    }
+
+    if globals.has_rc_gi > 0u && roughness > 0.6 {
+        let rc_spec = sample_rc_specular(world_pos, R, roughness, N);
+        spec_ind = mix(
+            spec_ind,
+            rc_spec,
+            smoothstep(0.6, 0.9, roughness) * 0.4,
+        );
+    }
+
+    let contribution = select(spec_ind * ao_combined, spec_ind, has_lightmap);
+    return vec4<f32>(contribution, 0.0);
 }

--- a/crates/passes/3d/helio-pass-deferred-light/src/lib.rs
+++ b/crates/passes/3d/helio-pass-deferred-light/src/lib.rs
@@ -3,6 +3,15 @@ use helio_core::graph::{ResourceBuilder, ResourceSize};
 use helio_core::{DebugViewDescriptor, PassContext, PrepareContext, RenderPass, Result as HelioResult};
 use std::borrow::Cow;
 
+/// Maximum sampled textures visible to either deferred-light fragment entry point.
+///
+/// Base lighting uses nine G-buffer inputs and six scene textures. Reflection
+/// composition uses six G-buffer inputs and four reflection textures.
+pub const BASE_SAMPLED_TEXTURE_COUNT: u32 = 15;
+pub const REFLECTION_SAMPLED_TEXTURE_COUNT: u32 = 10;
+const _: () = assert!(BASE_SAMPLED_TEXTURE_COUNT <= 16);
+const _: () = assert!(REFLECTION_SAMPLED_TEXTURE_COUNT <= 16);
+
 #[repr(C)]
 #[derive(Clone, Copy, Pod, Zeroable)]
 struct DeferredGlobals {
@@ -44,20 +53,27 @@ struct DeferredGlobals {
 
 pub struct DeferredLightPass {
     pipeline: wgpu::RenderPipeline,
+    reflection_pipeline: wgpu::RenderPipeline,
+    reflection_debug_pipeline: wgpu::RenderPipeline,
     globals_buf: wgpu::Buffer,
     shadow_config_buf: wgpu::Buffer,
-    bgl_0: wgpu::BindGroupLayout,
     bgl_1: wgpu::BindGroupLayout,
     bgl_2: wgpu::BindGroupLayout,
     bgl_3: wgpu::BindGroupLayout,
+    reflection_bgl_1: wgpu::BindGroupLayout,
+    reflection_bgl_2: wgpu::BindGroupLayout,
     bind_group_0: wgpu::BindGroup,
     bind_group_1: Option<wgpu::BindGroup>,
     bind_group_2: Option<wgpu::BindGroup>,
     bind_group_3: Option<wgpu::BindGroup>,
-    bind_group_1_key: Option<(usize, usize, usize, usize, usize, usize, usize, usize)>,
+    reflection_bind_group_1: Option<wgpu::BindGroup>,
+    reflection_bind_group_2: Option<wgpu::BindGroup>,
+    bind_group_1_key: Option<[usize; 9]>,
     bind_group_2_key:
         Option<[usize; 14]>,
     bind_group_3_key: Option<(usize, usize)>,
+    reflection_bind_group_1_key: Option<(usize, usize, usize, usize, usize, usize)>,
+    reflection_bind_group_2_key: Option<(usize, usize, usize, usize, usize, usize)>,
     fallback_tile_lists: wgpu::Buffer,
     fallback_tile_counts: wgpu::Buffer,
     pre_aa_format: wgpu::TextureFormat,
@@ -83,8 +99,6 @@ pub struct DeferredLightPass {
     fallback_ssr_view: wgpu::TextureView,
     /// 1×1 black Rgba16Float fallback for planar reflections when not available.
     fallback_planar_view: wgpu::TextureView,
-    /// Linear clamp sampler for planar reflection blending.
-    planar_sampler: wgpu::Sampler,
     fallback_ies_view: wgpu::TextureView,
     ies_sampler: wgpu::Sampler,
     pub debug_mode: u32,
@@ -240,25 +254,8 @@ impl DeferredLightPass {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Comparison),
                     count: None,
                 },
-                // Reflection cube array: layer 6*i is capture i's cubemap.
-                wgpu::BindGroupLayoutEntry {
-                    binding: 3,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Texture {
-                        sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                        view_dimension: wgpu::TextureViewDimension::CubeArray,
-                        multisampled: false,
-                    },
-                    count: None,
-                },
                 storage_entry(4),
                 texture_entry(5, wgpu::TextureSampleType::Float { filterable: false }),
-                wgpu::BindGroupLayoutEntry {
-                    binding: 6,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
                 wgpu::BindGroupLayoutEntry {
                     binding: 7,
                     visibility: wgpu::ShaderStages::FRAGMENT,
@@ -296,19 +293,6 @@ impl DeferredLightPass {
                     ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
                     count: None,
                 },
-                // SSR accum texture (binding 14, Rgba16Float, half resolution)
-                texture_entry(14, wgpu::TextureSampleType::Float { filterable: false }),
-                // Reflection captures (binding 15), sorted largest influence first
-                storage_entry(15),
-                // Planar reflection texture (binding 16, Rgba16Float, full resolution)
-                texture_entry(16, wgpu::TextureSampleType::Float { filterable: true }),
-                // Planar reflection sampler (binding 17)
-                wgpu::BindGroupLayoutEntry {
-                    binding: 17,
-                    visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                    count: None,
-                },
                 // IES texture array (binding 18)
                 wgpu::BindGroupLayoutEntry {
                     binding: 18,
@@ -339,6 +323,65 @@ impl DeferredLightPass {
                 storage_entry(1), // tile_light_counts
             ],
         });
+
+        // Reflection composition is a second draw in the same render pass. Its
+        // deliberately narrow layouts keep this fragment stage at ten sampled
+        // textures while base deferred lighting remains at fifteen.
+        let reflection_bgl_1 = device.create_bind_group_layout(
+            &wgpu::BindGroupLayoutDescriptor {
+                label: Some("DeferredReflection BGL1"),
+                entries: &[
+                    texture_entry(1, wgpu::TextureSampleType::Float { filterable: false }),
+                    texture_entry(2, wgpu::TextureSampleType::Float { filterable: false }),
+                    texture_entry(3, wgpu::TextureSampleType::Float { filterable: false }),
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 4,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Depth,
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    texture_entry(5, wgpu::TextureSampleType::Float { filterable: true }),
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 6,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    texture_entry(7, wgpu::TextureSampleType::Float { filterable: false }),
+                ],
+            },
+        );
+        let reflection_bgl_2 = device.create_bind_group_layout(
+            &wgpu::BindGroupLayoutDescriptor {
+                label: Some("DeferredReflection BGL2"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 3,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::CubeArray,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    texture_entry(5, wgpu::TextureSampleType::Float { filterable: false }),
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 6,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    texture_entry(14, wgpu::TextureSampleType::Float { filterable: false }),
+                    storage_entry(15),
+                    texture_entry(16, wgpu::TextureSampleType::Float { filterable: true }),
+                ],
+            },
+        );
 
         let bind_group_0 = device.create_bind_group(&wgpu::BindGroupDescriptor {
             label: Some("DeferredLight BG0"),
@@ -392,6 +435,87 @@ impl DeferredLightPass {
             multiview_mask: None,
             cache: None,
         });
+        let reflection_pipeline_layout =
+            device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some("DeferredReflection PL"),
+                bind_group_layouts: &[
+                    Some(&bgl_0),
+                    Some(&reflection_bgl_1),
+                    Some(&reflection_bgl_2),
+                ],
+                immediate_size: 0,
+            });
+        let reflection_pipeline = device.create_render_pipeline(
+            &wgpu::RenderPipelineDescriptor {
+                label: Some("DeferredReflection Additive Pipeline"),
+                layout: Some(&reflection_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_reflection"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: pre_aa_format,
+                        blend: Some(wgpu::BlendState {
+                            color: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::One,
+                                dst_factor: wgpu::BlendFactor::One,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                            alpha: wgpu::BlendComponent {
+                                src_factor: wgpu::BlendFactor::Zero,
+                                dst_factor: wgpu::BlendFactor::One,
+                                operation: wgpu::BlendOperation::Add,
+                            },
+                        }),
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            },
+        );
+        let reflection_debug_pipeline = device.create_render_pipeline(
+            &wgpu::RenderPipelineDescriptor {
+                label: Some("DeferredReflection Debug Pipeline"),
+                layout: Some(&reflection_pipeline_layout),
+                vertex: wgpu::VertexState {
+                    module: &shader,
+                    entry_point: Some("vs_main"),
+                    compilation_options: Default::default(),
+                    buffers: &[],
+                },
+                fragment: Some(wgpu::FragmentState {
+                    module: &shader,
+                    entry_point: Some("fs_reflection"),
+                    compilation_options: Default::default(),
+                    targets: &[Some(wgpu::ColorTargetState {
+                        format: pre_aa_format,
+                        blend: None,
+                        write_mask: wgpu::ColorWrites::ALL,
+                    })],
+                }),
+                primitive: wgpu::PrimitiveState {
+                    topology: wgpu::PrimitiveTopology::TriangleList,
+                    ..Default::default()
+                },
+                depth_stencil: None,
+                multisample: wgpu::MultisampleState::default(),
+                multiview_mask: None,
+                cache: None,
+            },
+        );
 
         let (_fallback_shadow_tex, fallback_shadow_view) = fallback_shadow_texture(device);
         let (_fallback_static_shadow_tex, fallback_static_shadow_view) = fallback_shadow_texture(device);
@@ -415,7 +539,7 @@ impl DeferredLightPass {
             compare: None, // No comparison - returns actual depth values for PCSS blocker search
             ..Default::default()
         });
-        let (fallback_env_texture, fallback_env_view) = black_cube_texture(device, queue);
+        let (_fallback_env_texture, fallback_env_view) = black_cube_texture(device, queue);
         let fallback_env_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("Deferred Env Sampler"),
             address_mode_u: wgpu::AddressMode::ClampToEdge,
@@ -426,11 +550,11 @@ impl DeferredLightPass {
             mipmap_filter: wgpu::MipmapFilterMode::Nearest,
             ..Default::default()
         });
-        let (fallback_rc_texture, fallback_rc_view) =
+        let (_fallback_rc_texture, fallback_rc_view) =
             black_2d_texture(device, queue, "Deferred Fallback RC");
 
         // Fallback caustics texture (black 1x1 RGBA16Float)
-        let (fallback_caustics_texture, fallback_caustics_view) =
+        let (_fallback_caustics_texture, fallback_caustics_view) =
             black_2d_texture(device, queue, "Deferred Fallback Caustics");
 
         // Caustics sampler
@@ -550,7 +674,7 @@ impl DeferredLightPass {
 
         // Fallback 1×1 black Rgba16Float lightmap texture.
         // Used when baked lightmap is not available (no indirect lighting).
-        let (fallback_lightmap_tex, fallback_lightmap_view) =
+        let (_fallback_lightmap_tex, fallback_lightmap_view) =
             black_2d_texture(device, queue, "Deferred Fallback Lightmap");
         let fallback_lightmap_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
             label: Some("Deferred Fallback Lightmap Sampler"),
@@ -568,18 +692,6 @@ impl DeferredLightPass {
         // Fallback 1×1 black Rgba16Float planar reflection texture.
         let (_fallback_planar_texture, fallback_planar_view) =
             black_2d_texture(device, queue, "Deferred Fallback Planar");
-
-        // Linear clamp sampler for planar reflection texture.
-        let planar_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
-            label: Some("Deferred Planar Sampler"),
-            address_mode_u: wgpu::AddressMode::ClampToEdge,
-            address_mode_v: wgpu::AddressMode::ClampToEdge,
-            address_mode_w: wgpu::AddressMode::ClampToEdge,
-            mag_filter: wgpu::FilterMode::Linear,
-            min_filter: wgpu::FilterMode::Linear,
-            mipmap_filter: wgpu::MipmapFilterMode::Linear,
-            ..Default::default()
-        });
 
         // Fallback 1×1 zero Rg16Float lightmap UV texture.
         // Used when lightmap UVs are not available from GBuffer.
@@ -608,19 +720,26 @@ impl DeferredLightPass {
 
         Self {
             pipeline,
+            reflection_pipeline,
+            reflection_debug_pipeline,
             globals_buf,
             shadow_config_buf,
-            bgl_0,
             bgl_1,
             bgl_2,
             bgl_3,
+            reflection_bgl_1,
+            reflection_bgl_2,
             bind_group_0,
             bind_group_1: None,
             bind_group_2: None,
             bind_group_3: None,
+            reflection_bind_group_1: None,
+            reflection_bind_group_2: None,
             bind_group_1_key: None,
             bind_group_2_key: None,
             bind_group_3_key: None,
+            reflection_bind_group_1_key: None,
+            reflection_bind_group_2_key: None,
             fallback_tile_lists,
             fallback_tile_counts,
             pre_aa_format,
@@ -641,7 +760,6 @@ impl DeferredLightPass {
             fallback_lightmap_uv_view,
             fallback_ssr_view,
             fallback_planar_view,
-            planar_sampler,
             fallback_ies_view,
             ies_sampler,
             debug_mode: 0,
@@ -653,6 +771,7 @@ impl DeferredLightPass {
     /// - 0  = normal PBR lighting
     /// - 10 = shadow factor greyscale (white=lit, black=shadowed)
     /// - 11 = raw shadow atlas depth slice 0 (unmipped, linear)
+    ///
     /// Enable/disable the environment-cubemap indirect specular term.
     pub fn set_env_reflections(&mut self, enabled: bool) {
         self.enable_env_reflections = enabled;
@@ -810,16 +929,17 @@ impl RenderPass for DeferredLightPass {
         let sss_view = ctx.resources.gbuffer_sss.get().unwrap_or(&self.fallback_lightmap_uv_view);
         let extra_view = ctx.resources.gbuffer_extra.get().unwrap_or(&self.fallback_lightmap_uv_view);
 
-        let gbuffer_key = (
+        let gbuffer_key = [
             gbuffer.albedo as *const _ as usize,
             gbuffer.normal as *const _ as usize,
             gbuffer.orm as *const _ as usize,
             gbuffer.emissive as *const _ as usize,
             ctx.depth as *const _ as usize,
             ao_view as *const _ as usize,
+            lightmap_uv_view as *const _ as usize,
             sss_view as *const _ as usize,
             extra_view as *const _ as usize,
-        );
+        ];
         if self.bind_group_1_key != Some(gbuffer_key) {
             self.bind_group_1 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("DeferredLight BG1"),
@@ -850,6 +970,39 @@ impl RenderPass for DeferredLightPass {
             self.bind_group_1_key = Some(gbuffer_key);
         }
 
+        let reflection_gbuffer_key = (
+            gbuffer.normal as *const _ as usize,
+            gbuffer.orm as *const _ as usize,
+            gbuffer.emissive as *const _ as usize,
+            ctx.depth as *const _ as usize,
+            ao_view as *const _ as usize,
+            lightmap_uv_view as *const _ as usize,
+        );
+        if self.reflection_bind_group_1_key != Some(reflection_gbuffer_key) {
+            self.reflection_bind_group_1 = Some(ctx.device.create_bind_group(
+                &wgpu::BindGroupDescriptor {
+                    label: Some("DeferredReflection BG1"),
+                    layout: &self.reflection_bgl_1,
+                    entries: &[
+                        texture_view_entry(1, gbuffer.normal),
+                        texture_view_entry(2, gbuffer.orm),
+                        texture_view_entry(3, gbuffer.emissive),
+                        wgpu::BindGroupEntry {
+                            binding: 4,
+                            resource: wgpu::BindingResource::TextureView(ctx.depth),
+                        },
+                        texture_view_entry(5, ao_view),
+                        wgpu::BindGroupEntry {
+                            binding: 6,
+                            resource: wgpu::BindingResource::Sampler(&self.fallback_ao_sampler),
+                        },
+                        texture_view_entry(7, lightmap_uv_view),
+                    ],
+                },
+            ));
+            self.reflection_bind_group_1_key = Some(reflection_gbuffer_key);
+        }
+
         let shadow_view = ctx.resources.shadow_atlas.get().unwrap_or(&self.fallback_shadow_view);
         let static_shadow_view = ctx.resources.static_shadow_atlas.get().unwrap_or(&self.fallback_static_shadow_view);
         let shadow_sampler = ctx
@@ -875,6 +1028,22 @@ impl RenderPass for DeferredLightPass {
         let lightmap_view = ctx.resources.baked_lightmap.get().unwrap_or(&self.fallback_lightmap_view);
         let lightmap_sampler = ctx.resources.baked_lightmap_sampler.get().unwrap_or(&self.fallback_lightmap_sampler);
 
+        let caustics_view = ctx
+            .resources
+            .water_caustics
+            .get()
+            .unwrap_or(&self.fallback_caustics_view);
+        let water_volumes = ctx
+            .resources
+            .water_volumes
+            .get()
+            .unwrap_or(&self.fallback_water_volumes);
+        let ies_view = ctx
+            .resources
+            .ies_textures
+            .get()
+            .unwrap_or(&self.fallback_ies_view);
+
         // SSR texture from SsrPass
         let ssr_view = ctx.resources.ssr_trace.get().unwrap_or(&self.fallback_ssr_view);
         // Planar reflection texture from PlanarReflectionPass
@@ -883,17 +1052,17 @@ impl RenderPass for DeferredLightPass {
         let scene_key = [
             ctx.scene.lights as *const _ as usize,
             shadow_view as *const _ as usize,
-            static_shadow_view as *const _ as usize,
             shadow_sampler as *const _ as usize,
-            env_view as *const _ as usize,
             ctx.scene.shadow_matrices as *const _ as usize,
             rc_view as *const _ as usize,
-            ssr_view as *const _ as usize,
-            env_sampler as *const _ as usize,
-            ctx.scene.reflection_captures as *const _ as usize,
-            planar_view as *const _ as usize,
-            &self.planar_sampler as *const _ as usize,
-            &self.fallback_ies_view as *const _ as usize,
+            &self.shadow_depth_sampler as *const _ as usize,
+            caustics_view as *const _ as usize,
+            &self.caustics_sampler as *const _ as usize,
+            water_volumes as *const _ as usize,
+            static_shadow_view as *const _ as usize,
+            lightmap_view as *const _ as usize,
+            lightmap_sampler as *const _ as usize,
+            ies_view as *const _ as usize,
             &self.ies_sampler as *const _ as usize,
         ];
         if self.bind_group_2_key != Some(scene_key) {
@@ -913,22 +1082,17 @@ impl RenderPass for DeferredLightPass {
                         binding: 2,
                         resource: wgpu::BindingResource::Sampler(shadow_sampler),
                     },
-                    texture_view_entry(3, env_view),
                     wgpu::BindGroupEntry {
                         binding: 4,
                         resource: ctx.scene.shadow_matrices.as_entire_binding(),
                     },
                     texture_view_entry(5, rc_view),
                     wgpu::BindGroupEntry {
-                        binding: 6,
-                        resource: wgpu::BindingResource::Sampler(env_sampler),
-                    },
-                    wgpu::BindGroupEntry {
                         binding: 7,
                         resource: wgpu::BindingResource::Sampler(&self.shadow_depth_sampler),
                     },
                     // Water caustics texture (binding 8)
-                    texture_view_entry(8, ctx.resources.water_caustics.get().unwrap_or(&self.fallback_caustics_view)),
+                    texture_view_entry(8, caustics_view),
                     // Caustics sampler (binding 9)
                     wgpu::BindGroupEntry {
                         binding: 9,
@@ -937,7 +1101,7 @@ impl RenderPass for DeferredLightPass {
                     // Water volumes buffer (binding 10)
                     wgpu::BindGroupEntry {
                         binding: 10,
-                        resource: ctx.resources.water_volumes.get().unwrap_or(&self.fallback_water_volumes).as_entire_binding(),
+                        resource: water_volumes.as_entire_binding(),
                     },
                     // Static shadow atlas (binding 11) — cached, only changes with Static topology
                     texture_view_entry(11, static_shadow_view),
@@ -948,24 +1112,11 @@ impl RenderPass for DeferredLightPass {
                         binding: 13,
                         resource: wgpu::BindingResource::Sampler(lightmap_sampler),
                     },
-                    // SSR accum texture (binding 14)
-                    texture_view_entry(14, ssr_view),
-                    wgpu::BindGroupEntry {
-                        binding: 15,
-                        resource: ctx.scene.reflection_captures.as_entire_binding(),
-                    },
-                    // Planar reflection texture (binding 16)
-                    texture_view_entry(16, planar_view),
-                    // Planar reflection sampler (binding 17)
-                    wgpu::BindGroupEntry {
-                        binding: 17,
-                        resource: wgpu::BindingResource::Sampler(&self.planar_sampler),
-                    },
                     // IES textures (binding 18) — from frame resources, fallback to identity
                     wgpu::BindGroupEntry {
                         binding: 18,
                         resource: wgpu::BindingResource::TextureView(
-                            ctx.resources.ies_textures.get().unwrap_or(&self.fallback_ies_view)
+                            ies_view
                         ),
                     },
                     // IES sampler (binding 19)
@@ -976,6 +1127,38 @@ impl RenderPass for DeferredLightPass {
                 ],
             }));
             self.bind_group_2_key = Some(scene_key);
+        }
+
+        let reflection_scene_key = (
+            env_view as *const _ as usize,
+            rc_view as *const _ as usize,
+            env_sampler as *const _ as usize,
+            ssr_view as *const _ as usize,
+            ctx.scene.reflection_captures as *const _ as usize,
+            planar_view as *const _ as usize,
+        );
+        if self.reflection_bind_group_2_key != Some(reflection_scene_key) {
+            self.reflection_bind_group_2 = Some(ctx.device.create_bind_group(
+                &wgpu::BindGroupDescriptor {
+                    label: Some("DeferredReflection BG2"),
+                    layout: &self.reflection_bgl_2,
+                    entries: &[
+                        texture_view_entry(3, env_view),
+                        texture_view_entry(5, rc_view),
+                        wgpu::BindGroupEntry {
+                            binding: 6,
+                            resource: wgpu::BindingResource::Sampler(env_sampler),
+                        },
+                        texture_view_entry(14, ssr_view),
+                        wgpu::BindGroupEntry {
+                            binding: 15,
+                            resource: ctx.scene.reflection_captures.as_entire_binding(),
+                        },
+                        texture_view_entry(16, planar_view),
+                    ],
+                },
+            ));
+            self.reflection_bind_group_2_key = Some(reflection_scene_key);
         }
 
         // ── Bind group 3: tile light culling results ──────────────────────────
@@ -1000,6 +1183,17 @@ impl RenderPass for DeferredLightPass {
         rp.set_bind_group(1, self.bind_group_1.as_ref().unwrap(), &[]);
         rp.set_bind_group(2, self.bind_group_2.as_ref().unwrap(), &[]);
         rp.set_bind_group(3, self.bind_group_3.as_ref().unwrap(), &[]);
+        rp.draw(0..3, 0..1);
+
+        let reflection_pipeline = if matches!(self.debug_mode, 30 | 31) {
+            &self.reflection_debug_pipeline
+        } else {
+            &self.reflection_pipeline
+        };
+        rp.set_pipeline(reflection_pipeline);
+        rp.set_bind_group(0, &self.bind_group_0, &[]);
+        rp.set_bind_group(1, self.reflection_bind_group_1.as_ref().unwrap(), &[]);
+        rp.set_bind_group(2, self.reflection_bind_group_2.as_ref().unwrap(), &[]);
         rp.draw(0..3, 0..1);
         Ok(())
     }

--- a/crates/passes/3d/helio-pass-forward-lit/src/lib.rs
+++ b/crates/passes/3d/helio-pass-forward-lit/src/lib.rs
@@ -5,14 +5,6 @@ use helio::radiant::{RadiantShaderCache, RadiantShaderKey};
 use helio_core::graph::{ResourceBuilder, ResourceSize};
 use helio_core::{PassContext, PrepareContext, RenderPass, Result as HelioResult};
 
-#[cfg(not(target_arch = "wasm32"))]
-use std::num::NonZeroU32;
-
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android")))]
-const MAX_TEXTURES: usize = 256;
-#[cfg(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android"))]
-const MAX_TEXTURES: usize = 16;
-
 const TILE_SIZE: u32 = 16;
 
 #[repr(C)]
@@ -30,6 +22,7 @@ struct ForwardLitGlobals {
 }
 
 pub struct ForwardLitPass {
+    material_binding: libhelio::MaterialBindingConfig,
     pipelines: HashMap<RadiantShaderKey, wgpu::RenderPipeline>,
     shader_cache: RadiantShaderCache,
     /// This pass's own class-0 override (never synced from the scene).
@@ -55,6 +48,7 @@ pub struct ForwardLitPass {
 
 impl ForwardLitPass {
     pub fn new(device: &wgpu::Device, surface_format: wgpu::TextureFormat) -> Self {
+        let material_binding = libhelio::MaterialBindingConfig::for_device(device);
         let globals_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("ForwardLitGlobals"),
             size: std::mem::size_of::<ForwardLitGlobals>() as u64,
@@ -139,7 +133,7 @@ impl ForwardLitPass {
                 ],
             });
 
-        let bind_group_layout_1 = create_material_bgl(device);
+        let bind_group_layout_1 = create_material_bgl(device, material_binding);
 
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("ForwardLit PL"),
@@ -171,6 +165,7 @@ impl ForwardLitPass {
         };
 
         Self {
+            material_binding,
             pipelines: HashMap::new(),
             shader_cache: RadiantShaderCache::new(),
             local_class0,
@@ -215,7 +210,12 @@ impl ForwardLitPass {
                 &self.local_class0
             });
             let module = self.shader_cache.get_or_compile(
-                device, key, template, graph_wgsl, MAX_TEXTURES, "ForwardLit Shader",
+                device,
+                key,
+                template,
+                graph_wgsl,
+                self.material_binding,
+                "ForwardLit Shader",
             );
             let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
                 label: Some("ForwardLit Pipeline"),
@@ -477,36 +477,12 @@ impl RenderPass for ForwardLitPass {
                     resource: ms.material_textures.material_textures.as_entire_binding(),
                 },
             ];
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureViewArray(
-                        ms.material_textures.texture_views,
-                    ),
-                });
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: wgpu::BindingResource::SamplerArray(
-                        ms.material_textures.samplers,
-                    ),
-                });
-            }
-            #[cfg(target_arch = "wasm32")]
-            {
-                for (index, view) in ms.material_textures.texture_views.iter().enumerate() {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + index as u32,
-                        resource: wgpu::BindingResource::TextureView(view),
-                    });
-                }
-                for (index, sampler) in ms.material_textures.samplers.iter().enumerate() {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                        resource: wgpu::BindingResource::Sampler(sampler),
-                    });
-                }
-            }
+            self.material_binding.append_bind_group_entries(
+                &mut entries,
+                2,
+                ms.material_textures.texture_views,
+                ms.material_textures.samplers,
+            );
             self.bind_group_1 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("ForwardLit BG 1"),
                 layout: &self.bind_group_layout_1,
@@ -595,11 +571,10 @@ impl RenderPass for ForwardLitPass {
     }
 }
 
-fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    #[cfg(not(target_arch = "wasm32"))]
-    let texture_array_count =
-        NonZeroU32::new(MAX_TEXTURES as u32).expect("non-zero texture table size");
-
+fn create_material_bgl(
+    device: &wgpu::Device,
+    material_binding: libhelio::MaterialBindingConfig,
+) -> wgpu::BindGroupLayout {
     let mut entries = vec![
         wgpu::BindGroupLayoutEntry {
             binding: 0,
@@ -622,48 +597,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
             count: None,
         },
     ];
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 2,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Texture {
-                sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                view_dimension: wgpu::TextureViewDimension::D2,
-                multisampled: false,
-            },
-            count: Some(texture_array_count),
-        });
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 3,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-            count: Some(texture_array_count),
-        });
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: None,
-            });
-        }
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            });
-        }
-    }
+    material_binding.append_layout_entries(&mut entries, 2, wgpu::ShaderStages::FRAGMENT);
 
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("ForwardLit BGL 1"),

--- a/crates/passes/3d/helio-pass-gbuffer/src/lib.rs
+++ b/crates/passes/3d/helio-pass-gbuffer/src/lib.rs
@@ -34,15 +34,6 @@ use helio_core::{
     DebugViewDescriptor, PassContext, PrepareContext, RenderPass, Result as HelioResult,
 };
 use std::collections::HashMap;
-#[cfg(not(target_arch = "wasm32"))]
-use std::num::NonZeroU32;
-
-/// Bindless texture array size per shader stage.
-/// Capped at 16 on wasm32, Apple native Metal, and Android; 256 on other desktop backends.
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android")))]
-const MAX_TEXTURES: usize = 256;
-#[cfg(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android"))]
-const MAX_TEXTURES: usize = 16;
 
 // ── Uniform types ─────────────────────────────────────────────────────────────
 
@@ -67,6 +58,7 @@ pub struct GBufferGlobals {
 // ── Pass struct ───────────────────────────────────────────────────────────────
 
 pub struct GBufferPass {
+    material_binding: libhelio::MaterialBindingConfig,
     pipelines: HashMap<RadiantShaderKey, wgpu::RenderPipeline>,
     shader_cache: RadiantShaderCache,
     /// Shared with the renderer and GPU scene — never deep-cloned (see
@@ -100,6 +92,7 @@ pub struct GBufferPass {
 impl GBufferPass {
     /// Create the GBuffer pass.
     pub fn new(device: &wgpu::Device) -> Self {
+        let material_binding = libhelio::MaterialBindingConfig::for_device(device);
         // ── Globals buffer ────────────────────────────────────────────────────
         let globals_buf = device.create_buffer(&wgpu::BufferDescriptor {
             label: Some("GBufferGlobals"),
@@ -174,7 +167,7 @@ impl GBufferPass {
             });
 
         // ── Bind Group Layout 1: material + textures ──────────────────────────
-        let bind_group_layout_1 = create_material_bgl(device);
+        let bind_group_layout_1 = create_material_bgl(device, material_binding);
 
         // ── Pipeline layout (shared by all pipeline variants) ─────────────────
         let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
@@ -193,6 +186,7 @@ impl GBufferPass {
         });
 
         Self {
+            material_binding,
             pipelines: HashMap::new(),
             shader_cache: RadiantShaderCache::new(),
             template_registry: None,
@@ -483,41 +477,12 @@ impl RenderPass for GBufferPass {
                         .as_entire_binding(),
                 },
             ];
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureViewArray(
-                        main_scene.material_textures.texture_views,
-                    ),
-                });
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: wgpu::BindingResource::SamplerArray(
-                        main_scene.material_textures.samplers,
-                    ),
-                });
-            }
-            #[cfg(target_arch = "wasm32")]
-            {
-                for (index, view) in main_scene
-                    .material_textures
-                    .texture_views
-                    .iter()
-                    .enumerate()
-                {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + index as u32,
-                        resource: wgpu::BindingResource::TextureView(view),
-                    });
-                }
-                for (index, sampler) in main_scene.material_textures.samplers.iter().enumerate() {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                        resource: wgpu::BindingResource::Sampler(sampler),
-                    });
-                }
-            }
+            self.material_binding.append_bind_group_entries(
+                &mut entries,
+                2,
+                main_scene.material_textures.texture_views,
+                main_scene.material_textures.samplers,
+            );
             self.bind_group_1 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("GBuffer BG 1"),
                 layout: &self.bind_group_layout_1,
@@ -716,7 +681,7 @@ impl GBufferPass {
                 key,
                 template,
                 graph_wgsl,
-                MAX_TEXTURES,
+                self.material_binding,
                 "GBuffer Shader",
             );
             let pipeline = device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
@@ -846,11 +811,10 @@ impl GBufferPass {
 // Both GBufferPass and TransparentPass need the same material bind group layout.
 // This should be moved to a shared crate (helio-core or libhelio) so neither
 // pass depends on the other for basic infrastructure.
-pub fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    #[cfg(not(target_arch = "wasm32"))]
-    let texture_array_count =
-        NonZeroU32::new(MAX_TEXTURES as u32).expect("non-zero texture table size");
-
+pub fn create_material_bgl(
+    device: &wgpu::Device,
+    material_binding: libhelio::MaterialBindingConfig,
+) -> wgpu::BindGroupLayout {
     let mut entries = vec![
         wgpu::BindGroupLayoutEntry {
             binding: 0,
@@ -873,48 +837,7 @@ pub fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
             count: None,
         },
     ];
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 2,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Texture {
-                sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                view_dimension: wgpu::TextureViewDimension::D2,
-                multisampled: false,
-            },
-            count: Some(texture_array_count),
-        });
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 3,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-            count: Some(texture_array_count),
-        });
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: None,
-            });
-        }
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            });
-        }
-    }
+    material_binding.append_layout_entries(&mut entries, 2, wgpu::ShaderStages::FRAGMENT);
 
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("GBuffer BGL 1"),

--- a/crates/passes/3d/helio-pass-transparent/src/lib.rs
+++ b/crates/passes/3d/helio-pass-transparent/src/lib.rs
@@ -371,7 +371,12 @@ impl TransparentPass {
                 &self.local_class0
             });
             let module = self.shader_cache.get_or_compile(
-                device, key, template, graph_wgsl, 16, "Transparent Shader",
+                device,
+                key,
+                template,
+                graph_wgsl,
+                libhelio::MaterialBindingConfig::for_device(device),
+                "Transparent Shader",
             );
             let alpha_blend = wgpu::BlendState {
                 color: wgpu::BlendComponent {

--- a/crates/passes/3d/helio-pass-virtual-geometry/src/lib.rs
+++ b/crates/passes/3d/helio-pass-virtual-geometry/src/lib.rs
@@ -9,13 +9,6 @@ use helio_core::GpuInstanceData;
 // Constants
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Bindless texture array size per shader stage.
-/// Capped at 16 on wasm32, Apple native Metal, and Android; 256 on other desktop backends.
-#[cfg(not(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android")))]
-pub(crate) const MAX_TEXTURES: usize = 256;
-#[cfg(any(target_arch = "wasm32", target_os = "macos", target_os = "ios", target_os = "android"))]
-pub(crate) const MAX_TEXTURES: usize = 16;
-
 pub const LOD_LEVEL_COUNT: u32 = 8;
 
 /// Draw publication counters written by the GPU cull stages.

--- a/crates/passes/3d/helio-pass-virtual-geometry/src/rendering.rs
+++ b/crates/passes/3d/helio-pass-virtual-geometry/src/rendering.rs
@@ -1,10 +1,7 @@
-#[cfg(not(target_arch = "wasm32"))]
-use std::num::NonZeroU32;
-
 use crate::{
     CullUniforms, InstanceCullData, LodQuality, VgGlobals, VirtualGeometryBudget,
     VirtualGeometryDebugStats, DRAW_COUNTER_BYTES, INITIAL_INSTANCES, INITIAL_MESHLETS,
-    INITIAL_OBJECTS, MAX_TEXTURES,
+    INITIAL_OBJECTS,
 };
 use helio_core::graph::ResourceBuilder;
 use helio_core::{
@@ -24,6 +21,7 @@ enum DebugReadbackState {
 }
 
 pub struct VirtualGeometryPass {
+    pub(crate) material_binding: libhelio::MaterialBindingConfig,
     pub(crate) select_pipeline: wgpu::ComputePipeline,
     pub(crate) cull_pipeline: wgpu::ComputePipeline,
     pub(crate) cull_bgl: wgpu::BindGroupLayout,
@@ -76,6 +74,7 @@ impl VirtualGeometryPass {
         camera_buf: &wgpu::Buffer,
         budget: VirtualGeometryBudget,
     ) -> Self {
+        let material_binding = libhelio::MaterialBindingConfig::for_device(device);
         let cull_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("VG Cull Shader"),
             source: wgpu::ShaderSource::Wgsl(include_str!("../shaders/vg_cull.wgsl").into()),
@@ -84,15 +83,26 @@ impl VirtualGeometryPass {
             let s = include_str!("../shaders/vg_gbuffer.wgsl")
                 .replace(
                     "binding_array<texture_2d<f32>, 256>",
-                    &format!("binding_array<texture_2d<f32>, {MAX_TEXTURES}>"),
+                    &format!(
+                        "binding_array<texture_2d<f32>, {}>",
+                        material_binding.max_textures
+                    ),
                 )
                 .replace(
                     "binding_array<sampler, 256>",
-                    &format!("binding_array<sampler, {MAX_TEXTURES}>"),
+                    &format!(
+                        "binding_array<sampler, {}>",
+                        material_binding.max_textures
+                    ),
                 );
-            #[cfg(target_arch = "wasm32")]
-            let s = libhelio::shader::apply_webgpu_material_bindings(&s, MAX_TEXTURES);
-            s
+            if material_binding.uses_binding_arrays() {
+                s
+            } else {
+                libhelio::shader::apply_webgpu_material_bindings(
+                    &s,
+                    material_binding.max_textures,
+                )
+            }
         };
         let draw_shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("VG GBuffer Shader"),
@@ -346,7 +356,7 @@ impl VirtualGeometryPass {
             ],
         }));
 
-        let draw_bgl_1 = create_material_bgl(device);
+        let draw_bgl_1 = create_material_bgl(device, material_binding);
 
         let draw_pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
             label: Some("VG Draw PL"),
@@ -514,6 +524,7 @@ impl VirtualGeometryPass {
         });
 
         Self {
+            material_binding,
             select_pipeline,
             cull_pipeline,
             cull_bgl,
@@ -961,41 +972,12 @@ impl RenderPass for VirtualGeometryPass {
                         .as_entire_binding(),
                 },
             ];
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 2,
-                    resource: wgpu::BindingResource::TextureViewArray(
-                        main_scene.material_textures.texture_views,
-                    ),
-                });
-                entries.push(wgpu::BindGroupEntry {
-                    binding: 3,
-                    resource: wgpu::BindingResource::SamplerArray(
-                        main_scene.material_textures.samplers,
-                    ),
-                });
-            }
-            #[cfg(target_arch = "wasm32")]
-            {
-                for (index, view) in main_scene
-                    .material_textures
-                    .texture_views
-                    .iter()
-                    .enumerate()
-                {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + index as u32,
-                        resource: wgpu::BindingResource::TextureView(view),
-                    });
-                }
-                for (index, sampler) in main_scene.material_textures.samplers.iter().enumerate() {
-                    entries.push(wgpu::BindGroupEntry {
-                        binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                        resource: wgpu::BindingResource::Sampler(sampler),
-                    });
-                }
-            }
+            self.material_binding.append_bind_group_entries(
+                &mut entries,
+                2,
+                main_scene.material_textures.texture_views,
+                main_scene.material_textures.samplers,
+            );
             self.draw_bg_1 = Some(ctx.device.create_bind_group(&wgpu::BindGroupDescriptor {
                 label: Some("VG Draw BG1"),
                 layout: &self.draw_bgl_1,
@@ -1383,9 +1365,10 @@ impl RenderPass for VirtualGeometryPass {
 // Helpers
 // ═══════════════════════════════════════════════════════════════════════════════
 
-fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-    #[cfg(not(target_arch = "wasm32"))]
-    let count = NonZeroU32::new(MAX_TEXTURES as u32).expect("non-zero");
+fn create_material_bgl(
+    device: &wgpu::Device,
+    material_binding: libhelio::MaterialBindingConfig,
+) -> wgpu::BindGroupLayout {
     let mut entries = vec![
         wgpu::BindGroupLayoutEntry {
             binding: 0,
@@ -1408,48 +1391,7 @@ fn create_material_bgl(device: &wgpu::Device) -> wgpu::BindGroupLayout {
             count: None,
         },
     ];
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 2,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Texture {
-                sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                view_dimension: wgpu::TextureViewDimension::D2,
-                multisampled: false,
-            },
-            count: Some(count),
-        });
-        entries.push(wgpu::BindGroupLayoutEntry {
-            binding: 3,
-            visibility: wgpu::ShaderStages::FRAGMENT,
-            ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-            count: Some(count),
-        });
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Texture {
-                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
-                    view_dimension: wgpu::TextureViewDimension::D2,
-                    multisampled: false,
-                },
-                count: None,
-            });
-        }
-        for index in 0..MAX_TEXTURES {
-            entries.push(wgpu::BindGroupLayoutEntry {
-                binding: 2 + MAX_TEXTURES as u32 + index as u32,
-                visibility: wgpu::ShaderStages::FRAGMENT,
-                ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
-                count: None,
-            });
-        }
-    }
+    material_binding.append_layout_entries(&mut entries, 2, wgpu::ShaderStages::FRAGMENT);
     device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
         label: Some("VG Material BGL"),
         entries: &entries,


### PR DESCRIPTION
## Summary
- select one authoritative material binding tier from device capabilities and use it consistently in scene upload, GBuffer, forward-lit, decal, virtual geometry, and Radiant shader generation
- retain the 256-entry descriptor-indexed path where the complete WGPU feature pair is available; use a complete expanded-binding path elsewhere
- reserve the five non-material texture slots used by decal collection, giving the 16-texture tier 11 material textures without exceeding its stage limit
- split deferred lighting into base-lighting and reflection-composition draws in the same render pass (15 and 10 sampled textures respectively), preserving SSR/environment/planar/RC composition and debug modes
- include lightmap, water, IES, and reflection resources in deferred bind-group cache identities so changed resources cannot reuse stale bindings

## Validation
- `cargo test -p libhelio material_binding_tests --lib`
- `cargo test -p helio renderer::config::tests --lib`
- `cargo test -p helio-pass-deferred-light --lib`
- `cargo test -p helio-default-graphs --test limited_native --test planetary_extension`
- GPU test renders the complete 37-pass default graph on an explicitly non-bindless device capped at 16 sampled textures per stage
- GPU test renders the same complete graph through the bindless tier when supported
- `cargo clippy -p helio-pass-deferred-light --lib --no-deps -- -D warnings`
- standard Clippy for the affected crates completes; repository-wide strict Clippy remains blocked by pre-existing warnings outside these changes

Closes #190
Closes #191