### PR TITLE
Fix wgpu feature regression + update SceneDB pin + benchmark scenarios for #212/#213/#214

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.0",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -2236,7 +2236,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2706,7 +2706,7 @@ dependencies = [
  "log",
  "presser",
  "thiserror 2.0.19",
- "windows 0.62.2",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -3712,7 +3712,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -4653,7 +4653,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#91c420a4ccb96a38f981d36eddf169f998c89159"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#3f67d9bd8886b4887a9ebee49cade59090a75391"
 dependencies = [
  "ahash",
  "profiling 0.1.0",
@@ -5459,7 +5459,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#91c420a4ccb96a38f981d36eddf169f998c89159"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB#3f67d9bd8886b4887a9ebee49cade59090a75391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5890,7 +5890,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5903,7 +5903,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7494,7 +7494,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7673,15 +7673,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-wgpu = { version = "30.0.0", default-features = true, features = ["vulkan", "vulkan-portability", "wgsl"] }
+wgpu = { version = "30.0.0", default-features = true, features = ["vulkan", "vulkan-portability", "metal", "dx12", "gles", "webgpu", "wgsl"] }
 blade-graphics = { git = "https://github.com/tristanpoland/blade", rev = "d85bd14a78ed7729abc298906e87332257674a02" }
 blade-macros =   { git = "https://github.com/tristanpoland/blade", rev = "d85bd14a78ed7729abc298906e87332257674a02" }
 bytemuck = { version = "1", features = ["derive"] }

--- a/crates/helio-scenedb/benches/world_mirror_scale.rs
+++ b/crates/helio-scenedb/benches/world_mirror_scale.rs
@@ -358,6 +358,98 @@ fn flush_cost_vs_dirty_fraction() {
     }
 }
 
+// ── Scenario 6 (round 2, post-Helio#212): reservation eliminates in-batch growth ──
+
+fn reservation_eliminates_batch_growth() {
+    println!("\n=== Scenario 6 (post-#212): reserve_gpu_mirror_capacity before a known-size batch spawn ===");
+    println!("{:>10} | {:>18} | {:>18} | {:>14}", "N", "reallocs (cold)", "reallocs (reserved)", "reserved wall time");
+    for &n in &[1_000u32, 10_000, 100_000] {
+        // Cold: no reservation, same shape as scenario 1.
+        let ctx = test_context();
+        let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+        BenchInstance::register_gpu_columns_growable(&mut store, 64, ctx.device());
+        let store = Arc::new(store);
+        let mut world = World::new();
+        world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+        let id = BenchInstance::packed_gpu_component_id();
+        let epoch_before = store.growable_epoch_for_id(id).unwrap_or(0);
+        for i in 0..n {
+            let e = world.spawn();
+            world.insert(e, sample_instance(i));
+        }
+        let cold_reallocs = store.growable_epoch_for_id(id).unwrap_or(0) - epoch_before;
+
+        // Reserved: same batch, but reserve_gpu_mirror_capacity(n) first.
+        let ctx2 = test_context();
+        let mut store2 = SceneGpuStore::new(&ctx2, scene_cfg());
+        BenchInstance::register_gpu_columns_growable(&mut store2, 64, ctx2.device());
+        let store2 = Arc::new(store2);
+        let mut world2 = World::new();
+        world2.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store2), Arc::clone(ctx2.queue())));
+        world2
+            .reserve_gpu_mirror_capacity(ctx2.queue(), n)
+            .expect("mirror attached")
+            .expect("reserve succeeds");
+        let epoch_before2 = store2.growable_epoch_for_id(id).unwrap_or(0);
+        let start = Instant::now();
+        for i in 0..n {
+            let e = world2.spawn();
+            world2.insert(e, sample_instance(i));
+        }
+        let elapsed = start.elapsed();
+        let reserved_reallocs = store2.growable_epoch_for_id(id).unwrap_or(0) - epoch_before2;
+
+        println!(
+            "{:>10} | {:>18} | {:>18} | {:>14}",
+            n, cold_reallocs, reserved_reallocs, fmt_dur(elapsed),
+        );
+    }
+}
+
+// ── Scenario 7 (round 2, post-Helio#213): concurrent mark_dirty ────────────
+
+fn concurrent_mark_dirty() {
+    println!("\n=== Scenario 7 (post-#213): concurrent mark_dirty on disjoint rows, pre-reserved (fast read-lock path) ===");
+    println!("{:>10} | {:>8} | {:>14} | {:>18}", "N total", "threads", "wall time", "per-mark");
+    #[derive(SceneStore, Clone, Copy)]
+    struct ConcurrentMarkField {
+        #[gpu]
+        value: u32,
+    }
+    for &n in &[10_000u32, 100_000] {
+        for &threads in &[1u32, 4, 8, 16] {
+            let ctx = test_context();
+            let mut store = SceneGpuStore::new(&ctx, scene_cfg());
+            ConcurrentMarkField::register_gpu_columns_growable(&mut store, n, ctx.device());
+            let store = Arc::new(store);
+            let id = ConcurrentMarkField::gpu_columns()[0].field_token.id();
+            let per_thread = n / threads;
+
+            let start = Instant::now();
+            std::thread::scope(|scope| {
+                for t in 0..threads {
+                    let store = Arc::clone(&store);
+                    scope.spawn(move || {
+                        let base = t * per_thread;
+                        let value_bytes = (t).to_ne_bytes();
+                        for row in base..base + per_thread {
+                            store.mark_gpu_row_dirty(id, row, &value_bytes);
+                        }
+                    });
+                }
+            });
+            let elapsed = start.elapsed();
+            println!(
+                "{:>10} | {:>8} | {:>14} | {:>18}",
+                n,
+                threads,
+                fmt_dur(elapsed),
+                fmt_dur(elapsed / n),
+            );
+        }
+    }
+}
+
 fn main() {
     println!("Helio#211 -- World<->GPU mirror bridge AAA-scale benchmark");
     println!("(pulsar_scenedb#24 + follow-ups, real GPU device)");
@@ -366,4 +458,6 @@ fn main() {
     reallocation_latency();
     concurrent_buffer_access();
     flush_cost_vs_dirty_fraction();
+    reservation_eliminates_batch_growth();
+    concurrent_mark_dirty();
 }


### PR DESCRIPTION
A stray auto-commit/auto-merge (PR #215, merged before my intended #216) accidentally shipped a local debugging workaround to `main`: dx12/metal/gles/webgpu stripped from the workspace's wgpu feature list. This restores the correct, full feature declaration. Restoring it will likely re-surface a separate, already-tracked issue (windows-core version conflict breaking the Windows DX12 build) — that's real and pre-existing, tracked on its own, not something this PR causes or fixes.

Also bundled: bumps the `pulsar_scenedb` pin to pick up the merged #212/#213/#214 hardening fixes, and adds two new benchmark scenarios validating them directly (reservation eliminating in-batch reallocations; concurrent `mark_dirty` — the actual path #213 fixed, which the original `concurrent_buffer_access` scenario didn't exercise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)