### PR TITLE
Add AAA-scale benchmark harness for the World<->GPU mirror bridge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,7 +198,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -209,7 +209,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2236,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3574,6 +3574,7 @@ dependencies = [
  "naga 30.0.0",
  "pollster 0.4.0",
  "pulsar_scenedb",
+ "pulsar_scenedb_derive",
  "wgpu 30.0.0",
 ]
 
@@ -4652,7 +4653,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5418,7 +5419,7 @@ dependencies = [
 [[package]]
 name = "pulsar_reflection"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=cf37ed000fedb9a01424c7e575d1d6ee30db7281#cf37ed000fedb9a01424c7e575d1d6ee30db7281"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff#b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff"
 dependencies = [
  "dashmap",
  "glam 0.33.2",
@@ -5434,7 +5435,7 @@ dependencies = [
 [[package]]
 name = "pulsar_reflection_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=cf37ed000fedb9a01424c7e575d1d6ee30db7281#cf37ed000fedb9a01424c7e575d1d6ee30db7281"
+source = "git+https://github.com/Far-Beyond-Pulsar/Pulsar-Reflection?rev=b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff#b9dd888d84fd5e0724f8c6cc8abcbb10c351e5ff"
 dependencies = [
  "owo-colors",
  "proc-macro2",
@@ -5445,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#89e21e7b81ccc0ce890dddc6f0fa100625ff81a2"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#91c420a4ccb96a38f981d36eddf169f998c89159"
 dependencies = [
  "ahash",
  "profiling 0.1.0",
@@ -5453,6 +5454,16 @@ dependencies = [
  "serde_json",
  "tracing",
  "wgpu 30.0.0",
+]
+
+[[package]]
+name = "pulsar_scenedb_derive"
+version = "0.1.0"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#91c420a4ccb96a38f981d36eddf169f998c89159"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5892,7 +5903,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7483,7 +7494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/helio-scenedb/Cargo.toml
+++ b/crates/helio-scenedb/Cargo.toml
@@ -5,6 +5,20 @@ edition = "2021"
 description = "Helio <-> SceneDB binding seam: SceneDbBinding binds SceneDB-owned GPU buffers into Helio's bind-group model (M3-a T9, design Rev 2 S5)"
 license = "MIT OR Apache-2.0"
 
+[features]
+# `#[derive(SceneStore)]`'s generated code (`pulsar_scenedb_derive`) wraps
+# its GPU-column methods (`register_gpu_columns_growable`,
+# `packed_gpu_component_id`, the world-mirror dispatch registration, ...)
+# in `#[cfg(feature = "gpu")]`. That `cfg` attribute, once spliced into
+# THIS crate's compilation unit by macro expansion, checks THIS crate's
+# own Cargo features -- not `pulsar_scenedb`'s -- so any crate other than
+# `pulsar_scenedb` itself that uses the derive needs its own "gpu" feature
+# of that exact name to make the generated methods compile at all. This
+# crate is unconditionally GPU-oriented (the whole point of the
+# Helio<->SceneDB seam), so "gpu" is on by default rather than opt-in.
+default = ["gpu"]
+gpu = []
+
 [dependencies]
 pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", features = ["gpu"] }
 # Helio's workspace wgpu = 30 (crates.io) -- MUST resolve to the same major
@@ -31,6 +45,9 @@ bytemuck = { workspace = true }
 
 [dev-dependencies]
 pollster = { workspace = true }
+# World-mirror scale benchmark (world_mirror_scale.rs, Helio#211) needs
+# #[derive(SceneStore)] to define its own bench fixture components.
+pulsar_scenedb_derive = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB" }
 # naga tracks the same major as Helio's workspace wgpu (crates.io 30) — the
 # Test 3 reflection harness (`tests/binding_layout.rs`, M3-a T10) parses
 # `wgsl::SCENE_BINDINGS_WGSL` with naga's WGSL front end and reflects struct
@@ -45,4 +62,15 @@ naga = { version = "30", features = ["wgsl-in"] }
 # size/statistics and printing a table, not a criterion harness.
 [[bench]]
 name = "pass_timing"
+harness = false
+
+# Helio#211: AAA-scale measurement for the World<->GPU mirror bridge
+# (pulsar_scenedb#24 + follow-ups) -- spawn throughput, sustained churn,
+# reallocation latency, concurrent buffer access, flush cost vs. dirty
+# fraction, swept across realistic entity counts. `harness = false`, same
+# reasoning as `pass_timing`/`legacy_model_bench` upstream: this measures
+# real wall-clock cost of GPU-submitting operations, not a pure-CPU
+# microbenchmark criterion is built for.
+[[bench]]
+name = "world_mirror_scale"
 harness = false

--- a/crates/helio-scenedb/benches/WORLD_MIRROR_SCALE_BASELINE.md
+++ b/crates/helio-scenedb/benches/WORLD_MIRROR_SCALE_BASELINE.md
@@ -1,0 +1,152 @@
+# `world_mirror_scale` reference numbers (Helio#211)
+
+Measured 2026-08-08 on the maintainer's dev machine (Windows 11,
+`cargo bench -p helio-scenedb --bench world_mirror_scale`, real GPU device,
+Vulkan backend — see the "How these were captured" note at the bottom for
+why not the workspace's default DX12 backend). **These are a human reference
+point for the Helio#212/#213/#214 prioritization decision, not a CI
+regression gate** — same status as `pulsar_scenedb`'s own `BASELINE.md`
+files upstream.
+
+## Scenario 1 — spawn throughput
+
+| N | wall time | per-entity | reallocations |
+|---|---|---|---|
+| 1,000 | 18.8 ms | 18.8 µs | 4 |
+| 10,000 | 42.3 ms | 4.2 µs | 8 |
+| 100,000 | 317.5 ms | 3.2 µs | 11 |
+| 1,000,000 | 3.083 s | 3.1 µs | 14 |
+
+Amortized per-entity cost stabilizes around ~3 µs once past a few thousand
+entities. Reallocation counts match the expected doubling sequence exactly
+(64 → 128 → … → past 1,000,000 is 14 doublings) — direct confirmation the
+growth mechanism behaves as designed, not just "eventually correct."
+
+## Scenario 2 — steady-state churn (30 simulated frames, one flush/frame)
+
+| N | churn | per-frame | vs. 16.6 ms (60 fps) budget |
+|---|---|---|---|
+| 1,000 | 1% | 30.7 µs | fine |
+| 1,000 | 10% | 341.8 µs | fine |
+| 1,000 | 50% | 1.856 ms | fine |
+| 10,000 | 1% | 390.0 µs | fine |
+| 10,000 | 10% | 3.914 ms | fine |
+| 10,000 | 50% | 21.020 ms | **over budget** |
+| 100,000 | 1% | 3.904 ms | fine (but 23% of budget) |
+| 100,000 | 10% | 44.011 ms | **over budget (2.6 frames)** |
+| 100,000 | 50% | 263.237 ms | **over budget (15.9 frames)** |
+
+**This is the headline finding for Stage 3 planning.** At 100,000 live
+entities with a realistic 10% per-frame churn rate (streamed sublevels,
+spawned/despawned effects), one frame's worth of despawn+respawn+flush
+already costs *2.6x* the entire 60fps frame budget on its own — before
+accounting for anything else the frame has to do (rendering, physics, audio,
+gameplay). 1% churn at the same scale is within budget but consumes nearly a
+quarter of it for this one subsystem alone.
+
+## Scenario 3 — single reallocation latency (isolated)
+
+| N (before) | → 2N | realloc time |
+|---|---|---|
+| 1,000 | 2,000 | 901.7 µs |
+| 10,000 | 20,000 | 3.046 ms |
+| 100,000 | 200,000 | 42.734 ms |
+
+Scales roughly linearly with the copied byte count (bandwidth-bound
+`copy_buffer_to_buffer`, as expected). **42.7 ms for one reallocation at
+100k→200k rows is over 2.5x the entire 60fps frame budget, landing wherever
+whichever `world.insert()` call happens to cross the capacity threshold** —
+direct, measured evidence for Helio#212's premise (a pre-reservation API is
+not a nice-to-have at this scale, it's necessary to avoid an unpredictable,
+severe frame hitch).
+
+**A crash, not just a slow number, at the next scale up.** Attempting
+1,000,000 → 2,000,000 rows of this benchmark's 256-byte packed fixture
+(512,000,000 bytes) panics with a real `wgpu` validation error:
+
+```
+wgpu error: Validation Error
+Caused by:
+  In Device::create_buffer, label = 'BenchInstance::packed'
+    Buffer size 512000000 is greater than the maximum buffer size (268435456)
+```
+
+Neither `DynamicGpuBuffer::ensure_capacity` nor `GrowableSceneBuffer` check
+against `wgpu::Limits::max_buffer_size` (256 MiB by default) before
+doubling — growth just keeps doubling until it hits this ceiling and panics
+outright, with no graceful failure path. **This is new scope for
+Helio#212**, not originally called out in that issue: a real, hard ceiling
+exists well within AAA-relevant entity counts for wide per-row records (a
+256-byte packed instance record hits it at 1,048,576 rows in one buffer),
+and needs either a documented capacity ceiling + graceful error, a
+device-limits increase requested at context-creation time, or splitting a
+single logical column across multiple physical buffers past the limit —
+this needs its own design decision, not just noting the number.
+
+## Scenario 4 — concurrent access to one shared buffer (bypassing `World`)
+
+| N | threads | wall time | per-write |
+|---|---|---|---|
+| 10,000 | 1 | 23.5 ms | 2.4 µs |
+| 10,000 | 4 | 37.4 ms | 3.7 µs |
+| 10,000 | 8 | 40.1 ms | 4.0 µs |
+| 10,000 | 16 | 43.1 ms | 4.3 µs |
+| 100,000 | 1 | 159.0 ms | 1.6 µs |
+| 100,000 | 4 | 283.6 ms | 2.8 µs |
+| 100,000 | 8 | 246.9 ms | 2.5 µs |
+| 100,000 | 16 | 252.9 ms | 2.5 µs |
+
+**Per-write cost gets WORSE, not better, as thread count increases** — the
+opposite of what embarrassingly-parallel disjoint-row writes should do. At
+10,000 rows, going from 1 to 16 threads makes each write ~79% slower on a
+per-write basis despite each thread touching completely disjoint rows. This
+is direct, measured confirmation that Helio#213's `RwLock`-contention
+concern is real, not speculative — the lock IS the bottleneck here, not
+useful parallelism. Justifies prioritizing #213's `mark_dirty`
+read-vs-write-lock fix and the sharding/lock-free evaluation, not just the
+"fix regardless" small item.
+
+## Scenario 5 — flush cost vs. dirty fraction
+
+| N | dirty % | flush time |
+|---|---|---|
+| 1,000 | 0% | 0.5 µs |
+| 1,000 | 1% | 1.6 µs |
+| 1,000 | 10% | 1.6 µs |
+| 1,000 | 100% | 2.0 µs |
+| 10,000 | 0% | 3.8 µs |
+| 10,000 | 1% | 5.3 µs |
+| 10,000 | 10% | 6.4 µs |
+| 10,000 | 100% | 6.9 µs |
+| 100,000 | 0% | 38.5 µs |
+| 100,000 | 1% | 59.6 µs |
+| 100,000 | 10% | 56.8 µs |
+| 100,000 | 100% | 76.9 µs |
+
+**The 0%-dirty baseline cost is real and non-trivial, and barely grows with
+dirty fraction.** At 100,000 rows, scanning for zero dirty rows already
+costs 38.5 µs — and 1% dirty (59.6 µs) costs about as much as 10% dirty
+(56.8 µs, within noise of each other), while 100% dirty (76.9 µs) is barely
+2x the 0% baseline despite touching 100x more rows. This is exactly the
+signature Helio#214 predicted: the `O(capacity)` scan dominates over the
+actual write cost across nearly the whole dirty-fraction range, meaning
+sparse per-frame changes (the realistic case for a large, mostly-static
+scene) get charged almost the full-capacity cost regardless of how little
+actually changed. Confirms #214's proposed fix (an explicit dirty-row list,
+`O(dirty)` instead of `O(capacity)`) targets a real, measured cost, not a
+theoretical one.
+
+## How these were captured — a dependency-resolution note
+
+Captured with `dx12` locally (uncommitted) removed from this workspace's
+`wgpu` feature list and the Vulkan backend used instead. Updating
+`pulsar_scenedb` to pick up the merged World-mirror work exposed a
+pre-existing, latent Cargo.lock issue — two incompatible `windows-core`
+versions (0.58.0 via `gpu-allocator`, 0.62.2 direct in `wgpu-hal` 30.0.0)
+already coexist in the checked-in lockfile, and re-resolving *anything* (not
+specifically `pulsar_scenedb`) can flip which one `wgpu-hal`'s own DX12
+module resolves against, breaking the Windows DX12 backend's compilation.
+Confirmed via clean-cache A/B testing this is unrelated to this PR's actual
+changes. Filed and tracked separately; this PR's committed `Cargo.toml` does
+**not** carry the `dx12`-disabling workaround — that was local-only, used
+solely to capture these numbers.

--- a/crates/helio-scenedb/benches/world_mirror_scale.rs
+++ b/crates/helio-scenedb/benches/world_mirror_scale.rs
@@ -1,0 +1,369 @@
+//! Helio#211: AAA-scale measurement for `pulsar_scenedb`'s World<->GPU
+//! mirror bridge (SceneDB#24 + follow-ups #25-#29, all merged) — spawn
+//! throughput, sustained churn, reallocation latency, concurrent buffer
+//! access, and flush cost vs. dirty fraction, at realistic entity counts.
+//!
+//! Run: `cargo bench -p helio-scenedb --bench world_mirror_scale`
+//!
+//! `harness = false`, matching `pass_timing.rs`/upstream `legacy_model_bench.rs`'s
+//! own choice: this measures real wall-clock cost of GPU-submitting
+//! operations end to end (CPU bookkeeping + `queue.write_buffer`/
+//! `copy_buffer_to_buffer` + submission), which is exactly what a running
+//! game pays per frame — not a pure-CPU microbenchmark criterion is tuned
+//! for, and not something a fine-grained GPU-timestamp bracket
+//! (`gpu_timing.rs`'s own approach) is the right tool for either, since the
+//! CPU-side bookkeeping (locking, dirty-marking, HashMap lookups) is very
+//! much part of the cost being measured here, not overhead to isolate away.
+//!
+//! ## A finding this benchmark surfaced before a single number was taken
+//!
+//! The original issue proposed a "concurrent mutation" scenario: N worker
+//! threads calling `world.insert()` in parallel. That scenario doesn't
+//! exist to measure — `World::insert(&mut self, ..)` takes `&mut self`, so
+//! the Rust borrow checker already prevents two threads from calling it on
+//! the same `World` concurrently; genuinely parallel `world.insert()` calls
+//! are not possible today without wrapping `World` itself in a `Mutex`
+//! (which would serialize everything at that outer lock, making the
+//! per-buffer `RwLock` inside `GrowableSceneBuffer`/`DirtyTrackedSceneBuffer`
+//! moot -- contention would show up at the `Mutex<World>`, not there).
+//!
+//! What IS reachable concurrently today: `SceneGpuStore`'s own public
+//! methods (`write_row_bytes_growing`, `mark_gpu_row_dirty`, `with_buffer`
+//! accessors) take `&self`, reachable from multiple threads via
+//! `Arc<SceneGpuStore>` without going through `World` at all -- exactly the
+//! shape a hypothetical future "parallelize the CPU-side World mutation,
+//! then scatter the GPU-mirror writes across threads afterward" API would
+//! need. [`concurrent_buffer_access`] measures THAT instead: N threads
+//! calling `write_row_bytes_growing` directly on disjoint rows of one
+//! shared, already-registered buffer. This is the honest scope of what
+//! "concurrency" means for this bridge today, and it's what Helio#213
+//! (the concurrency-model issue) should be evaluated against.
+//!
+//! ## Scale sweep
+//!
+//! {1,000 / 10,000 / 100,000} for every scenario; {1,000,000} additionally
+//! for [`spawn_throughput`] and [`reallocation_latency`] specifically (cheap
+//! enough to run at that scale in a reasonable bench wall-clock budget).
+//! [`steady_state_churn`] and [`flush_cost_vs_dirty_fraction`] run real
+//! per-frame simulation loops (tens of frames each) and would push total
+//! bench runtime past what's reasonable for a routine `cargo bench` if also
+//! run at 1M -- 100,000 is already two orders of magnitude past anything
+//! this bridge has been exercised at before this file, and is the number
+//! that matters most for the "is this safe to build Stage 3 on" question.
+//!
+//! ## A dependency-resolution landmine this file's own development tripped
+//!
+//! Building this bench (or ANY target in this workspace) after `cargo
+//! update`-ing `pulsar_scenedb` to pick up the merged World-mirror work can
+//! break `wgpu-hal`'s DX12 backend compilation on Windows -- confirmed to be
+//! a PRE-EXISTING, latent Cargo.lock issue (two incompatible `windows-core`
+//! versions already coexist in the checked-in lockfile; re-resolving
+//! ANYTHING, not specifically `pulsar_scenedb`, can flip which one
+//! `wgpu-hal`'s own code resolves against), not something this change
+//! introduces. Filed and tracked separately, not fixed here.
+
+use pulsar_scenedb::gpu::{EngineGpuContext, GpuMirrorHandle, RegionClassConfig, SceneGpuConfig, SceneGpuStore};
+use pulsar_scenedb::World;
+use pulsar_scenedb_derive::SceneStore;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Shaped like `libhelio::instance::GpuInstanceData` (208 bytes) -- the
+/// actual Stage 3 motivating case, not a toy-sized fixture. `#[gpu(layout =
+/// packed)]` so it lands in exactly one buffer, matching how Stage 3 will
+/// actually register it.
+///
+/// `#[gpu(mirror = Once)]`, not the plain `#[gpu]` (`DirtyTracked`) default
+/// -- deliberately, so `register_gpu_columns_growable` routes this through
+/// `register_growable_gpu_buffer` (the immediate/growable path) rather than
+/// `register_dirty_tracked_gpu_buffer` (deferred until an explicit
+/// `flush_gpu_mirror` call). Scenarios 1/3/4 below are specifically about
+/// `GrowableSceneBuffer`'s real reallocation cost (`copy_buffer_to_buffer`)
+/// and `write_row_bytes_growing`'s real write path -- neither of which a
+/// `DirtyTracked`-mode field would exercise without an explicit flush this
+/// file never calls for those three scenarios (scenario 5, further down,
+/// uses its own separate DirtyTracked fixture specifically to measure THAT
+/// path instead). An earlier version of this fixture used the plain
+/// `#[gpu]` default here and silently measured CPU-only dirty-marking cost
+/// for all three scenarios instead of real GPU buffer growth -- caught by
+/// noticing scenario 1's reported realloc count was 0 at every scale
+/// despite starting from a capacity of 64 and reaching 1,000,000 rows.
+#[derive(SceneStore, Clone, Copy)]
+#[gpu(layout = packed)]
+struct BenchInstance {
+    #[gpu(mirror = Once)]
+    model: [f32; 16],
+    #[gpu(mirror = Once)]
+    normal_mat: [f32; 16], // padded to match GpuInstanceData's 3x vec4 (48B) closely enough for a size-realistic fixture; exact WGSL layout doesn't matter for a CPU/GPU-bandwidth benchmark
+    #[gpu(mirror = Once)]
+    bounds: [f32; 16],
+    #[gpu(mirror = Once)]
+    mesh_material_flags: [f32; 16], // stand-in for mesh_id/material_id/flags/lightmap_index (4x u32 = 16B); using f32;16 keeps this fixture on the crate's one built-in Pod array size rather than needing a bespoke Pod impl
+}
+
+fn test_context() -> EngineGpuContext {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+        power_preference: wgpu::PowerPreference::HighPerformance,
+        compatible_surface: None,
+        force_fallback_adapter: false,
+        apply_limit_buckets: false,
+    }))
+    .expect("no adapter -- GPU bench needs a local GPU");
+    let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+        label: Some("helio-scenedb-world-mirror-scale-bench"),
+        ..Default::default()
+    }))
+    .expect("device");
+    EngineGpuContext::new(Arc::new(device), Arc::new(queue))
+}
+
+fn scene_cfg() -> SceneGpuConfig {
+    SceneGpuConfig {
+        classes: vec![RegionClassConfig { capacity: 64, max_resident_cells: 1 }],
+        tombstone_headroom: 8,
+        max_cells_metadata: 16,
+    }
+}
+
+fn sample_instance(i: u32) -> BenchInstance {
+    BenchInstance {
+        model: [i as f32; 16],
+        normal_mat: [i as f32; 16],
+        bounds: [i as f32; 16],
+        mesh_material_flags: [i as f32; 16],
+    }
+}
+
+fn fmt_dur(d: Duration) -> String {
+    if d.as_secs_f64() >= 1.0 {
+        format!("{:.3} s", d.as_secs_f64())
+    } else if d.as_micros() >= 1000 {
+        format!("{:.3} ms", d.as_secs_f64() * 1e3)
+    } else {
+        format!("{:.1} us", d.as_secs_f64() * 1e6)
+    }
+}
+
+// ── Scenario 1: spawn throughput + reallocation count ──────────────────────
+
+fn spawn_throughput() {
+    println!("\n=== Scenario 1: spawn throughput (N entities, one packed #[gpu] insert each) ===");
+    println!("{:>10} | {:>12} | {:>14} | {:>10}", "N", "wall time", "per-entity", "reallocs");
+    for &n in &[1_000u32, 10_000, 100_000, 1_000_000] {
+        let ctx = test_context();
+        let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+        // Small initial capacity -- the point is measuring growth cost as
+        // part of ordinary spawn throughput, not avoiding it via a
+        // conveniently-large upfront allocation.
+        BenchInstance::register_gpu_columns_growable(&mut store, 64, ctx.device());
+        let store = Arc::new(store);
+        let mut world = World::new();
+        world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+        let id = BenchInstance::packed_gpu_component_id();
+        let epoch_before = store.growable_epoch_for_id(id).unwrap_or(0);
+
+        let start = Instant::now();
+        for i in 0..n {
+            let e = world.spawn();
+            world.insert(e, sample_instance(i));
+        }
+        let elapsed = start.elapsed();
+
+        let epoch_after = store.growable_epoch_for_id(id).unwrap_or(0);
+        println!(
+            "{:>10} | {:>12} | {:>14} | {:>10}",
+            n,
+            fmt_dur(elapsed),
+            fmt_dur(elapsed / n),
+            epoch_after - epoch_before,
+        );
+    }
+}
+
+// ── Scenario 2: steady-state churn ──────────────────────────────────────────
+
+fn steady_state_churn() {
+    println!("\n=== Scenario 2: steady-state churn (N live entities, F frames, each frame despawns+respawns a fraction, one flush/frame) ===");
+    println!("{:>10} | {:>8} | {:>10} | {:>14} | {:>14}", "N", "churn %", "frames", "total", "per-frame");
+    const FRAMES: u32 = 30;
+    for &n in &[1_000u32, 10_000, 100_000] {
+        for &churn_pct in &[1u32, 10, 50] {
+            let ctx = test_context();
+            let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+            BenchInstance::register_gpu_columns_growable(&mut store, n, ctx.device());
+            let store = Arc::new(store);
+            let mut world = World::new();
+            world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+
+            let mut entities: Vec<_> = (0..n)
+                .map(|i| {
+                    let e = world.spawn();
+                    world.insert(e, sample_instance(i));
+                    e
+                })
+                .collect();
+
+            let churn_count = ((n as u64 * churn_pct as u64) / 100) as usize;
+            let start = Instant::now();
+            for frame in 0..FRAMES {
+                for slot in 0..churn_count {
+                    let idx = (slot * 7919 + frame as usize) % entities.len(); // deterministic pseudo-scatter, not just a contiguous prefix
+                    world.despawn(entities[idx]);
+                    let e = world.spawn();
+                    world.insert(e, sample_instance(idx as u32));
+                    entities[idx] = e;
+                }
+                world.flush_gpu_mirror(ctx.queue()).expect("mirror attached");
+            }
+            let elapsed = start.elapsed();
+            println!(
+                "{:>10} | {:>7}% | {:>10} | {:>14} | {:>14}",
+                n,
+                churn_pct,
+                FRAMES,
+                fmt_dur(elapsed),
+                fmt_dur(elapsed / FRAMES),
+            );
+        }
+    }
+}
+
+// ── Scenario 3: reallocation latency in isolation ──────────────────────────
+
+fn reallocation_latency() {
+    println!("\n=== Scenario 3: single reallocation latency (doubling N -> 2N, direct ensure_capacity-equivalent via one write past capacity) ===");
+    // NOT swept to 1,000,000 here (unlike scenarios 1/3's siblings): doubling
+    // 1,000,000 rows of this 256-byte fixture needs a 512,000,000-byte
+    // buffer, which EXCEEDS wgpu's default `Limits::max_buffer_size` (256
+    // MiB = 268,435,456 bytes) and panics with a wgpu validation error
+    // rather than failing gracefully -- confirmed empirically, not a
+    // hypothetical. Neither `DynamicGpuBuffer::ensure_capacity` nor
+    // `GrowableSceneBuffer` currently check against this limit before
+    // doubling. This is real, important evidence for Helio#212
+    // (pre-reservation/growth issue): growth needs a documented ceiling
+    // check (and either a `Result`-based failure path or a device-limits
+    // increase at context-creation time), not just "double forever."
+    println!("{:>12} | {:>12} | {:>14}", "N (before)", "-> 2N", "realloc time");
+    for &n in &[1_000u32, 10_000, 100_000] {
+        let ctx = test_context();
+        let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+        BenchInstance::register_gpu_columns_growable(&mut store, n, ctx.device());
+        let store = Arc::new(store);
+        let mut world = World::new();
+        world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+
+        // Fill to capacity N first (untimed) so the timed insert below is
+        // the one that actually crosses the threshold and triggers growth.
+        for i in 0..n {
+            let e = world.spawn();
+            world.insert(e, sample_instance(i));
+        }
+
+        let start = Instant::now();
+        let e = world.spawn();
+        world.insert(e, sample_instance(n));
+        ctx.device().poll(wgpu::PollType::wait_indefinitely()).expect("poll"); // ensure the GPU-to-GPU copy has actually landed, not just been enqueued
+        let elapsed = start.elapsed();
+
+        println!("{:>12} | {:>12} | {:>14}", n, n * 2, fmt_dur(elapsed));
+    }
+}
+
+// ── Scenario 4: concurrent buffer access (see module doc for scope) ────────
+
+fn concurrent_buffer_access() {
+    println!("\n=== Scenario 4: concurrent access to one shared, already-registered buffer (disjoint rows per thread; see module doc for why this replaces \"concurrent world.insert\") ===");
+    println!("{:>10} | {:>8} | {:>14} | {:>18}", "N total", "threads", "wall time", "per-write");
+    for &n in &[10_000u32, 100_000] {
+        for &threads in &[1u32, 4, 8, 16] {
+            let ctx = test_context();
+            let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+            BenchInstance::register_gpu_columns_growable(&mut store, n, ctx.device());
+            let store = Arc::new(store);
+            let id = BenchInstance::packed_gpu_component_id();
+            let per_thread = n / threads;
+
+            let start = Instant::now();
+            std::thread::scope(|scope| {
+                for t in 0..threads {
+                    let store = Arc::clone(&store);
+                    let queue = Arc::clone(ctx.queue());
+                    scope.spawn(move || {
+                        let base = t * per_thread;
+                        let value = sample_instance(t);
+                        let bytes: &[u8] = unsafe {
+                            std::slice::from_raw_parts(&value as *const BenchInstance as *const u8, std::mem::size_of::<BenchInstance>())
+                        };
+                        for row in base..base + per_thread {
+                            let _ = store.write_row_bytes_growing(id, &queue, bytes, row);
+                        }
+                    });
+                }
+            });
+            let elapsed = start.elapsed();
+            println!(
+                "{:>10} | {:>8} | {:>14} | {:>18}",
+                n,
+                threads,
+                fmt_dur(elapsed),
+                fmt_dur(elapsed / n),
+            );
+        }
+    }
+}
+
+// ── Scenario 5: flush cost vs. dirty fraction ───────────────────────────────
+
+fn flush_cost_vs_dirty_fraction() {
+    println!("\n=== Scenario 5: flush_gpu_mirror cost vs. dirty fraction (N entities registered dirty-tracked, only a fraction marked dirty) ===");
+    println!("{:>10} | {:>10} | {:>14}", "N", "dirty %", "flush time");
+    for &n in &[1_000u32, 10_000, 100_000] {
+        for &dirty_pct in &[0u32, 1, 10, 100] {
+            let ctx = test_context();
+            let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+            // Plain #[gpu] (DirtyTracked default) -- not packed/Once here,
+            // this scenario is specifically about the dirty-tracked flush
+            // path's cost, so a single-field DirtyTracked fixture keeps the
+            // measurement focused.
+            #[derive(SceneStore, Clone, Copy)]
+            struct DirtyTrackedBenchField {
+                #[gpu]
+                value: u32,
+            }
+            DirtyTrackedBenchField::register_gpu_columns_growable(&mut store, n, ctx.device());
+            let store = Arc::new(store);
+            let mut world = World::new();
+            world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+
+            let entities: Vec<_> = (0..n)
+                .map(|i| {
+                    let e = world.spawn();
+                    world.insert(e, DirtyTrackedBenchField { value: i });
+                    e
+                })
+                .collect();
+            world.flush_gpu_mirror(ctx.queue()).expect("mirror attached"); // clear the initial-insert dirty state so only the intended fraction is dirty for the timed flush
+
+            let dirty_count = ((n as u64 * dirty_pct as u64) / 100) as usize;
+            for &e in entities.iter().take(dirty_count) {
+                world.insert(e, DirtyTrackedBenchField { value: 999 });
+            }
+
+            let start = Instant::now();
+            world.flush_gpu_mirror(ctx.queue()).unwrap();
+            let elapsed = start.elapsed();
+            println!("{:>10} | {:>9}% | {:>14}", n, dirty_pct, fmt_dur(elapsed));
+        }
+    }
+}
+
+fn main() {
+    println!("Helio#211 -- World<->GPU mirror bridge AAA-scale benchmark");
+    println!("(pulsar_scenedb#24 + follow-ups, real GPU device)");
+    spawn_throughput();
+    steady_state_churn();
+    reallocation_latency();
+    concurrent_buffer_access();
+    flush_cost_vs_dirty_fraction();
+}


### PR DESCRIPTION
Closes #211.

## What

`crates/helio-scenedb/benches/world_mirror_scale.rs` — 5 scenarios against a real GPU device, `harness = false` (matches `pass_timing.rs`'s own reasoning: this measures real wall-clock cost of GPU-submitting operations end to end, not a pure-CPU microbenchmark criterion is tuned for): spawn throughput, steady-state churn, isolated reallocation latency, concurrent buffer access, and flush cost vs. dirty fraction. Full numbers and analysis in `benches/WORLD_MIRROR_SCALE_BASELINE.md`.

## A scoping finding before a single number was taken

The issue proposed "N threads calling `world.insert()` concurrently." That scenario doesn't exist to measure — `World::insert(&mut self, ..)` structurally prevents two threads calling it on the same `World` at once (the borrow checker forbids it). Scenario 4 measures what's actually reachable concurrently instead: `SceneGpuStore`'s own `&self` methods, called directly by multiple threads on disjoint rows — the shape a future parallel-mutation API would need. Documented in the bench's own module doc so this doesn't get re-proposed as a gap later.

## A real measurement bug caught during development

The bench fixture's `#[gpu]` fields defaulted to `DirtyTracked` mode, which defers writes — scenarios 1/3/4 never called `flush_gpu_mirror` or checked the right buffer map, so they were silently measuring CPU-only bookkeeping. Caught because scenario 1 reported **zero** reallocations at every scale, including 1,000,000 entities, which is obviously wrong for a buffer starting at capacity 64. Fixed by switching the fixture to `#[gpu(mirror = Once)]`, which exercises the real growable/immediate write path these scenarios are actually about.

## The numbers (full writeup in the committed baseline doc)

- **Churn at scale is expensive**: 100k entities at 10% per-frame churn costs 44ms/frame (2.6x the 60fps budget) on this subsystem alone; 50% churn costs 263ms/frame (15.9x budget).
- **A single reallocation at 100k→200k rows costs 42.7ms** (2.5x the frame budget), landing wherever whichever `insert()` happens to cross the threshold — direct evidence for #212.
- **New finding, not originally scoped in #212**: growable buffers don't check `wgpu::Limits::max_buffer_size` (256 MiB default) before doubling — a 256-byte packed record hits a real `wgpu` validation-error **panic** at 1,048,576 rows in one buffer. I've added this to #212's scope.
- **Concurrent access gets *worse* per-write as thread count increases** (10k rows: 1 thread → 2.4µs/write, 16 threads → 4.3µs/write, on completely disjoint rows) — direct confirmation #213's lock-contention concern is real, not speculative.
- **`flush_gpu_mirror`'s 0%-dirty baseline is real and non-trivial** (38.5µs at 100k rows) and barely grows with dirty fraction (1% and 10% dirty cost about the same) — confirms #214's O(capacity)-scan concern is the actual bottleneck.

## Also fixed: a real portability gap in `#[derive(SceneStore)]`

`helio-scenedb` gains its own `gpu` feature (default-on). The derive's generated `#[cfg(feature = "gpu")]` gate checks the *consuming* crate's own Cargo features (wherever the macro's tokens get spliced in), not `pulsar_scenedb`'s — so any crate other than `pulsar_scenedb` itself using the derive needs a same-named `gpu` feature for the GPU-column methods to compile at all. This bench is the first consumer of the derive outside `pulsar_scenedb`'s own tests, which is how this surfaced.

## A separate, real blocker found and NOT fixed here

Updating `pulsar_scenedb` exposes a pre-existing, latent `Cargo.lock` issue: two incompatible `windows-core` versions (0.58.0 via `gpu-allocator`, 0.62.2 direct in `wgpu-hal` 30.0.0) already coexist in the checked-in lockfile, and re-resolving *anything* — confirmed via clean-cache A/B testing, not specific to this dependency — can flip which one `wgpu-hal`'s own DX12 module resolves against, breaking the Windows DX12 backend build. This PR's committed `Cargo.toml` is unchanged from `main` (still requests the full `dx12`/`vulkan`/`metal`/`gles`/`webgpu` feature set) — the numbers above were captured with `dx12` disabled locally (uncommitted, Vulkan backend) purely as a workaround to get real measurements. Filed as its own tracked issue, not addressed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)