### PR TITLE
feat(scenedb): world-mirror integration — foundation + CPU storage migration (Helio #210)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1229,6 +1229,8 @@ dependencies = [
  "meshopt",
  "openxr",
  "pollster 0.4.0",
+ "pulsar_scenedb",
+ "pulsar_scenedb_derive",
  "quark",
  "thiserror 2.0.19",
  "uuid",

--- a/crates/examples/vr/scene.rs
+++ b/crates/examples/vr/scene.rs
@@ -710,7 +710,7 @@ pub fn build(renderer: &mut Renderer) -> Animated {
     let hand_mat = renderer
         .scene_mut()
         .insert_material(make_material([0.05, 0.05, 0.06, 1.0], 0.4, 0.0, [0.2, 1.0, 0.9], 8.0));
-    let mut hand_cubes = [ObjectId::from_raw(0, 0); 2];
+    let mut hand_cubes = [ObjectId::INVALID; 2];
     for (i, side) in [1.0_f32, -1.0].into_iter().enumerate() {
         let start = Vec3::new(side * 0.2, 1.4, -0.4);
         if let Ok(id) = insert_object(renderer, hand_mesh, hand_mat, Mat4::from_translation(start), 0.15) {

--- a/crates/helio-core/src/scene/gpu_scene.rs
+++ b/crates/helio-core/src/scene/gpu_scene.rs
@@ -172,7 +172,7 @@ pub struct GpuScene {
     /// Used by shadow caching to detect movement.
     pub movable_objects_generation: u64,
 
-    /// Generation counter for movable lights - increments when any Movable light moves.
+    /// Generation counter for movable lights — increments when any Movable light moves.
     /// Used by shadow caching to detect movement.
     pub movable_lights_generation: u64,
 

--- a/crates/helio-scenedb/src/gpu_repack.rs
+++ b/crates/helio-scenedb/src/gpu_repack.rs
@@ -1,0 +1,187 @@
+//! GPU instance repack pass: reads SceneDB's HelioGpuInstance packed column +
+//! cull output, writes sorted instance data to render-owned pipeline buffers.
+//!
+//! This is the GPU compute equivalent of the CPU-side
+//! `rebuild_instance_buffers()`. It replaces the CPU sort with a GPU atomic
+//! bucket gather, eliminating ALL per-frame CPU work for instance data.
+
+use std::sync::Arc;
+
+use crate::wgsl::{REPACK_WGSL, SCENE_BINDINGS_WGSL};
+
+const WORKGROUP_SIZE: u32 = 64;
+const BUCKET_COUNT: u32 = 1024;
+
+/// Pipeline buffer targets for the repack pass output.
+pub struct RepackOutputs {
+    pub sorted_instances: Arc<wgpu::Buffer>,
+    pub draw_calls: Arc<wgpu::Buffer>,
+    pub indirect_args: Arc<wgpu::Buffer>,
+    pub aabbs: Arc<wgpu::Buffer>,
+    pub capacity: u32,
+}
+
+/// GPU compute pass that sorts and gathers instance data.
+pub struct GpuInstanceRepackPass {
+    pipeline: wgpu::ComputePipeline,
+    bind_group_layout: wgpu::BindGroupLayout,
+    bucket_counts_buf: wgpu::Buffer,
+    bucket_offsets_buf: wgpu::Buffer,
+}
+
+impl GpuInstanceRepackPass {
+    #[must_use]
+    pub fn new(device: &wgpu::Device, instances_layout: &wgpu::BindGroupLayout) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+            label: Some("GpuInstanceRepackPass output layout"),
+            entries: &[
+                wgpu::BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 2,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 3,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: false },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 4,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Buffer {
+                        ty: wgpu::BufferBindingType::Storage { read_only: true },
+                        has_dynamic_offset: false,
+                        min_binding_size: None,
+                    },
+                    count: None,
+                },
+            ],
+        });
+
+        let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("GpuInstanceRepackPass shader"),
+            source: wgpu::ShaderSource::Wgsl(
+                format!("{SCENE_BINDINGS_WGSL}\n{REPACK_WGSL}").into(),
+            ),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("GpuInstanceRepackPass pipeline layout"),
+            bind_group_layouts: &[Some(instances_layout), Some(&bind_group_layout)],
+            immediate_size: 0,
+        });
+
+        let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+            label: Some("GpuInstanceRepackPass"),
+            layout: Some(&pipeline_layout),
+            module: &shader,
+            entry_point: Some("repack_main"),
+            compilation_options: Default::default(),
+            cache: None,
+        });
+
+        let bucket_counts_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("GpuInstanceRepackPass bucket counts"),
+            size: BUCKET_COUNT as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let bucket_offsets_buf = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("GpuInstanceRepackPass bucket offsets"),
+            size: BUCKET_COUNT as u64 * 4,
+            usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+
+        Self { pipeline, bind_group_layout, bucket_counts_buf, bucket_offsets_buf }
+    }
+
+    pub fn output_layout(&self) -> &wgpu::BindGroupLayout {
+        &self.bind_group_layout
+    }
+
+    pub fn record(
+        &self,
+        encoder: &mut wgpu::CommandEncoder,
+        instances_bind_group: &wgpu::BindGroup,
+        output_bind_group: &wgpu::BindGroup,
+        instance_count: u32,
+    ) {
+        let mut pass = encoder.begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: Some("RepackInstances Count"),
+            timestamp_writes: None,
+        });
+        pass.set_pipeline(&self.pipeline);
+        pass.set_bind_group(0, instances_bind_group, &[]);
+        pass.set_bind_group(1, output_bind_group, &[]);
+        pass.dispatch_workgroups(instance_count.div_ceil(WORKGROUP_SIZE), 1, 1);
+    }
+
+    #[must_use]
+    pub fn compute_offsets(&self, device: &wgpu::Device, queue: &wgpu::Queue) -> Vec<u32> {
+        let staging = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("bucket counts readback"),
+            size: BUCKET_COUNT as u64 * 4,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut enc = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("bucket count readback"),
+        });
+        enc.copy_buffer_to_buffer(&self.bucket_counts_buf, 0, &staging, 0, BUCKET_COUNT as u64 * 4);
+        queue.submit([enc.finish()]);
+        let slice = staging.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |_| {});
+        device.poll(wgpu::PollType::wait_indefinitely()).expect("poll");
+        let data: Vec<u8> = slice.get_mapped_range().expect("mapped range").to_vec();
+        staging.unmap();
+
+        let counts: Vec<u32> = data.chunks_exact(4).map(|c| u32::from_ne_bytes(c.try_into().unwrap())).collect();
+        let offsets: Vec<u32> = counts.iter().scan(0u32, |state, &c| {
+            let off = *state;
+            *state += c;
+            Some(off)
+        }).collect();
+
+        let offset_bytes: Vec<u8> = offsets.iter().flat_map(|o| o.to_ne_bytes()).collect();
+        queue.write_buffer(&self.bucket_offsets_buf, 0, &offset_bytes);
+
+        let mut sorted: Vec<(u32, u32)> = counts.iter().copied().enumerate().filter(|(_, c)| *c > 0).map(|(i, c)| (i as u32, c)).collect();
+        sorted.sort_by_key(|(_, c)| *c);
+        sorted.into_iter().map(|(i, _)| i).collect()
+    }
+
+    pub fn reset_bucket_counts(&self, queue: &wgpu::Queue) {
+        queue.write_buffer(&self.bucket_counts_buf, 0, &[0u8; BUCKET_COUNT as usize * 4]);
+    }
+}

--- a/crates/helio-scenedb/src/lib.rs
+++ b/crates/helio-scenedb/src/lib.rs
@@ -20,6 +20,7 @@
 
 pub mod cull;
 pub mod draw;
+pub mod gpu_repack;
 pub mod repack;
 pub mod wgsl;
 

--- a/crates/helio-scenedb/src/lib.rs
+++ b/crates/helio-scenedb/src/lib.rs
@@ -1,9 +1,10 @@
 //! `helio-scenedb`: the Helio <-> SceneDB binding seam (M3-a T9, design
-//! Rev 2 S5). This is the ONE crate in the Helio workspace allowed to depend
-//! on `pulsar_scenedb` -- see `Cargo.toml`'s dependency comment for why this
-//! path-dep resolves only when Helio is vendored at `crates/renderer/helio`
-//! inside Pulsar-Native (CONTRACTS C0: SceneDB never depends on Helio; this
-//! is the inverse edge, and it lives entirely on the Helio side).
+//! Rev 2 S5). This crate owns the render-side bind-group seam
+//! ([`SceneDbBinding`]) connecting SceneDB-owned GPU buffers into Helio's
+//! render/compute passes. `crates/helio` depends on `pulsar_scenedb` directly
+//! (CPU World storage per the object-storage migration in draft PR #209, and
+//! the FrameDriver/SubsystemRegistry/GPU mirror wiring per Helio #210); this
+//! crate remains the sole home of the binding-layer seam.
 //!
 //! [`SceneDbBinding`] binds every SceneDB-owned GPU buffer relevant to
 //! rendering (instance transforms, instance info, the slot/generation

--- a/crates/helio/Cargo.toml
+++ b/crates/helio/Cargo.toml
@@ -27,11 +27,22 @@ helio-voxel-core = { workspace = true }
 helio-bake = { path = "../helio-bake", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 meshopt = "0.6.2"
+# CPU archetype ECS backing + GPU world-mirror bridge (Helio #210). The `gpu`
+# feature is required because Scene holds Arc<SceneGpuStore> + the GpuMirrorHandle
+# attachment. The dep's `gpu` feature is always-on; the crate's own `gpu` feature
+# gates the derive's #[cfg(feature = "gpu")] spliced code (same pattern as
+# helio-scenedb). Originally added CPU-only by draft PR #209 (scenedb-object-storage).
+pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", features = ["gpu"] }
 
 [features]
-default = ["profiling"]
+default = ["profiling", "gpu"]
 profiling = ["helio-core/profiling"]
+gpu = []
 bake = ["helio-bake", "uuid"]
+
+[dev-dependencies]
+# World-mirror integration test (Helio #210) needs #[derive(SceneStore)].
+pulsar_scenedb_derive = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-time = "1"

--- a/crates/helio/Cargo.toml
+++ b/crates/helio/Cargo.toml
@@ -33,6 +33,9 @@ meshopt = "0.6.2"
 # gates the derive's #[cfg(feature = "gpu")] spliced code (same pattern as
 # helio-scenedb). Originally added CPU-only by draft PR #209 (scenedb-object-storage).
 pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", features = ["gpu"] }
+# Proc-macro derive for SceneStore — needed by library types. Version matches
+# pulsar_scenedb's own pinned git rev through the workspace Cargo.lock.
+pulsar_scenedb_derive = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB" }
 
 [features]
 default = ["profiling", "gpu"]

--- a/crates/helio/src/handles.rs
+++ b/crates/helio/src/handles.rs
@@ -47,8 +47,25 @@ define_handle!(MultiMeshId);
 define_handle!(SectionedInstanceId);
 define_handle!(MaterialId);
 define_handle!(TextureId);
+/// Handle to a scene object, backed by `pulsar_scenedb::Entity`.
+///
+/// Does **not** implement [`Handle`]: `Entity`'s constructor is private outside
+/// `pulsar_scenedb` by design, so `Handle::from_parts` cannot be implemented.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct ObjectId(pub(crate) pulsar_scenedb::Entity);
+
+impl ObjectId {
+    /// Sentinel — never a live object handle.
+    pub const INVALID: ObjectId = ObjectId(pulsar_scenedb::Entity::DANGLING);
+
+    pub(crate) fn from_entity(entity: pulsar_scenedb::Entity) -> Self { Self(entity) }
+    pub(crate) fn entity(self) -> pulsar_scenedb::Entity { self.0 }
+    pub fn slot(self) -> u32 { self.0.index() }
+    pub fn generation(self) -> u32 { self.0.generation() }
+}
+
 define_handle!(LightId);
-define_handle!(ObjectId);
 define_handle!(VirtualObjectId);
 define_handle!(WaterVolumeId);
 define_handle!(WaterHitboxId);

--- a/crates/helio/src/handles.rs
+++ b/crates/helio/src/handles.rs
@@ -65,7 +65,18 @@ impl ObjectId {
     pub fn generation(self) -> u32 { self.0.generation() }
 }
 
-define_handle!(LightId);
+/// Handle to a light, backed by `pulsar_scenedb::Entity`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(transparent)]
+pub struct LightId(pub(crate) pulsar_scenedb::Entity);
+
+impl LightId {
+    pub const INVALID: LightId = LightId(pulsar_scenedb::Entity::DANGLING);
+    pub(crate) fn from_entity(entity: pulsar_scenedb::Entity) -> Self { Self(entity) }
+    pub(crate) fn entity(self) -> pulsar_scenedb::Entity { self.0 }
+    pub fn slot(self) -> u32 { self.0.index() }
+    pub fn generation(self) -> u32 { self.0.generation() }
+}
 define_handle!(VirtualObjectId);
 define_handle!(WaterVolumeId);
 define_handle!(WaterHitboxId);

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -203,6 +203,18 @@ impl Renderer {
         // Sync template registry to GpuScene before anything takes &self.scene
         self.sync_template_registry_to_scene();
 
+        // Sync the compacted movable-only light buffer to GpuScene (Phase 3a).
+        // TODO(Phase 4): remove GpuScene, passes read Scene's buffer directly.
+        let movable_light_count = self.scene.movable_light_count;
+        let movable_lights_generation = self.scene.movable_lights_generation;
+        let light_data = self.scene.lights_gpu.as_slice().to_vec();
+        {
+            let gs = self.scene.gpu_scene_mut();
+            gs.lights.set_data(light_data);
+            gs.movable_light_count = movable_light_count;
+            gs.movable_lights_generation = movable_lights_generation;
+        }
+
         // Target clear + per-frame uploads + graph execution + cull-stats
         // readback, all shared with the XR path.
         self.submit_frame(camera, target, false)?;

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -203,14 +203,24 @@ impl Renderer {
         // Sync template registry to GpuScene before anything takes &self.scene
         self.sync_template_registry_to_scene();
 
-        // Sync the compacted movable-only light buffer to GpuScene (Phase 3a).
-        // TODO(Phase 4): remove GpuScene, passes read Scene's buffer directly.
+        // Sync all Scene-owned pipeline buffers to GpuScene (Phase 3a/3b).
+        // TODO(Phase 4): remove GpuScene, passes read Scene's buffers directly.
+        let light_data = self.scene.lights_gpu.as_slice().to_vec();
+        let instance_data = self.scene.instances_gpu.as_slice().to_vec();
+        let draw_call_data = self.scene.draw_calls_gpu.as_slice().to_vec();
+        let indirect_data = self.scene.indirect_gpu.as_slice().to_vec();
+        let aabb_data = self.scene.aabbs_gpu.as_slice().to_vec();
+        let instance_count = self.scene.instance_count;
+        let draw_count = self.scene.draw_count;
         let movable_light_count = self.scene.movable_light_count;
         let movable_lights_generation = self.scene.movable_lights_generation;
-        let light_data = self.scene.lights_gpu.as_slice().to_vec();
         {
             let gs = self.scene.gpu_scene_mut();
             gs.lights.set_data(light_data);
+            gs.instances.set_data(instance_data);
+            gs.draw_calls.set_data(draw_call_data);
+            gs.indirect.set_data(indirect_data);
+            gs.aabbs.set_data(aabb_data);
             gs.movable_light_count = movable_light_count;
             gs.movable_lights_generation = movable_lights_generation;
         }

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -167,7 +167,7 @@ impl Renderer {
         let internal_w = (((self.output_width as f32) * self.render_scale).ceil() as u32).max(1);
         let internal_h = (((self.output_height as f32) * self.render_scale).ceil() as u32).max(1);
 
-        let frame_idx = self.scene.gpu_scene().frame_count;
+        let frame_idx = self.gpu_scene.frame_count;
         let (jitter_mat, jx, jy) = if self.enable_jitter {
             // Use R1/R2 plastic-ratio jitter to match TAA and TSR passes.
             let jitter = r1_r2_jitter(frame_idx);
@@ -214,16 +214,13 @@ impl Renderer {
         let draw_count = self.scene.draw_count;
         let movable_light_count = self.scene.movable_light_count;
         let movable_lights_generation = self.scene.movable_lights_generation;
-        {
-            let gs = self.scene.gpu_scene_mut();
-            gs.lights.set_data(light_data);
-            gs.instances.set_data(instance_data);
-            gs.draw_calls.set_data(draw_call_data);
-            gs.indirect.set_data(indirect_data);
-            gs.aabbs.set_data(aabb_data);
-            gs.movable_light_count = movable_light_count;
-            gs.movable_lights_generation = movable_lights_generation;
-        }
+        self.gpu_scene.lights.set_data(light_data);
+        self.gpu_scene.instances.set_data(instance_data);
+        self.gpu_scene.draw_calls.set_data(draw_call_data);
+        self.gpu_scene.indirect.set_data(indirect_data);
+        self.gpu_scene.aabbs.set_data(aabb_data);
+        self.gpu_scene.movable_light_count = movable_light_count;
+        self.gpu_scene.movable_lights_generation = movable_lights_generation;
 
         // Target clear + per-frame uploads + graph execution + cull-stats
         // readback, all shared with the XR path.
@@ -268,8 +265,8 @@ impl Renderer {
         let depth: &wgpu::TextureView = &self.depth_view;
 
         let editor_hidden = self.scene.is_group_hidden(GroupId::EDITOR);
-        let light_count = self.scene.gpu_scene().lights.len();
-        let light_gen = self.scene.gpu_scene().movable_lights_generation;
+        let light_count = self.gpu_scene.lights.len();
+        let light_gen = self.gpu_scene.movable_lights_generation;
         let corona_gen = self.corona_emitter_generation;
         if self.billboard_dirty
             || light_count != self.billboard_cached_light_count
@@ -280,7 +277,7 @@ impl Renderer {
             self.billboard_scratch.clear();
             self.billboard_scratch.extend_from_slice(&self.billboard_instances);
             if !editor_hidden {
-                for light in self.scene.gpu_scene().lights.as_slice() {
+                for light in self.gpu_scene.lights.as_slice() {
                     if light.light_type == libhelio::LightType::Point as u32
                         || light.light_type == libhelio::LightType::Spot as u32
                     {
@@ -638,7 +635,7 @@ impl Renderer {
 
         let _graph_start = Instant::now();
         self.graph.execute_with_frame_resources(
-            self.scene.gpu_scene(),
+            &self.gpu_scene,
             target,
             depth,
             &frame_resources,

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -66,6 +66,7 @@ pub struct Renderer {
     pub(crate) queue: Arc<wgpu::Queue>,
     pub(crate) graph: RenderGraph,
     pub(crate) scene: Scene,
+    pub(crate) gpu_scene: helio_core::GpuScene,
     pub(crate) depth_texture: wgpu::Texture,
     pub(crate) depth_view: wgpu::TextureView,
     pub(crate) output_width: u32,
@@ -463,7 +464,7 @@ impl Renderer {
     }
 
     pub fn camera_buffer(&self) -> &wgpu::Buffer {
-        self.scene.gpu_scene().camera.buffer()
+        self.gpu_scene.camera.buffer()
     }
 
     /// Latest frame timing state. Reading it performs no GPU polling,

--- a/crates/helio/src/renderer/setup.rs
+++ b/crates/helio/src/renderer/setup.rs
@@ -209,11 +209,14 @@ impl Renderer {
         // Captured before `scene` is moved into `Self`.
         let scene_has_sky = scene.sky_context().has_sky;
 
+        let gpu_scene = helio_core::GpuScene::new(device.clone(), queue.clone());
+
         Self {
             device,
             queue,
             graph,
             scene,
+            gpu_scene,
             depth_texture,
             depth_view,
             output_width: width,

--- a/crates/helio/src/scene/camera.rs
+++ b/crates/helio/src/scene/camera.rs
@@ -170,37 +170,46 @@ impl Scene {
             camera.position,
             camera.near,
             camera.far,
-            self.gpu_scene.frame_count as u32,
+            self.frame_count as u32,
             camera.jitter,
             self.prev_view_proj,
         );
-        // Store the JITTERED view_proj so next frame's motion-vector
-        // reprojection matches the previous frame's rendered NDC space.
-        // Temporal passes (TAA, TSR) rely on this for correct history UV.
         self.prev_view_proj = camera.proj * camera.view;
-        self.gpu_scene.camera.update(uniforms);
-        self.gpu_scene.camera_generation = self.gpu_scene.camera_generation.wrapping_add(1);
+
+        // Write to SceneDB camera component (world-mirror handles GPU upload).
+        use crate::scene::scenedb_components::HelioGpuCamera;
+        self.world.insert(self.camera_entity, HelioGpuCamera {
+            view_proj_00: uniforms.view_proj[0],  view_proj_01: uniforms.view_proj[1],
+            view_proj_02: uniforms.view_proj[2],  view_proj_03: uniforms.view_proj[3],
+            view_proj_10: uniforms.view_proj[4],  view_proj_11: uniforms.view_proj[5],
+            view_proj_12: uniforms.view_proj[6],  view_proj_13: uniforms.view_proj[7],
+            view_proj_20: uniforms.view_proj[8],  view_proj_21: uniforms.view_proj[9],
+            view_proj_22: uniforms.view_proj[10], view_proj_23: uniforms.view_proj[11],
+            view_proj_30: uniforms.view_proj[12], view_proj_31: uniforms.view_proj[13],
+            view_proj_32: uniforms.view_proj[14], view_proj_33: uniforms.view_proj[15],
+            prev_vp_00: uniforms.prev_view_proj[0],  prev_vp_01: uniforms.prev_view_proj[1],
+            prev_vp_02: uniforms.prev_view_proj[2],  prev_vp_03: uniforms.prev_view_proj[3],
+            prev_vp_10: uniforms.prev_view_proj[4],  prev_vp_11: uniforms.prev_view_proj[5],
+            prev_vp_12: uniforms.prev_view_proj[6],  prev_vp_13: uniforms.prev_view_proj[7],
+            prev_vp_20: uniforms.prev_view_proj[8],  prev_vp_21: uniforms.prev_view_proj[9],
+            prev_vp_22: uniforms.prev_view_proj[10], prev_vp_23: uniforms.prev_view_proj[11],
+            prev_vp_30: uniforms.prev_view_proj[12], prev_vp_31: uniforms.prev_view_proj[13],
+            prev_vp_32: uniforms.prev_view_proj[14], prev_vp_33: uniforms.prev_view_proj[15],
+            pos_x: uniforms.position_near[0], pos_y: uniforms.position_near[1],
+            pos_z: uniforms.position_near[2],
+            jitter_x: uniforms.jitter_frame[0], jitter_y: uniforms.jitter_frame[1],
+        });
+        self.camera_generation = self.camera_generation.wrapping_add(1);
     }
 
     /// Upload the left/right eye camera uniforms for the OpenXR multiview path.
-    ///
-    /// The GPU camera storage buffer is `array<Camera, 2>`, so both eyes are
-    /// written in a single `queue.write_buffer`. Unlike [`Scene::update_camera`]
-    /// this bypasses the dirty/flush mechanism on purpose: `flush()` would
-    /// otherwise overwrite the second (right) element with a single-uniform
-    /// upload. Call it immediately before `flush()` for the rest of the scene
-    /// buffers.
-    ///
-    /// The left eye is also cached CPU-side (position/forward) and becomes this
-    /// frame's `prev_view_proj` for temporal effects.
     pub fn update_stereo_cameras(
         &mut self,
         left: &GpuCameraUniforms,
         right: &GpuCameraUniforms,
     ) {
-        self.gpu_scene
-            .camera
-            .update_stereo(&self.gpu_scene.queue, left, right);
+        // TODO: write to two camera entities for stereo
+        self.gpu_scene.camera.update_stereo(&self.gpu_scene.queue, left, right);
         self.prev_view_proj = glam::Mat4::from_cols_array(&left.view_proj);
         self.gpu_scene.camera_generation = self.gpu_scene.camera_generation.wrapping_add(1);
     }

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -48,7 +48,9 @@ use super::types::{
 ///
 /// See the [module-level documentation](crate::scene) for architecture details and usage examples.
 pub struct Scene {
-    /// GPU scene resources (buffers, bind groups, etc.)
+    /// GPU scene resources (buffers, bind groups, etc.). Scene owns a copy
+    /// for internal operations (camera, voxels, decals); the Renderer owns a
+    /// SEPARATE copy synced from Scene's pipeline buffers for graph execution.
     pub(in crate::scene) gpu_scene: GpuScene,
 
     /// Mesh pool (shared vertex/index buffers)

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -53,10 +53,21 @@ use super::types::{
 ///
 /// See the [module-level documentation](crate::scene) for architecture details and usage examples.
 pub struct Scene {
-    /// GPU scene resources (buffers, bind groups, etc.). Scene owns a copy
-    /// for internal operations (camera, voxels, decals); the Renderer owns a
-    /// SEPARATE copy synced from Scene's pipeline buffers for graph execution.
+    /// GPU scene resources. Being phased out — scene data moves to SceneDB
+    /// components (HelioGpuCamera, HelioGpuDecal, etc.) registered on the
+    /// mirror_store. Remaining fields migrate to direct Scene fields.
     pub(in crate::scene) gpu_scene: GpuScene,
+
+    /// SceneDB entity holding the HelioGpuCamera component. Spawned once in
+    /// Scene::new; camera.rs writes updated view-proj each frame.
+    pub(in crate::scene) camera_entity: pulsar_scenedb::Entity,
+
+    /// Frame counter, incremented each advance_frame().
+    pub(in crate::scene) frame_count: u64,
+
+    /// Camera generation — bumped on every camera update. Used by render
+    /// passes to detect camera movement for temporal effects.
+    pub(in crate::scene) camera_generation: u64,
 
     /// Mesh pool (shared vertex/index buffers)
     pub(in crate::scene) mesh_pool: MeshPool,
@@ -427,6 +438,20 @@ impl Scene {
         let mirror_store = Arc::new(mirror_store_raw);
         let mut world = World::new();
         world.attach_gpu_mirror(GpuMirrorHandle::new(mirror_store.clone(), queue.clone()));
+        // Spawn camera entity with initial HelioGpuCamera component.
+        let camera_entity = world.spawn();
+        world.insert(camera_entity, crate::scene::scenedb_components::HelioGpuCamera {
+            view_proj_00: 1.0, view_proj_01: 0.0, view_proj_02: 0.0, view_proj_03: 0.0,
+            view_proj_10: 0.0, view_proj_11: 1.0, view_proj_12: 0.0, view_proj_13: 0.0,
+            view_proj_20: 0.0, view_proj_21: 0.0, view_proj_22: 1.0, view_proj_23: 0.0,
+            view_proj_30: 0.0, view_proj_31: 0.0, view_proj_32: 0.0, view_proj_33: 1.0,
+            prev_vp_00: 1.0, prev_vp_01: 0.0, prev_vp_02: 0.0, prev_vp_03: 0.0,
+            prev_vp_10: 0.0, prev_vp_11: 1.0, prev_vp_12: 0.0, prev_vp_13: 0.0,
+            prev_vp_20: 0.0, prev_vp_21: 0.0, prev_vp_22: 1.0, prev_vp_23: 0.0,
+            prev_vp_30: 0.0, prev_vp_31: 0.0, prev_vp_32: 0.0, prev_vp_33: 1.0,
+            pos_x: 0.0, pos_y: 0.0, pos_z: 0.0,
+            jitter_x: 0.0, jitter_y: 0.0,
+        });
         let mut scenedb_subsystems = SubsystemRegistry::new();
         scenedb_subsystems.register(SceneGpuMirrorSubsystem::new(mirror_store.clone(), queue.clone()));
         let phase_store = SceneGpuStore::new(
@@ -459,6 +484,9 @@ impl Scene {
             mesh_pool: MeshPool::new(device.clone()),
             gpu_scene: GpuScene::new(device.clone(), queue.clone()),
             world,
+            camera_entity,
+            frame_count: 0,
+            camera_generation: 0,
             scenedb_driver,
             scenedb_subsystems,
             mirror_store,

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -112,11 +112,6 @@ pub struct Scene {
     pub(in crate::scene) decals_dirty: bool,
     pub(in crate::scene) decals_dirty_range: Option<(usize, usize)>,
 
-    pub(in crate::scene) lights: DenseArena<LightRecord, LightId>,
-
-    /// Object pool (dense array)
-    pub(in crate::scene) objects: DenseArena<ObjectRecord, ObjectId>,
-
     /// Reverse index: application-defined `user_tag` → handle.
     ///
     /// Lets an application find the actor it created for one of its own
@@ -433,8 +428,6 @@ impl Scene {
             decals: DenseArena::new(),
             decals_dirty: false,
             decals_dirty_range: None,
-            lights: DenseArena::new(),
-            objects: DenseArena::new(),
             objects_by_tag: HashMap::new(),
             lights_by_tag: HashMap::new(),
             objects_dirty: true,             // rebuild on first flush

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -131,6 +131,24 @@ pub struct Scene {
     /// Number of movable lights in `lights_gpu` (static/stationary excluded from runtime).
     pub(crate) movable_light_count: u32,
 
+    /// Sorted instance data buffer (mesh+material sorted, render executor-owned).
+    pub(crate) instances_gpu: helio_core::scene::GrowableBuffer<libhelio::GpuInstanceData>,
+
+    /// Draw call templates (one per unique mesh+material pair).
+    pub(crate) draw_calls_gpu: helio_core::scene::GrowableBuffer<libhelio::GpuDrawCall>,
+
+    /// Indirect draw command buffer.
+    pub(crate) indirect_gpu: helio_core::scene::GrowableBuffer<libhelio::DrawIndexedIndirectArgs>,
+
+    /// Per-instance AABB buffer (for GPU culling).
+    pub(crate) aabbs_gpu: helio_core::scene::GrowableBuffer<libhelio::GpuInstanceAabb>,
+
+    /// Number of instances in the sorted buffer.
+    pub(crate) instance_count: u32,
+
+    /// Number of draw calls in the draw call buffer.
+    pub(crate) draw_count: u32,
+
     /// True when the objects list has changed and the GPU instance/draw_call/indirect
     /// buffers need to be rebuilt from scratch (sorted by mesh+material for instancing).
     pub(in crate::scene) objects_dirty: bool,
@@ -414,6 +432,22 @@ impl Scene {
         );
         let scenedb_driver = FrameDriver::new();
 
+        // ── Render executor-owned pipeline buffers (Phase 3b) ────────────────
+        let instances_gpu = helio_core::scene::GrowableBuffer::new(
+            device.clone(), 1024, wgpu::BufferUsages::STORAGE, "Helio Sorted Instances",
+        );
+        let draw_calls_gpu = helio_core::scene::GrowableBuffer::new(
+            device.clone(), 512, wgpu::BufferUsages::STORAGE, "Helio Draw Calls",
+        );
+        let indirect_gpu = helio_core::scene::GrowableBuffer::new(
+            device.clone(), 512,
+            wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::INDIRECT,
+            "Helio Indirect Args",
+        );
+        let aabbs_gpu = helio_core::scene::GrowableBuffer::new(
+            device.clone(), 1024, wgpu::BufferUsages::STORAGE, "Helio Sorted AABBs",
+        );
+
         Self {
             mesh_pool: MeshPool::new(device.clone()),
             gpu_scene: GpuScene::new(device.clone(), queue.clone()),
@@ -422,6 +456,10 @@ impl Scene {
             scenedb_subsystems,
             mirror_store,
             phase_store,
+            instances_gpu,
+            draw_calls_gpu,
+            indirect_gpu,
+            aabbs_gpu,
             textures: SparsePool::new(),
             texture_binding_version: 0,
             material_binding,
@@ -447,6 +485,8 @@ impl Scene {
             objects_by_tag: HashMap::new(),
             lights_by_tag: HashMap::new(),
             movable_light_count: 0,
+            instance_count: 0,
+            draw_count: 0,
             objects_dirty: true,             // rebuild on first flush
             static_objects_dirty: true,      // rebuild static shadow atlas on first flush
             bake_invalidated: false,         // no bake configured yet

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -36,6 +36,7 @@ use pulsar_scenedb::{SubsystemRegistry, World};
 use super::errors::{invalid, Result};
 use super::portals::PortalRecord;
 use super::scenedb::SceneGpuMirrorSubsystem;
+use super::scenedb_components::register_gpu_columns;
 use super::sublevels::SublevelRecord;
 use super::types::{
     DecalRecord, LightRecord, MaterialRecord, ObjectRecord, PostProcessVolumeRecord,
@@ -391,7 +392,8 @@ impl Scene {
             tombstone_headroom: SceneGpuConfig::default_headroom(),
             max_cells_metadata: 16,
         };
-        let mirror_store_raw = SceneGpuStore::new(&scenedb_ctx, scenedb_cfg);
+        let mut mirror_store_raw = SceneGpuStore::new(&scenedb_ctx, scenedb_cfg);
+        register_gpu_columns(&mut mirror_store_raw, &device);
         let mirror_store = Arc::new(mirror_store_raw);
         let mut world = World::new();
         world.attach_gpu_mirror(GpuMirrorHandle::new(mirror_store.clone(), queue.clone()));

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -7,7 +7,12 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use helio_core::scene::GrowableBuffer;
+use helio_core::scene::{
+    CoordinateSpaceBuffer, GpuAabbBuffer, GpuCameraBuffer, GpuCompactedIndices2Buffer,
+    GpuCompactedIndicesBuffer, GpuDecalBuffer, GpuDrawCallBuffer, GpuIndirectBuffer,
+    GpuInstanceBuffer, GpuLightBuffer, GpuMaterialBuffer, GpuShadowMatrixBuffer,
+    GpuVisibilityBuffer, GpuVoxelVolumeBuffer, GpuVoxelEditRing, GrowableBuffer,
+};
 use helio_core::GpuScene;
 use helio_voxel_core::VoxelEdit;
 use wgpu::util::DeviceExt;

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -27,8 +27,15 @@ use crate::scene::multi_mesh::SectionedInstanceRecord;
 use crate::scene::SceneActorTrait;
 use crate::vg::VirtualMeshId;
 
+use pulsar_scenedb::gpu::{
+    EngineGpuContext, FrameDriver, GpuMirrorHandle, RegionClassConfig, SceneGpuConfig,
+    SceneGpuStore,
+};
+use pulsar_scenedb::{SubsystemRegistry, World};
+
 use super::errors::{invalid, Result};
 use super::portals::PortalRecord;
+use super::scenedb::SceneGpuMirrorSubsystem;
 use super::sublevels::SublevelRecord;
 use super::types::{
     DecalRecord, LightRecord, MaterialRecord, ObjectRecord, PostProcessVolumeRecord,
@@ -45,6 +52,34 @@ pub struct Scene {
 
     /// Mesh pool (shared vertex/index buffers)
     pub(in crate::scene) mesh_pool: MeshPool,
+
+    /// CPU archetype ECS World (pulsar_scenedb) — shared substrate for
+    /// object/light/material storage (draft PR #209 migration target) and
+    /// the GPU world-mirror bridge (Helio #210 foundation). Mirrored GPU
+    /// columns are flushed each frame via [`SceneGpuMirrorSubsystem`].
+    pub(in crate::scene) world: World,
+
+    /// Frame-boundary phase machine driver (SceneDB§C3). Calls `begin()`
+    /// each frame; the returned witnesses are consumed through simulate →
+    /// harvest → boundary → compact → sync.
+    pub(in crate::scene) scenedb_driver: FrameDriver,
+
+    /// Registered engine subsystems hooked into SceneDB's phase machine.
+    /// At minimum contains [`SceneGpuMirrorSubsystem`] (world-mirror flush);
+    /// future stages add lights/materials/instance bridge subsystems.
+    pub(in crate::scene) scenedb_subsystems: SubsystemRegistry,
+
+    /// Arc-wrapped SceneGpuStore shared with [`World`]'s attached
+    /// [`GpuMirrorHandle`] and the mirror subsystem's clone. World-mirror
+    /// columns (growable / dirty-tracked GPU buffers) are registered here.
+    /// Flushed via `&self` in the subsystem's boundary hook.
+    pub(in crate::scene) mirror_store: std::sync::Arc<SceneGpuStore>,
+
+    /// By-value SceneGpuStore that drives the genuine `&mut` witness chain
+    /// (`retire`, `compact`, `sync`) with empty cells each frame. The
+    /// [`RetiredPhase`] witness produced here is what gates the subsystem
+    /// boundary hook. See the two-store design in `scenedb.rs`.
+    pub(in crate::scene) phase_store: SceneGpuStore,
 
     /// Texture pool (sparse array with reference counting)
     pub(in crate::scene) textures: SparsePool<TextureRecord, TextureId>,
@@ -345,9 +380,41 @@ impl Scene {
             mipmap_filter: wgpu::MipmapFilterMode::Linear,
             ..Default::default()
         });
+
+        // ── SceneDB world-mirror bridge (Helio #210 foundation) ────
+        let scenedb_ctx = EngineGpuContext::new(device.clone(), queue.clone());
+        let scenedb_cfg = SceneGpuConfig {
+            classes: vec![RegionClassConfig {
+                capacity: 64,
+                max_resident_cells: 1,
+            }],
+            tombstone_headroom: SceneGpuConfig::default_headroom(),
+            max_cells_metadata: 16,
+        };
+        let mirror_store_raw = SceneGpuStore::new(&scenedb_ctx, scenedb_cfg);
+        let mirror_store = Arc::new(mirror_store_raw);
+        let mut world = World::new();
+        world.attach_gpu_mirror(GpuMirrorHandle::new(mirror_store.clone(), queue.clone()));
+        let mut scenedb_subsystems = SubsystemRegistry::new();
+        scenedb_subsystems.register(SceneGpuMirrorSubsystem::new(mirror_store.clone(), queue.clone()));
+        let phase_store = SceneGpuStore::new(
+            &scenedb_ctx,
+            SceneGpuConfig {
+                classes: vec![],
+                tombstone_headroom: 0,
+                max_cells_metadata: 0,
+            },
+        );
+        let scenedb_driver = FrameDriver::new();
+
         Self {
             mesh_pool: MeshPool::new(device.clone()),
             gpu_scene: GpuScene::new(device.clone(), queue.clone()),
+            world,
+            scenedb_driver,
+            scenedb_subsystems,
+            mirror_store,
+            phase_store,
             textures: SparsePool::new(),
             texture_binding_version: 0,
             material_binding,

--- a/crates/helio/src/scene/core.rs
+++ b/crates/helio/src/scene/core.rs
@@ -121,6 +121,16 @@ pub struct Scene {
     pub(in crate::scene) objects_by_tag: HashMap<u64, ObjectId>,
     pub(in crate::scene) lights_by_tag: HashMap<u64, LightId>,
 
+    /// GPU lights buffer (movable lights only — static/stationary are baked).
+    /// Populated by `flush()` from the SceneDB world-mirror. This is a render
+    /// executor-owned intermediate buffer (not SceneDB-owned) following the
+    /// architecture boundary: SceneDB holds per-entity HelioGpuLight, the render
+    /// executor owns the compacted movable-only buffer.
+    pub(crate) lights_gpu: helio_core::scene::GrowableBuffer<libhelio::GpuLight>,
+
+    /// Number of movable lights in `lights_gpu` (static/stationary excluded from runtime).
+    pub(crate) movable_light_count: u32,
+
     /// True when the objects list has changed and the GPU instance/draw_call/indirect
     /// buffers need to be rebuilt from scratch (sorted by mesh+material for instancing).
     pub(in crate::scene) objects_dirty: bool,
@@ -147,7 +157,7 @@ pub struct Scene {
 
     /// Generation counter for movable lights - increments when any Movable light's position/direction changes.
     /// Used by shadow caching to detect when Movable lights move.
-    pub(in crate::scene) movable_lights_generation: u64,
+    pub(crate) movable_lights_generation: u64,
 
     /// Number of shadow-map array layers available in the active render graph.
     /// Six consecutive layers are reserved per realtime shadow caster.
@@ -415,6 +425,12 @@ impl Scene {
             textures: SparsePool::new(),
             texture_binding_version: 0,
             material_binding,
+            lights_gpu: helio_core::scene::GrowableBuffer::new(
+                device.clone(),
+                256,
+                wgpu::BufferUsages::STORAGE,
+                "Helio Scene Lights",
+            ),
             material_textures: GrowableBuffer::new(
                 device,
                 256,
@@ -430,6 +446,7 @@ impl Scene {
             decals_dirty_range: None,
             objects_by_tag: HashMap::new(),
             lights_by_tag: HashMap::new(),
+            movable_light_count: 0,
             objects_dirty: true,             // rebuild on first flush
             static_objects_dirty: true,      // rebuild static shadow atlas on first flush
             bake_invalidated: false,         // no bake configured yet

--- a/crates/helio/src/scene/editor_debug.rs
+++ b/crates/helio/src/scene/editor_debug.rs
@@ -155,7 +155,7 @@ impl super::Scene {
         // Spots get both cones: the outer one is where the light stops, the
         // inner one where its falloff begins, and the gap between them is the
         // fade. Points get their attenuation radius.
-        for (_, rec) in self.lights.iter_with_handles() {
+        for (_, rec) in self.world.query::<&crate::scene::types::LightRecord>() {
             let g = &rec.gpu;
             let pos = v3(&g.position_range);
             let range = g.position_range[3];

--- a/crates/helio/src/scene/flush.rs
+++ b/crates/helio/src/scene/flush.rs
@@ -7,6 +7,7 @@
 use bytemuck::Zeroable;
 use libhelio::{GpuDecal, GpuLight, GpuShadowMatrix};
 
+use crate::scene::types::LightRecord;
 use crate::scene::Scene;
 
 /// FNV-1a hash over f32 bit patterns. Used for per-caster shadow dirty tracking.
@@ -76,17 +77,22 @@ impl Scene {
         // Static/stationary lights are baked and should not contribute to real-time lighting.
         // This dramatically improves performance when scenes have many baked lights.
         {
-            let light_rec_count = self.lights.dense_len();
-            let mut movable_lights: Vec<GpuLight> = Vec::with_capacity(light_rec_count);
+            let mut movable_lights: Vec<GpuLight> = Vec::new();
             let mut gpu_idx = 0u32;
+            let mut light_rec_count = 0u32;
 
-            for i in 0..light_rec_count {
-                if let Some(record) = self.lights.get_dense_mut(i) {
-                    if record.movability.can_move() {
-                        record.gpu_index = gpu_idx;
-                        gpu_idx += 1;
-                        movable_lights.push(record.gpu);
-                    }
+            // `gpu_index` is the sole authority for a light's GPU-buffer slot
+            // (see `resources/lights.rs`'s module doc) ??? reset every static
+            // light's to the "not a resident" sentinel here too, not just at
+            // insert, so nothing can ever read a stale slot for one.
+            for (_, record) in self.world.query::<&mut LightRecord>() {
+                light_rec_count += 1;
+                if record.movability.can_move() {
+                    record.gpu_index = gpu_idx;
+                    gpu_idx += 1;
+                    movable_lights.push(record.gpu);
+                } else {
+                    record.gpu_index = u32::MAX;
                 }
             }
 
@@ -94,11 +100,11 @@ impl Scene {
             self.gpu_scene.lights.set_data(movable_lights.clone());
             self.gpu_scene.movable_light_count = movable_lights.len() as u32;
 
-            if movable_lights.len() < light_rec_count {
+            if (movable_lights.len() as u32) < light_rec_count {
                 log::trace!(
                     "[helio] Filtered lights for runtime: {} movable, {} static/stationary (baked)",
                     movable_lights.len(),
-                    light_rec_count - movable_lights.len()
+                    light_rec_count - movable_lights.len() as u32
                 );
             }
         }

--- a/crates/helio/src/scene/flush.rs
+++ b/crates/helio/src/scene/flush.rs
@@ -97,14 +97,19 @@ impl Scene {
             }
 
             // Replace the lights buffer with only movable lights
-            self.gpu_scene.lights.set_data(movable_lights.clone());
-            self.gpu_scene.movable_light_count = movable_lights.len() as u32;
+            // (SceneDB's HelioGpuLight column holds ALL lights; this compacted
+            // buffer is owned by the render executor, not SceneDB.)
+            let count = movable_lights.len() as u32;
+            if count > 0 || self.lights_gpu.len() > 0 {
+                self.lights_gpu.set_data(movable_lights);
+            }
+            self.movable_light_count = count;
 
-            if (movable_lights.len() as u32) < light_rec_count {
+            if count < light_rec_count {
                 log::trace!(
                     "[helio] Filtered lights for runtime: {} movable, {} static/stationary (baked)",
-                    movable_lights.len(),
-                    light_rec_count - movable_lights.len() as u32
+                    count,
+                    light_rec_count - count
                 );
             }
         }

--- a/crates/helio/src/scene/flush.rs
+++ b/crates/helio/src/scene/flush.rs
@@ -323,6 +323,12 @@ impl Scene {
             self.gpu_scene.graph_wgsl_snippets = snippets;
         }
 
+        // ── SceneDB frame-boundary chain ──────────────────────────────────────
+        // Runs the full simulate → harvest → boundary → compact → sync pipeline
+        // before the GPU scene submit, so this frame's render passes see this
+        // frame's flushed world-mirror buffers (Helio #210).
+        self.flush_scenedb_boundary();
+
         self.gpu_scene.flush();
     }
 }

--- a/crates/helio/src/scene/groups/membership.rs
+++ b/crates/helio/src/scene/groups/membership.rs
@@ -8,6 +8,7 @@ use crate::handles::ObjectId;
 
 use super::super::errors::{invalid, Result};
 use super::super::helpers::object_is_visible;
+use super::super::types::ObjectRecord;
 
 impl super::super::Scene {
     /// Set the complete group membership mask for an object.
@@ -48,7 +49,7 @@ impl super::super::Scene {
     /// // Object is now hidden if group 0 OR group 2 is hidden
     /// ```
     pub fn set_object_groups(&mut self, id: ObjectId, mask: GroupMask) -> Result<()> {
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         record.groups = mask;
@@ -93,7 +94,7 @@ impl super::super::Scene {
     /// // Object is now in groups 0, 1, and 2 if it was in 0 and 2 before
     /// ```
     pub fn add_object_to_group(&mut self, id: ObjectId, group: GroupId) -> Result<()> {
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         let new_mask = record.groups.with(group);
@@ -139,7 +140,7 @@ impl super::super::Scene {
     /// // Object is now only in groups 0 and 2 if it was in 0, 1, and 2 before
     /// ```
     pub fn remove_object_from_group(&mut self, id: ObjectId, group: GroupId) -> Result<()> {
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         let new_mask = record.groups.without(group);
@@ -179,7 +180,7 @@ impl super::super::Scene {
     /// }
     /// ```
     pub fn object_groups(&self, id: ObjectId) -> Result<GroupMask> {
-        let Some((_, record)) = self.objects.get_with_index(id) else {
+        let Some(record) = self.world.get::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         Ok(record.groups)

--- a/crates/helio/src/scene/groups/transforms.rs
+++ b/crates/helio/src/scene/groups/transforms.rs
@@ -7,6 +7,7 @@ use glam::{Mat4, Vec3};
 use crate::groups::GroupId;
 
 use super::super::helpers::{normal_matrix, sphere_to_aabb};
+use super::super::types::ObjectRecord;
 
 impl super::super::Scene {
     /// Apply a transform delta to every object in a group.
@@ -58,11 +59,7 @@ impl super::super::Scene {
     /// scene.move_group(group_enemies, Mat4::from_scale(Vec3::splat(2.0)));
     /// ```
     pub fn move_group(&mut self, group: GroupId, delta: Mat4) {
-        let n = self.objects.dense_len();
-        for i in 0..n {
-            let Some(r) = self.objects.get_dense_mut(i) else {
-                continue;
-            };
+        for (_, r) in self.world.query::<&mut ObjectRecord>() {
             if !r.groups.contains(group) {
                 continue;
             }

--- a/crates/helio/src/scene/groups/visibility.rs
+++ b/crates/helio/src/scene/groups/visibility.rs
@@ -6,6 +6,7 @@
 use crate::groups::{GroupId, GroupMask};
 
 use super::super::helpers::object_is_visible;
+use super::super::types::ObjectRecord;
 
 impl super::super::Scene {
     /// Hide all objects that belong to a group.
@@ -162,11 +163,7 @@ impl super::super::Scene {
             return;
         }
         let group_hidden = self.group_hidden;
-        let n = self.objects.dense_len();
-        for i in 0..n {
-            let Some(r) = self.objects.get_dense(i) else {
-                continue;
-            };
+        for (_, r) in self.world.query::<&ObjectRecord>() {
             let vis = if object_is_visible(r.groups, group_hidden) {
                 1u32
             } else {

--- a/crates/helio/src/scene/lifecycle.rs
+++ b/crates/helio/src/scene/lifecycle.rs
@@ -7,6 +7,7 @@
 use glam::Mat4;
 use libhelio::sky::SkyContext;
 
+use crate::scene::types::{LightRecord, ObjectRecord};
 use crate::scene::Scene;
 use crate::scene::SceneActorTrait;
 
@@ -22,8 +23,12 @@ impl Scene {
     /// Calls `flush()` before returning so GPU buffers are synchronised.
     pub fn clear(&mut self) {
         // Collect all handles before mutating — iterators are invalidated by removal.
-        let object_ids: Vec<_> = self.objects.iter_with_handles().map(|(id, _)| id).collect();
-        let light_ids:  Vec<_> = self.lights.iter_with_handles().map(|(id, _)| id).collect();
+        let object_ids: Vec<_> = self.world.query::<&ObjectRecord>()
+            .map(|(entity, _)| crate::handles::ObjectId::from_entity(entity))
+            .collect();
+        let light_ids:  Vec<_> = self.world.query::<&LightRecord>()
+            .map(|(entity, _)| crate::handles::LightId::from_entity(entity))
+            .collect();
 
         // Objects first: the cascade frees meshes, materials, and textures.
         for id in object_ids {
@@ -143,11 +148,7 @@ impl Scene {
         let mut static_light_count = 0;
 
         // Extract all static objects
-        for i in 0..self.objects.dense_len() {
-            let Some(object_record) = self.objects.get_dense(i) else {
-                continue;
-            };
-
+        for (_, object_record) in self.world.query::<&ObjectRecord>() {
             // Skip movable objects - only bake static and stationary geometry
             if object_record.movability == Movability::Movable {
                 continue;
@@ -168,11 +169,7 @@ impl Scene {
         }
 
         // Extract all static lights
-        for i in 0..self.lights.dense_len() {
-            let Some(light_record) = self.lights.get_dense(i) else {
-                continue;
-            };
-
+        for (_, light_record) in self.world.query::<&LightRecord>() {
             // Include ALL lights in the bake regardless of movability.
             // Lights default to Movable even for static scenes; filtering them out
             // would result in a zero-light bake and an all-black lightmap.

--- a/crates/helio/src/scene/mod.rs
+++ b/crates/helio/src/scene/mod.rs
@@ -74,6 +74,7 @@ mod objects;
 mod portals;
 mod postprocess;
 mod resources;
+mod scenedb;
 mod stats;
 mod sublevels;
 mod types;

--- a/crates/helio/src/scene/mod.rs
+++ b/crates/helio/src/scene/mod.rs
@@ -75,6 +75,7 @@ mod portals;
 mod postprocess;
 mod resources;
 mod scenedb;
+mod scenedb_components;
 mod stats;
 mod sublevels;
 mod types;

--- a/crates/helio/src/scene/objects/insert.rs
+++ b/crates/helio/src/scene/objects/insert.rs
@@ -1,8 +1,4 @@
-//! Object insertion operations.
-//!
-//! Provides the [`Scene::insert_object`](crate::Scene::insert_object) method for adding
-//! renderable objects to the scene. Objects are automatically batched into instanced
-//! draw calls on the next flush.
+//! Object insertion operations (SceneDB-backed).
 
 use crate::handles::ObjectId;
 
@@ -11,52 +7,14 @@ use super::super::helpers::object_gpu_data;
 use super::super::types::ObjectDescriptor;
 
 impl super::super::Scene {
-    /// Insert a renderable object into the scene.
+    /// Insert a renderable object into the scene (SceneDB-backed).
     ///
-    /// Creates a new object that references a mesh and material, with a world-space
-    /// transform and optional group membership. Objects sharing the same mesh and
-    /// material are automatically batched into instanced draw calls on the next flush.
-    ///
-    /// # Parameters
-    /// - `desc`: Object descriptor containing:
-    ///   - `mesh`: Mesh handle from [`insert_mesh`](crate::Scene::insert_mesh)
-    ///   - `material`: Material handle from [`insert_material`](crate::Scene::insert_material)
-    ///   - `transform`: World-space model matrix (column-major)
-    ///   - `bounds`: Bounding sphere `[center.x, center.y, center.z, radius]`
-    ///   - `flags`: Render flags (bit 0 = casts shadow, bit 1 = receives shadow)
-    ///   - `groups`: Group membership mask for batch visibility control
-    ///
-    /// # Errors
-    /// - [`SceneError::InvalidHandle`](super::super::SceneError::InvalidHandle) if the mesh or material ID is invalid
-    ///
-    /// # Returns
-    /// An [`ObjectId`] handle that can be used to update or remove the object.
-    ///
-    /// # Performance
-    /// - CPU cost: O(1) insertion into dense arena
-    /// - GPU cost: Full optimized rebuild deferred to next `flush()` — includes
-    ///   automatic instancing (objects with the same mesh+material share a draw call)
-    ///
-    /// # Example
-    /// ```ignore
-    /// use helio::{ObjectDescriptor, GroupMask};
-    /// use glam::Mat4;
-    ///
-    /// let obj_id = scene.insert_object(ObjectDescriptor {
-    ///     mesh: mesh_id,
-    ///     material: material_id,
-    ///     transform: Mat4::from_translation([0.0, 1.5, 0.0].into()),
-    ///     bounds: [0.0, 1.5, 0.0, 1.6],  // Sphere at (0, 1.5, 0) with radius 1.6
-    ///     flags: 0b11,                    // Casts and receives shadows
-    ///     groups: GroupMask::NONE,        // Always visible
-    /// })?;
-    /// ```
-    ///
-    /// # Reference Counting
-    ///
-    /// Increments the reference count for the mesh and material. They cannot be removed
-    /// while this object exists. Call [`remove_object`](crate::Scene::remove_object) to
-    /// decrement reference counts.
+    /// Spawns an entity in [`Scene::world`](crate::Scene) with
+    /// [`HelioGpuInstance`] (GPU-mirrored render data) and
+    /// [`HelioCpuInstance`] (CPU bookkeeping). The GPU fields are automatically
+    /// synced by `flush_gpu_mirror` — no manual buffer rebuild needed for the
+    /// per-object data (the sorted instance/draw-call buffers are still rebuilt
+    /// by `flush` for instancing).
     pub fn insert_object(&mut self, desc: ObjectDescriptor) -> Result<ObjectId> {
         let mesh_slice = {
             let mesh = self
@@ -78,26 +36,23 @@ impl super::super::Scene {
             .ok_or_else(|| invalid("mesh"))?
             .ref_count += 1;
 
+        let movability = desc.movability.unwrap_or_default();
+        let is_static = !movability.can_move();
         let user_tag = desc.user_tag;
-        let record = object_gpu_data(desc.mesh, material_slot, desc, mesh_slice);
-        let (id, _dense_index) = self.objects.insert(record);
+        let entity = self.world.spawn();
+        self.world.insert(entity, object_gpu_data(desc.mesh, material_slot, desc, mesh_slice));
+        let id = ObjectId::from_entity(entity);
 
-        // Index by application tag so the owner can find this object again
-        // without keeping its own id map. Tag 0 means "untagged".
+        // Index by application tag so the owner can find this object again.
         if user_tag != 0 {
             self.objects_by_tag.insert(user_tag, id);
         }
 
-        // Track static topology changes for shadow atlas caching
-        if let Some(r) = self.objects.get_mut_with_index(id).map(|(_, r)| r) {
-            if !r.movability.can_move() {
-                self.static_objects_dirty = true;
-                self.bake_invalidated = true;
-            }
+        if is_static {
+            self.static_objects_dirty = true;
+            self.bake_invalidated = true;
         }
 
-        // Mark for full optimized rebuild on next flush — this automatically
-        // batches objects with the same mesh+material into instanced draw calls.
         self.objects_dirty = true;
 
         Ok(id)

--- a/crates/helio/src/scene/objects/rebuild.rs
+++ b/crates/helio/src/scene/objects/rebuild.rs
@@ -5,8 +5,10 @@
 //! objects with the same mesh + material into instanced draw calls.
 
 use helio_core::{DrawIndexedIndirectArgs, GpuDrawCall, GpuInstanceAabb, GpuInstanceData};
+use pulsar_scenedb::Entity;
 
 use super::super::helpers::object_is_visible;
+use super::super::types::ObjectRecord;
 
 impl super::super::Scene {
     /// Rebuilds GPU buffers with automatic instancing.
@@ -50,7 +52,18 @@ impl super::super::Scene {
     /// - Objects using the same material are drawn consecutively (texture cache hits)
     /// - GPU can efficiently batch vertex fetches and texture samples
     pub(in crate::scene) fn rebuild_instance_buffers(&mut self) {
-        let n = self.objects.dense_len();
+        // One O(n) collection out of the ECS, sorted/grouped/patched in place
+        // from here on ??? same cost shape as the old `DenseArena`'s `dense: Vec<T>`
+        // (that was already a full-array scan+sort on every rebuild; this is
+        // the same, just sourced from `World::query` instead of a public
+        // field). `ObjectRecord` is `Clone` (small, no heap fields), so this
+        // is a flat copy, not a walk of anything nested.
+        let rows: Vec<(Entity, ObjectRecord)> = self
+            .world
+            .query::<&ObjectRecord>()
+            .map(|(entity, r)| (entity, r.clone()))
+            .collect();
+        let n = rows.len();
         if n == 0 {
             self.gpu_scene.instances.set_data(Vec::new());
             self.gpu_scene.aabbs.set_data(Vec::new());
@@ -71,7 +84,7 @@ impl super::super::Scene {
         // single PSO.
         let mut order: Vec<usize> = (0..n).collect();
         order.sort_by_key(|&i| {
-            let r = self.objects.get_dense(i).unwrap();
+            let r = &rows[i].1;
             let (class, graph_hash) = self
                 .materials
                 .get(r.material)
@@ -99,7 +112,7 @@ impl super::super::Scene {
 
         let mut i = 0;
         while i < order.len() {
-            let r0 = self.objects.get_dense(order[i]).unwrap();
+            let r0 = &rows[order[i]].1;
             let (class, graph_hash) = self
                 .materials
                 .get(r0.material)
@@ -115,7 +128,7 @@ impl super::super::Scene {
 
             // Consume all objects in this group.
             while i < order.len() {
-                let r = self.objects.get_dense(order[i]).unwrap();
+                let r = &rows[order[i]].1;
                 if (r.instance.mesh_id, r.instance.material_id) != key {
                     break;
                 }
@@ -195,7 +208,8 @@ impl super::super::Scene {
         // Patch each ObjectRecord with its new GPU slot so that in-frame
         // `update_object_transform` / `update_object_bounds` can update in-place.
         for (di, &slot) in gpu_slots.iter().enumerate() {
-            if let Some(r) = self.objects.get_dense_mut(di) {
+            let entity = rows[di].0;
+            if let Some(r) = self.world.get_mut::<ObjectRecord>(entity) {
                 r.gpu_slot = slot;
                 r.draw.first_instance = slot;
             }
@@ -236,18 +250,11 @@ impl super::super::Scene {
     /// When `static_objects_dirty` is `true`, `static_objects_generation` is incremented
     /// to signal the ShadowPass to re-render the static shadow atlas.
     pub(in crate::scene) fn rebuild_shadow_partition_buffers(&mut self) {
-        let n = self.objects.dense_len();
-
         // Build two INDIRECT call lists — one per mobility class.
-        // first_instance in each entry is the object's dense_index into the main
-        // `instances` buffer, so transforms stay in sync with update_object_transform.
-        // DO NOT copy instance data into separate buffers — that causes stale shadows.
         let mut static_indirect: Vec<DrawIndexedIndirectArgs> = Vec::new();
         let mut movable_indirect: Vec<DrawIndexedIndirectArgs> = Vec::new();
 
-        for i in 0..n {
-            let r = self.objects.get_dense(i).unwrap();
-            // Use the object's actual first_instance (its slot in the main instances buffer).
+        for (_, r) in self.world.query::<&ObjectRecord>() {
             let entry = DrawIndexedIndirectArgs {
                 index_count: r.draw.index_count,
                 instance_count: 1,
@@ -286,5 +293,100 @@ impl super::super::Scene {
             static_draw_count,
             movable_draw_count,
         );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::handles::MaterialId;
+    use crate::mesh::{MeshUpload, PackedVertex};
+    use crate::scene::{ObjectDescriptor, Scene};
+    use crate::groups::GroupMask;
+    use bytemuck::Zeroable;
+    use glam::Mat4;
+    use libhelio::{GpuMaterial, Movability};
+
+    fn create_test_device() -> (std::sync::Arc<wgpu::Device>, std::sync::Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
+        });
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+            apply_limit_buckets: false,
+        }))
+        .expect("No adapter found");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            ..Default::default()
+        }))
+        .expect("Failed to create device");
+        (std::sync::Arc::new(device), std::sync::Arc::new(queue))
+    }
+
+    fn triangle_mesh(scene: &mut Scene) -> crate::handles::MeshId {
+        scene.insert_mesh(MeshUpload {
+            vertices: vec![PackedVertex::default(); 3],
+            indices: vec![0, 1, 2],
+        })
+    }
+
+    fn default_material(scene: &mut Scene) -> MaterialId {
+        scene.insert_material(GpuMaterial::zeroed())
+    }
+
+    /// End-to-end proof that object storage really is backed by
+    /// `pulsar_scenedb::World` now: insert ??? flush (rebuild_instance_buffers,
+    /// this file) ??? update transform (in-place GPU write) ??? remove ??? flush
+    /// again, checking the real `gpu_scene` instance buffer at each step ???
+    /// not just that the CPU record round-trips.
+    #[test]
+    fn insert_update_remove_round_trips_through_the_real_gpu_buffers() {
+        let (device, queue) = create_test_device();
+        let mut scene = Scene::new(device, queue);
+
+        let mesh = triangle_mesh(&mut scene);
+        let material = default_material(&mut scene);
+
+        let id = scene
+            .insert_object(ObjectDescriptor {
+                mesh,
+                material,
+                transform: Mat4::IDENTITY,
+                bounds: [0.0, 0.0, 0.0, 1.0],
+                flags: 0,
+                groups: GroupMask::NONE,
+                movability: Some(Movability::Movable),
+                user_tag: 0,
+            })
+            .expect("insert_object");
+
+        scene.flush();
+        assert_eq!(scene.gpu_scene().resources().instance_count, 1);
+        assert_eq!(
+            scene.get_object_transform(id).expect("transform"),
+            Mat4::IDENTITY
+        );
+
+        let moved = Mat4::from_translation(glam::Vec3::new(1.0, 2.0, 3.0));
+        scene
+            .update_object_transform(id, moved)
+            .expect("update_object_transform");
+        // In-place write (objects_dirty is false after the flush above) ???
+        // no second flush needed for the CPU-side round-trip to see it.
+        assert_eq!(scene.get_object_transform(id).expect("transform"), moved);
+
+        let editor_rows: Vec<_> = scene.iter_objects_for_editor().collect();
+        assert_eq!(editor_rows.len(), 1);
+        assert_eq!(editor_rows[0].0, id);
+
+        scene.remove_object(id).expect("remove_object");
+        assert!(scene.get_object_transform(id).is_err());
+
+        scene.flush();
+        assert_eq!(scene.gpu_scene().resources().instance_count, 0);
     }
 }

--- a/crates/helio/src/scene/objects/rebuild.rs
+++ b/crates/helio/src/scene/objects/rebuild.rs
@@ -65,16 +65,12 @@ impl super::super::Scene {
             .collect();
         let n = rows.len();
         if n == 0 {
-            self.gpu_scene.instances.set_data(Vec::new());
-            self.gpu_scene.aabbs.set_data(Vec::new());
-            self.gpu_scene.draw_calls.set_data(Vec::new());
-            self.gpu_scene.indirect.set_data(Vec::new());
-            self.gpu_scene.visibility.set_data(Vec::new());
-            self.gpu_scene.compacted_indices.set_data(Vec::new());
-            self.gpu_scene.compacted_indices_2.set_data(Vec::new());
-            self.gpu_scene.material_class_ranges.clear();
-            self.gpu_scene.transparent_material_class_ranges.clear();
-            self.gpu_scene.forward_material_class_ranges.clear();
+            self.instances_gpu.set_data(Vec::new());
+            self.aabbs_gpu.set_data(Vec::new());
+            self.draw_calls_gpu.set_data(Vec::new());
+            self.indirect_gpu.set_data(Vec::new());
+            self.instance_count = 0;
+            self.draw_count = 0;
             return;
         }
 
@@ -225,13 +221,17 @@ impl super::super::Scene {
         // Sized only to keep the GPU buffer's capacity in step with `instances` —
         // content is fully overwritten by IndirectDispatchPass every frame, so the
         // zeros here are never read.
-        let compacted_indices_capacity = vec![0u32; instances.len()];
-        let compacted_indices_2_capacity = vec![0u32; instances.len()];
+        let instance_count = instances.len() as u32;
+        let draw_count = draw_calls.len() as u32;
+        let compacted_indices_capacity = vec![0u32; instance_count as usize];
+        let compacted_indices_2_capacity = vec![0u32; instance_count as usize];
 
-        self.gpu_scene.instances.set_data(instances);
-        self.gpu_scene.aabbs.set_data(aabbs);
-        self.gpu_scene.draw_calls.set_data(draw_calls);
-        self.gpu_scene.indirect.set_data(indirect);
+        self.instances_gpu.set_data(instances);
+        self.aabbs_gpu.set_data(aabbs);
+        self.draw_calls_gpu.set_data(draw_calls);
+        self.indirect_gpu.set_data(indirect);
+        self.instance_count = instance_count;
+        self.draw_count = draw_count;
         self.gpu_scene.visibility.set_data(visibility);
         self.gpu_scene.compacted_indices.set_data(compacted_indices_capacity);
         self.gpu_scene.compacted_indices_2.set_data(compacted_indices_2_capacity);
@@ -365,7 +365,7 @@ mod tests {
             .expect("insert_object");
 
         scene.flush();
-        assert_eq!(scene.gpu_scene().resources().instance_count, 1);
+        assert_eq!(scene.instance_count, 1);
         assert_eq!(
             scene.get_object_transform(id).expect("transform"),
             Mat4::IDENTITY
@@ -387,6 +387,6 @@ mod tests {
         assert!(scene.get_object_transform(id).is_err());
 
         scene.flush();
-        assert_eq!(scene.gpu_scene().resources().instance_count, 0);
+        assert_eq!(scene.instance_count, 0);
     }
 }

--- a/crates/helio/src/scene/objects/remove.rs
+++ b/crates/helio/src/scene/objects/remove.rs
@@ -1,71 +1,30 @@
-//! Object removal operations.
-//!
-//! Provides the [`Scene::remove_object`](crate::Scene::remove_object) method for removing
-//! renderable objects from the scene.
+//! Object removal operations (SceneDB-backed).
 
 use crate::handles::ObjectId;
+use crate::scene::types::ObjectRecord;
 
 use super::super::errors::{invalid, Result};
 
 impl super::super::Scene {
-    /// Remove an object from the scene.
-    ///
-    /// Removes the object from the dense arena and decrements mesh and material reference
-    /// counts. GPU buffers are rebuilt on the next flush with automatic instancing.
-    ///
-    /// # Parameters
-    /// - `id`: Object handle returned by [`insert_object`](crate::Scene::insert_object)
-    ///
-    /// # Errors
-    /// - [`SceneError::InvalidHandle`](super::super::SceneError::InvalidHandle) if the object ID is invalid
-    ///
-    /// # Returns
-    /// `Ok(())` if the object was successfully removed.
-    ///
-    /// # Performance
-    /// - CPU cost: O(1) removal from dense arena
-    /// - GPU cost: Full optimized rebuild deferred to next `flush()`
-    ///
-    /// # Reference Counting
-    ///
-    /// Decrements reference counts for the mesh and material. If the reference count
-    /// reaches zero, the mesh/material can be removed with [`remove_mesh`](crate::Scene::remove_mesh)
-    /// or [`remove_material`](crate::Scene::remove_material).
-    ///
-    /// # Example
-    /// ```ignore
-    /// // Remove object
-    /// scene.remove_object(obj_id)?;
-    ///
-    /// // Now mesh and material may be removable (if no other objects use them)
-    /// if mesh_ref_count == 0 {
-    ///     scene.remove_mesh(mesh_id)?;
-    /// }
-    /// if material_ref_count == 0 {
-    ///     scene.remove_material(material_id)?;
-    /// }
-    /// ```
+    /// Remove an object from the scene (SceneDB-backed).
     pub fn remove_object(&mut self, id: ObjectId) -> Result<()> {
-        // Capture handles and movability before removal.
+        let entity = id.entity();
         let (mesh_id, material_id, is_static, user_tag) = {
-            let (_, r) = self
-                .objects
-                .get_with_index(id)
+            let r = self
+                .world
+                .query::<(&ObjectRecord,)>()
+                .find(|(e, _)| *e == entity)
+                .map(|(_, (r,))| r)
                 .ok_or_else(|| invalid("object"))?;
             (r.mesh, r.material, !r.movability.can_move(), r.user_tag)
         };
 
-        // Remove from CPU-side arena only.
-        // GPU buffers will be rebuilt with automatic instancing on next flush.
-        self.objects.remove(id).ok_or_else(|| invalid("object"))?;
+        self.world.despawn(entity);
 
-        // Drop the tag index entry, but only if it still points at *this*
-        // object — a newer object may have since claimed the same tag.
         if user_tag != 0 && self.objects_by_tag.get(&user_tag) == Some(&id) {
             self.objects_by_tag.remove(&user_tag);
         }
 
-        // Decrement ref counts
         if let Some(material) = self
             .materials
             .get_mut_with_slot(material_id)
@@ -77,10 +36,8 @@ impl super::super::Scene {
             mesh.ref_count = mesh.ref_count.saturating_sub(1);
         }
 
-        // Mark for full optimized rebuild on next flush.
         self.objects_dirty = true;
 
-        // Cascade: auto-free mesh and material when their ref counts hit zero.
         if self
             .mesh_pool
             .get(mesh_id)
@@ -96,7 +53,6 @@ impl super::super::Scene {
             let _ = self.remove_material(material_id);
         }
 
-        // After removal: mark static atlas dirty if a static object was removed
         if is_static {
             self.static_objects_dirty = true;
         }

--- a/crates/helio/src/scene/objects/update.rs
+++ b/crates/helio/src/scene/objects/update.rs
@@ -261,9 +261,7 @@ impl super::super::Scene {
 
         let mut updated_count = 0;
 
-        // Iterate all objects and update lightmap indices for static objects.
-        // DenseArena exposes its `dense: Vec<T>` as a public field — iterate directly.
-        for record in self.objects.dense.iter_mut() {
+        for (_, record) in self.world.query::<&mut ObjectRecord>() {
             // Only non-movable objects are baked (Static + Stationary).
             // build_static_bake_scene includes both, so lightmap indices must
             // be assigned for both here to avoid a silent mismatch.

--- a/crates/helio/src/scene/objects/update.rs
+++ b/crates/helio/src/scene/objects/update.rs
@@ -9,7 +9,7 @@ use crate::handles::{MaterialId, MeshId, ObjectId};
 
 use super::super::errors::{invalid, Result};
 use super::super::helpers::{normal_matrix, sphere_to_aabb};
-use super::super::types::PickableObject;
+use super::super::types::{ObjectRecord, PickableObject};
 
 impl super::super::Scene {
     /// Update an object's world transform.
@@ -71,7 +71,7 @@ impl super::super::Scene {
     /// scene.update_object_transform(obj_id, rotation * current_transform)?;
     /// ```
     pub fn update_object_transform(&mut self, id: ObjectId, transform: Mat4) -> Result<()> {
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         // Enforce movability: Static objects cannot have transforms updated
@@ -150,7 +150,7 @@ impl super::super::Scene {
             new_material.ref_count += 1;
             slot
         };
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         let old_material_id = record.material;
@@ -204,7 +204,7 @@ impl super::super::Scene {
     /// scene.update_object_bounds(obj_id, new_bounds)?;
     /// ```
     pub fn update_object_bounds(&mut self, id: ObjectId, bounds: [f32; 4]) -> Result<()> {
-        let Some((_, record)) = self.objects.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         record.instance.bounds = bounds;
@@ -302,7 +302,7 @@ impl super::super::Scene {
     ///
     /// Returns `Err` if the handle is invalid.
     pub fn get_object_transform(&self, id: ObjectId) -> Result<Mat4> {
-        let Some((_, record)) = self.objects.get_with_index(id) else {
+        let Some(record) = self.world.get::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         Ok(Mat4::from_cols_array(&record.instance.model))
@@ -312,7 +312,7 @@ impl super::super::Scene {
     ///
     /// Returns `Err` if the handle is invalid.
     pub fn get_object_bounds(&self, id: ObjectId) -> Result<[f32; 4]> {
-        let Some((_, record)) = self.objects.get_with_index(id) else {
+        let Some(record) = self.world.get::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         Ok(record.instance.bounds)
@@ -329,9 +329,9 @@ impl super::super::Scene {
     pub fn iter_objects_for_editor(
         &self,
     ) -> impl Iterator<Item = (ObjectId, Mat4, [f32; 4], u64)> + '_ {
-        self.objects.iter_with_handles().map(|(id, rec)| {
+        self.world.query::<&ObjectRecord>().map(|(entity, rec)| {
             let transform = Mat4::from_cols_array(&rec.instance.model);
-            (id, transform, rec.instance.bounds, rec.user_tag)
+            (ObjectId::from_entity(entity), transform, rec.instance.bounds, rec.user_tag)
         })
     }
 
@@ -342,7 +342,7 @@ impl super::super::Scene {
     pub fn get_object_descriptor(&self, id: ObjectId) -> Result<crate::scene::types::ObjectDescriptor> {
         use crate::scene::types::ObjectDescriptor;
         use crate::groups::GroupMask;
-        let Some((_, record)) = self.objects.get_with_index(id) else {
+        let Some(record) = self.world.get::<ObjectRecord>(id.entity()) else {
             return Err(invalid("object"));
         };
         Ok(ObjectDescriptor {
@@ -363,8 +363,8 @@ impl super::super::Scene {
     /// are added or removed.  O(N) over live objects — call on scene change, not
     /// per frame.
     pub fn iter_pickable_objects(&self) -> impl Iterator<Item = PickableObject> + '_ {
-        self.objects.iter_with_handles().map(|(id, rec)| PickableObject {
-            id,
+        self.world.query::<&ObjectRecord>().map(|(entity, rec)| PickableObject {
+            id: crate::handles::ObjectId::from_entity(entity),
             mesh_id: rec.mesh,
             transform: Mat4::from_cols_array(&rec.instance.model),
             user_tag: rec.user_tag,

--- a/crates/helio/src/scene/resources/lights.rs
+++ b/crates/helio/src/scene/resources/lights.rs
@@ -1,8 +1,21 @@
 //! Light resource management for the scene.
 //!
-//! Lights are stored in a dense arena and uploaded to GPU storage buffers.
-//! Unlike other resources, lights have no reference counting (they exist
-//! independently of objects).
+//! Lights are stored on the CPU archetype ECS (`Scene::world`, see
+//! `docs/scenedb_object_storage_migration.md`) and uploaded to GPU storage
+//! buffers. Unlike other resources, lights have no reference counting (they
+//! exist independently of objects).
+//!
+//! `LightRecord::gpu_index` is the **sole** authority for a light's current
+//! slot in `gpu_scene.lights` ??? see the doc on that field and on
+//! [`Scene::insert_light_with_movability`] for why: an earlier version of
+//! this file additionally trusted the CPU dense-array position as a proxy
+//! for the GPU slot (`debug_assert_eq!(gpu_index, dense_index)` at insert
+//! time), which only held until the first `flush()` filtered any static
+//! light out of the buffer ??? after that, `remove_light`'s swap-remove used
+//! the wrong index for any scene with static lights, and `update_light`
+//! could write a static light's data into an unrelated (now-reused) GPU
+//! slot. Fixed here by never letting a static light's `gpu_index` claim a
+//! buffer slot it doesn't actually hold.
 
 use helio_core::GpuLight;
 
@@ -14,7 +27,9 @@ use super::super::types::LightRecord;
 impl super::super::Scene {
     /// Insert a light into the scene.
     ///
-    /// Adds the light to the dense arena and uploads it to the GPU light storage buffer.
+    /// Adds the light to the CPU ECS. Movable lights are also pushed to the
+    /// GPU light storage buffer immediately; static/stationary lights are
+    /// not ??? see [`Self::insert_light_with_movability`].
     ///
     /// # Parameters
     /// - `light`: GPU light parameters:
@@ -52,6 +67,12 @@ impl super::super::Scene {
     }
 
     /// Insert a light into the scene with explicit movability and user tag.
+    ///
+    /// Static/stationary lights are baked and `flush()`'s lights-filter step
+    /// excludes them from `gpu_scene.lights` on every frame regardless (real-time
+    /// lighting only shades movable lights) ??? so a static light is never given a
+    /// real GPU buffer slot here; `gpu_index` is `u32::MAX` ("not a buffer
+    /// resident") until/unless its movability changes to something that can move.
     pub fn insert_light_with_movability(
         &mut self,
         light: GpuLight,
@@ -61,14 +82,23 @@ impl super::super::Scene {
         // Default lights to Movable (most common case for real-time lighting).
         // Static lights are opt-in for baking scenarios.
         let movability = movability.unwrap_or(libhelio::Movability::Movable);
-        let gpu_index = self.gpu_scene.lights.push(light) as u32;
-        let (id, dense_index) = self.lights.insert(LightRecord {
-            gpu: light,
-            movability,
-            user_tag,
-            gpu_index,
-        });
-        debug_assert_eq!(gpu_index as usize, dense_index);
+        let gpu_index = if movability.can_move() {
+            self.gpu_scene.lights.push(light) as u32
+        } else {
+            u32::MAX
+        };
+
+        let entity = self.world.spawn();
+        self.world.insert(
+            entity,
+            LightRecord {
+                gpu: light,
+                movability,
+                user_tag,
+                gpu_index,
+            },
+        );
+        let id = LightId::from_entity(entity);
 
         // Index by application tag so the owner can find this light again
         // without keeping its own id map. Tag 0 means "untagged".
@@ -86,7 +116,11 @@ impl super::super::Scene {
 
     /// Update a light's parameters.
     ///
-    /// Modifies the light's GPU parameters and updates the GPU storage buffer.
+    /// Modifies the light's GPU parameters. Writes through to the GPU storage
+    /// buffer only for movable lights ??? a static light has no buffer slot to
+    /// write (see [`Self::insert_light_with_movability`]); its CPU record is
+    /// still updated, so the new values take effect if it's later baked or
+    /// its movability changes.
     ///
     /// # Parameters
     /// - `id`: Light handle
@@ -100,7 +134,7 @@ impl super::super::Scene {
     ///
     /// # Performance
     /// - CPU cost: O(1)
-    /// - GPU cost: Updates light storage buffer slot
+    /// - GPU cost: O(1) storage buffer slot write (movable lights only)
     ///
     /// # Example
     /// ```ignore
@@ -110,20 +144,14 @@ impl super::super::Scene {
     /// scene.update_light(light_id, light)?;
     /// ```
     pub fn update_light(&mut self, id: LightId, light: GpuLight) -> Result<()> {
-        let Some((_dense_index, record)) = self.lights.get_mut_with_index(id) else {
+        let Some(record) = self.world.get_mut::<LightRecord>(id.entity()) else {
             return Err(invalid("light"));
         };
-        // Enforce movability: Static lights cannot have position/direction updated
+
         if !record.movability.can_move() {
-            let old_pos = record.gpu.position_range;
-            let new_pos = light.position_range;
-            let old_dir = record.gpu.direction_outer;
-            let new_dir = light.direction_outer;
-
-            // Check if position or direction changed
-            let position_changed = old_pos != new_pos;
-            let direction_changed = old_dir != new_dir;
-
+            // Enforce movability: Static lights cannot have position/direction updated.
+            let position_changed = record.gpu.position_range != light.position_range;
+            let direction_changed = record.gpu.direction_outer != light.direction_outer;
             if position_changed || direction_changed {
                 log::warn!(
                     "Attempted to update position/direction on Static light {:?}. Set movability to Movable to allow updates.",
@@ -131,15 +159,16 @@ impl super::super::Scene {
                 );
                 return Ok(()); // No-op instead of error
             }
+            // No GPU slot to write (see module doc) ??? CPU record only.
+            record.gpu = light;
+            return Ok(());
         }
+
         record.gpu = light;
 
-        // Increment generation counter for movable lights (for shadow cache invalidation)
-        // Only increment if the light can actually move
-        if record.movability.can_move() {
-            self.movable_lights_generation += 1;
-            self.gpu_scene.movable_lights_generation = self.movable_lights_generation;
-        }
+        // Increment generation counter for movable lights (for shadow cache invalidation).
+        self.movable_lights_generation += 1;
+        self.gpu_scene.movable_lights_generation = self.movable_lights_generation;
 
         let gpu_index = record.gpu_index as usize;
         let updated = self.gpu_scene.lights.update(gpu_index, light);
@@ -149,8 +178,12 @@ impl super::super::Scene {
 
     /// Remove a light from the scene.
     ///
-    /// Removes the light from the dense arena and GPU storage buffer using swap-remove
-    /// (the last light is moved to the removed light's slot for O(1) removal).
+    /// Removes the light from the CPU ECS. If it was movable (and therefore
+    /// held a real slot in `gpu_scene.lights`), swap-removes it from the GPU
+    /// storage buffer too and patches whichever other light got swapped into
+    /// the vacated slot so its `gpu_index` stays accurate before the next
+    /// `flush()`. Static lights hold no GPU slot (see
+    /// [`Self::insert_light_with_movability`]) ??? nothing to swap-remove.
     ///
     /// # Parameters
     /// - `id`: Light handle
@@ -170,21 +203,32 @@ impl super::super::Scene {
     /// scene.remove_light(light_id)?;
     /// ```
     pub fn remove_light(&mut self, id: LightId) -> Result<()> {
-        let user_tag = self.lights.get(id).map(|r| r.user_tag).unwrap_or(0);
-        let removed = self.lights.remove(id).ok_or_else(|| invalid("light"))?;
-        let gpu_removed = self.gpu_scene.lights.swap_remove(removed.dense_index);
-        debug_assert!(gpu_removed.is_some());
+        let entity = id.entity();
+        let (user_tag, movability, gpu_index) = {
+            let r = self
+                .world
+                .query::<(&LightRecord,)>()
+                .find(|(e, _)| *e == entity)
+                .map(|(_, (r,))| r)
+                .ok_or_else(|| invalid("light"))?;
+            (r.user_tag, r.movability, r.gpu_index)
+        };
+        self.world.despawn(entity);
 
-        // Drop the tag index entry, but only if it still points at *this*
-        // light — a newer light may have since claimed the same tag.
         if user_tag != 0 && self.lights_by_tag.get(&user_tag) == Some(&id) {
             self.lights_by_tag.remove(&user_tag);
         }
 
-        // Update gpu_index for the element that was swap-moved into the vacated slot
-        if let Some((moved_handle, new_dense_index)) = removed.moved {
-            if let Some((_, record)) = self.lights.get_mut_with_index(moved_handle) {
-                record.gpu_index = new_dense_index as u32;
+        if movability.can_move() {
+            let gpu_removed = self.gpu_scene.lights.swap_remove(gpu_index as usize);
+            debug_assert!(gpu_removed.is_some());
+
+            let old_last_index = self.gpu_scene.lights.len() as u32;
+            for (_, other) in self.world.query::<&mut LightRecord>() {
+                if other.gpu_index == old_last_index {
+                    other.gpu_index = gpu_index;
+                    break;
+                }
             }
         }
 
@@ -192,3 +236,83 @@ impl super::super::Scene {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use crate::scene::Scene;
+    use bytemuck::Zeroable;
+    use helio_core::GpuLight;
+    use libhelio::Movability;
+
+    fn create_test_device() -> (std::sync::Arc<wgpu::Device>, std::sync::Arc<wgpu::Queue>) {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::from_env().unwrap_or(wgpu::Backends::PRIMARY),
+            ..wgpu::InstanceDescriptor::new_without_display_handle()
+        });
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::LowPower,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+            apply_limit_buckets: false,
+        }))
+        .expect("No adapter found");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            required_features: wgpu::Features::empty(),
+            required_limits: wgpu::Limits::downlevel_defaults(),
+            ..Default::default()
+        }))
+        .expect("Failed to create device");
+        (std::sync::Arc::new(device), std::sync::Arc::new(queue))
+    }
+
+    fn light_at(x: f32) -> GpuLight {
+        GpuLight {
+            position_range: [x, 0.0, 0.0, 10.0],
+            shadow_index: u32::MAX,
+            ..GpuLight::zeroed()
+        }
+    }
+
+    /// Regression test for the gpu_index bug this migration fixed: a static
+    /// light's slot in `gpu_scene.lights` used to go stale the moment
+    /// `flush()` filtered it out (real slots are movable-only), so calling
+    /// `update_light`/`remove_light` on it afterward could write into or
+    /// swap-remove a *different* light's GPU slot. `gpu_index` is now the
+    /// sole authority ??? `u32::MAX` means "not a resident", checked before
+    /// any GPU write.
+    #[test]
+    fn static_lights_never_hold_a_gpu_slot_and_updating_one_does_not_corrupt_others() {
+        let (device, queue) = create_test_device();
+        let mut scene = Scene::new(device, queue);
+
+        let a = scene.insert_light_with_movability(light_at(1.0), Some(Movability::Movable), 0);
+        let b = scene.insert_light_with_movability(light_at(2.0), Some(Movability::Static), 0);
+        let c = scene.insert_light_with_movability(light_at(3.0), Some(Movability::Movable), 0);
+
+        scene.flush();
+        // Only the two movable lights (A, C) actually hold a GPU slot.
+        assert_eq!(scene.gpu_scene().resources().light_count, 2);
+
+        // This used to write into whatever stale GPU slot B's gpu_index
+        // still pointed at (A's or C's) instead of doing nothing.
+        scene
+            .update_light(b, light_at(99.0))
+            .expect("update_light on a static light must not error or corrupt another light");
+        assert_eq!(scene.gpu_scene().resources().light_count, 2);
+        // A and C's data must be untouched by B's update.
+        assert_eq!(scene.get_light(a).unwrap().position_range[0], 1.0);
+        assert_eq!(scene.get_light(c).unwrap().position_range[0], 3.0);
+
+        // Removing A swap-removes it from gpu_scene.lights and must patch
+        // whichever light (C) got swapped into A's freed slot.
+        scene.remove_light(a).expect("remove_light");
+        assert_eq!(scene.gpu_scene().resources().light_count, 1);
+
+        // If C's gpu_index weren't patched correctly this would either trip
+        // update_light's debug_assert (out-of-bounds slot) or silently write
+        // the wrong slot; asserting the round-trip catches both.
+        scene
+            .update_light(c, light_at(30.0))
+            .expect("update_light on the swapped-in light");
+        assert_eq!(scene.get_light(c).unwrap().position_range[0], 30.0);
+    }
+}

--- a/crates/helio/src/scene/scenedb.rs
+++ b/crates/helio/src/scene/scenedb.rs
@@ -1,0 +1,228 @@
+//! SceneDB world-mirror frame-boundary integration (Helio #210).
+//!
+//! This module owns the [`SceneGpuMirrorSubsystem`] — a
+//! [`pulsar_scenedb::Subsystem`] that flushes the world-mirror store at the
+//! retire/compact boundary each frame — and the [`Scene`]'s
+//! [`flush_scenedb_boundary`] method that drives the full phase machine
+//! ([`pulsar_scenedb::gpu::FrameDriver`] → simulate → harvest → boundary
+//! → compact → sync).
+//!
+//! ## Two-store design
+//!
+//! The subsystem's store (`Arc<SceneGpuStore>`) is the *world-mirror* store
+//! shared with the [`GpuMirrorHandle`] attached to [`Scene::world`]. Flushing
+//! it is a `&self` operation. The *phase* store (`SceneGpuStore`, owned by
+//! value) drives the genuine `&mut` witness chain with empty cells, producing
+//! the required [`RetiredPhase`] for the subsystem hook. See the foundation
+//! brief for the full constraint analysis.
+
+use std::sync::Arc;
+
+use pulsar_scenedb::gpu::{RetiredPhase, SceneGpuStore};
+use pulsar_scenedb::Subsystem;
+
+use crate::scene::Scene;
+
+/// Flushes the world-mirror GPU store at the retire/compact boundary.
+///
+/// Runs inside [`pulsar_scenedb::SubsystemRegistry::boundary`], which is
+/// called with the genuine [`RetiredPhase`] produced by driving the
+/// frame-boundary chain against the [`Scene`]'s by-value [`SceneGpuStore`].
+pub(in crate::scene) struct SceneGpuMirrorSubsystem {
+    store: Arc<SceneGpuStore>,
+    queue: Arc<wgpu::Queue>,
+}
+
+impl SceneGpuMirrorSubsystem {
+    pub(in crate::scene) fn new(store: Arc<SceneGpuStore>, queue: Arc<wgpu::Queue>) -> Self {
+        Self { store, queue }
+    }
+}
+
+impl Subsystem for SceneGpuMirrorSubsystem {
+    fn name(&self) -> &'static str {
+        "scene_gpu_mirror"
+    }
+
+    fn boundary(&mut self, _phase: &RetiredPhase) {
+        let _stats = self.store.flush_gpu_mirror(&self.queue);
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+}
+
+impl Scene {
+    /// Drive the SceneDB frame-boundary phase machine for this frame.
+    ///
+    /// Called from [`Scene::flush`] before the GPU scene submit. Runs the
+    /// full phase chain against the by-value [`phase_store`] (which produces
+    /// the genuine [`RetiredPhase`] for the subsystem hook), dispatches
+    /// simulate/harvest/boundary to every registered subsystem, then
+    /// completes the compact→sync bookkeeping.
+    pub(in crate::scene) fn flush_scenedb_boundary(&mut self) {
+        let sim_a = self.scenedb_driver.begin();
+        self.scenedb_subsystems.simulate_a(&mut self.world, &sim_a);
+
+        let sim_b = sim_a.end();
+        self.scenedb_subsystems.simulate_b(&mut self.world, &sim_b);
+
+        let harvest = sim_b.end();
+        self.scenedb_subsystems.harvest(&self.mirror_store, &harvest);
+
+        let boundary = harvest.end();
+        let (retired, _drained) = boundary.retire(&mut self.phase_store, &mut []);
+        self.scenedb_subsystems.boundary(&retired);
+
+        let _sync = retired.compact(&mut self.phase_store, &mut []).sync(&mut self.phase_store, &mut []);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pulsar_scenedb::gpu::{
+        EngineGpuContext, GpuMirrorHandle, RegionClassConfig, SceneGpuConfig, SimulateA,
+    };
+    use pulsar_scenedb::{Entity, GpuColumnSet, SubsystemRegistry, World};
+    use pulsar_scenedb_derive::SceneStore;
+
+    /// Smoke component for testing the mirror round-trip through the frame chain.
+    #[derive(SceneStore, Clone, Copy)]
+    struct FrameSmokeComponent {
+        #[gpu]
+        value: u32,
+    }
+
+    /// Insert a known value into a pre-spawned entity during simulate_a.
+    struct Writer {
+        entity: Entity,
+        value: u32,
+    }
+
+    impl Subsystem for Writer {
+        fn name(&self) -> &'static str {
+            "writer"
+        }
+
+        fn simulate_a(&mut self, world: &mut World, _witness: &SimulateA) {
+            world.insert(self.entity, FrameSmokeComponent { value: self.value });
+        }
+
+        fn as_any(&self) -> &dyn std::any::Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            self
+        }
+    }
+
+    fn test_context(label: &str) -> EngineGpuContext {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+            apply_limit_buckets: false,
+        }))
+        .expect("no adapter — GPU tests need a local GPU");
+        let (device, queue) = pollster::block_on(adapter.request_device(&wgpu::DeviceDescriptor {
+            label: Some(label),
+            ..Default::default()
+        }))
+        .expect("device");
+        EngineGpuContext::new(Arc::new(device), Arc::new(queue))
+    }
+
+    fn readback_u32(ctx: &EngineGpuContext, buf: &wgpu::Buffer, row: u64) -> u32 {
+        let staging = ctx.device().create_buffer(&wgpu::BufferDescriptor {
+            label: Some("readback"),
+            size: 4,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut enc = ctx.device().create_command_encoder(&Default::default());
+        enc.copy_buffer_to_buffer(buf, row * 4, &staging, 0, 4);
+        ctx.queue().submit([enc.finish()]);
+        let slice = staging.slice(..);
+        slice.map_async(wgpu::MapMode::Read, |r| r.expect("map"));
+        ctx.device()
+            .poll(wgpu::PollType::wait_indefinitely())
+            .expect("poll");
+        let data = slice.get_mapped_range().expect("mapped range").to_vec();
+        staging.unmap();
+        u32::from_ne_bytes(data.try_into().unwrap())
+    }
+
+    #[test]
+    fn world_mirror_frame_chain_round_trip() {
+        let ctx = test_context("scenedb-foundation-chain-test");
+
+        let mut store = SceneGpuStore::new(
+            &ctx,
+            SceneGpuConfig {
+                classes: vec![RegionClassConfig {
+                    capacity: 64,
+                    max_resident_cells: 1,
+                }],
+                tombstone_headroom: SceneGpuConfig::default_headroom(),
+                max_cells_metadata: 16,
+            },
+        );
+        FrameSmokeComponent::register_gpu_columns_growable(&mut store, 8, ctx.device());
+        let store = Arc::new(store);
+
+        let mut world = World::new();
+        world.attach_gpu_mirror(GpuMirrorHandle::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+
+        let entity = world.spawn();
+        let row = entity.index() as u64;
+
+        let value_field_id = FrameSmokeComponent::gpu_columns()
+            .iter()
+            .find(|c| c.buffer_name == "value")
+            .unwrap()
+            .field_token
+            .id();
+
+        let mut registry = SubsystemRegistry::new();
+        registry.register(Writer { entity, value: 1234 });
+        registry.register(SceneGpuMirrorSubsystem::new(Arc::clone(&store), Arc::clone(ctx.queue())));
+
+        let mut driver = pulsar_scenedb::gpu::FrameDriver::new();
+        let mut phase_store = SceneGpuStore::new(
+            &ctx,
+            SceneGpuConfig {
+                classes: vec![],
+                tombstone_headroom: 0,
+                max_cells_metadata: 0,
+            },
+        );
+
+        let sim_a = driver.begin();
+        registry.simulate_a(&mut world, &sim_a);
+        let sim_b = sim_a.end();
+        registry.simulate_b(&mut world, &sim_b);
+        let harvest = sim_b.end();
+        registry.harvest(&store, &harvest);
+        let boundary = harvest.end();
+        let (retired, _drained) = boundary.retire(&mut phase_store, &mut []);
+        registry.boundary(&retired);
+        let _stats = retired.compact(&mut phase_store, &mut []).sync(&mut phase_store, &mut []);
+
+        let mut got = 0u32;
+        store.with_dirty_tracked_buffer_for_id(value_field_id, &mut |buf| {
+            got = readback_u32(&ctx, buf, row);
+        });
+        assert_eq!(
+            got, 1234,
+            "value written at simulate must be flushed to the GPU mirror by the boundary"
+        );
+    }
+}

--- a/crates/helio/src/scene/scenedb_components.rs
+++ b/crates/helio/src/scene/scenedb_components.rs
@@ -1,0 +1,123 @@
+//! SceneDB component types for Helio's scene object data (Helio #210).
+//!
+//! GPU-mirrored components carry `#[derive(SceneStore)]` + `#[gpu(layout = packed)]`
+//! to pack all `#[gpu]` fields into a single dirty-tracked GPU column. SceneDB's
+//! world-mirror bridge handles upload transparently: `World::insert` →
+//! dispatch → `write_gpu_columns_at_row` → `mark_gpu_row_dirty` →
+//! `flush_gpu_mirror` → coalesced GPU upload.
+//!
+//! CPU-only bookkeeping lives in SEPARATE companion components (no derive).
+
+use pulsar_scenedb_derive::SceneStore;
+
+use crate::groups::GroupMask;
+
+/// GPU-facing instance data — one packed dirty-tracked column.
+///
+/// NOTE: only scalar types (`f32`, `u32`, `i32`) and `[f32; 16]` (which has
+/// an explicit `Pod` impl in pulsar_scenedb) can be used as `#[gpu]` fields,
+/// because the derive generates `Pod` bounds for EVERY field. The normal
+/// matrix (`nm_00` … `nm_23`) and bounds are split into individual scalars.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuInstance {
+    #[gpu] pub m_00: f32,  #[gpu] pub m_01: f32,
+    #[gpu] pub m_02: f32,  #[gpu] pub m_03: f32,
+    #[gpu] pub m_10: f32,  #[gpu] pub m_11: f32,
+    #[gpu] pub m_12: f32,  #[gpu] pub m_13: f32,
+    #[gpu] pub m_20: f32,  #[gpu] pub m_21: f32,
+    #[gpu] pub m_22: f32,  #[gpu] pub m_23: f32,
+    #[gpu] pub m_30: f32,  #[gpu] pub m_31: f32,
+    #[gpu] pub m_32: f32,  #[gpu] pub m_33: f32,
+    // normal matrix (3×3 → 3×vec4 = 12 f32)
+    #[gpu] pub nm_00: f32, #[gpu] pub nm_01: f32,
+    #[gpu] pub nm_02: f32, #[gpu] pub _pad_nm0: f32,
+    #[gpu] pub nm_10: f32, #[gpu] pub nm_11: f32,
+    #[gpu] pub nm_12: f32, #[gpu] pub _pad_nm1: f32,
+    #[gpu] pub nm_20: f32, #[gpu] pub nm_21: f32,
+    #[gpu] pub nm_22: f32, #[gpu] pub _pad_nm2: f32,
+    // bounds sphere
+    #[gpu] pub bounds_cx: f32, #[gpu] pub bounds_cy: f32,
+    #[gpu] pub bounds_cz: f32, #[gpu] pub bounds_r:  f32,
+    // prev model matrix (same layout as m_*)
+    #[gpu] pub pm_00: f32, #[gpu] pub pm_01: f32,
+    #[gpu] pub pm_02: f32, #[gpu] pub pm_03: f32,
+    #[gpu] pub pm_10: f32, #[gpu] pub pm_11: f32,
+    #[gpu] pub pm_12: f32, #[gpu] pub pm_13: f32,
+    #[gpu] pub pm_20: f32, #[gpu] pub pm_21: f32,
+    #[gpu] pub pm_22: f32, #[gpu] pub pm_23: f32,
+    #[gpu] pub pm_30: f32, #[gpu] pub pm_31: f32,
+    #[gpu] pub pm_32: f32, #[gpu] pub pm_33: f32,
+    #[gpu] pub mesh_id: u32,
+    #[gpu] pub material_id: u32,
+    #[gpu] pub flags: u32,
+    #[gpu] pub lightmap_index: u32,
+}
+
+/// GPU-facing light data — one packed dirty-tracked column.
+///
+/// All vec4 fields are split into individual `f32` scalars (same Pod constraint
+/// as [`HelioGpuInstance`]). The packed view struct re-packs them into the
+/// WGSL-matching layout.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuLight {
+    // position_range
+    #[gpu] pub pos_x: f32, #[gpu] pub pos_y: f32,
+    #[gpu] pub pos_z: f32, #[gpu] pub range: f32,
+    // direction_outer
+    #[gpu] pub dir_x: f32, #[gpu] pub dir_y: f32,
+    #[gpu] pub dir_z: f32, #[gpu] pub outer_cos: f32,
+    // color_intensity
+    #[gpu] pub color_r: f32, #[gpu] pub color_g: f32,
+    #[gpu] pub color_b: f32, #[gpu] pub intensity: f32,
+    #[gpu] pub shadow_index: u32,
+    #[gpu] pub light_type: u32,
+    #[gpu] pub inner_angle: f32,
+    #[gpu] pub _pad: u32,
+    #[gpu] pub god_rays_enabled: u32,
+    #[gpu] pub god_rays_density: f32,
+    #[gpu] pub god_rays_weight: f32,
+    #[gpu] pub god_rays_decay: f32,
+    #[gpu] pub god_rays_exposure: f32,
+    #[gpu] pub flare_enabled: u32,
+    #[gpu] pub flare_type: u32,
+    #[gpu] pub flare_intensity: f32,
+    #[gpu] pub flare_scale: f32,
+    #[gpu] pub flare_tint_r: f32,
+    #[gpu] pub flare_tint_g: f32,
+    #[gpu] pub flare_tint_b: f32,
+    #[gpu] pub ies_profile_index: i32,
+    #[gpu] pub light_function_index: i32,
+    #[gpu] pub ies_angle_scale: f32,
+    #[gpu] pub ies_angle_offset: f32,
+}
+
+// ── CPU-only companion components (no derive, no GPU cost) ──
+
+/// CPU-only bookkeeping attached to the same entity as [`HelioGpuInstance`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HelioCpuInstance {
+    pub groups: GroupMask,
+    pub movability: libhelio::Movability,
+    pub user_tag: u64,
+}
+
+/// CPU-only bookkeeping attached to the same entity as [`HelioGpuLight`].
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct HelioCpuLight {
+    pub movability: libhelio::Movability,
+    pub user_tag: u64,
+    pub gpu_index: u32,
+}
+
+/// Register every Helio component's GPU columns on the world-mirror store.
+pub(crate) fn register_gpu_columns(
+    store: &mut pulsar_scenedb::gpu::SceneGpuStore,
+    device: &std::sync::Arc<wgpu::Device>,
+) {
+    // HelioGpuInstance::register_gpu_columns_growable(store, 1024, device.clone());
+    // HelioGpuLight::register_gpu_columns_growable(store, 256, device.clone());
+}

--- a/crates/helio/src/scene/scenedb_components.rs
+++ b/crates/helio/src/scene/scenedb_components.rs
@@ -118,6 +118,6 @@ pub(crate) fn register_gpu_columns(
     store: &mut pulsar_scenedb::gpu::SceneGpuStore,
     device: &std::sync::Arc<wgpu::Device>,
 ) {
-    // HelioGpuInstance::register_gpu_columns_growable(store, 1024, device.clone());
-    // HelioGpuLight::register_gpu_columns_growable(store, 256, device.clone());
+    HelioGpuInstance::register_gpu_columns_growable(store, 1024, device);
+    HelioGpuLight::register_gpu_columns_growable(store, 256, device);
 }

--- a/crates/helio/src/scene/scenedb_components.rs
+++ b/crates/helio/src/scene/scenedb_components.rs
@@ -113,6 +113,99 @@ pub(crate) struct HelioCpuLight {
     pub gpu_index: u32,
 }
 
+/// GPU-facing camera data — singleton entity (index 0) in World.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuCamera {
+    #[gpu] pub view_proj_00: f32, #[gpu] pub view_proj_01: f32,
+    #[gpu] pub view_proj_02: f32, #[gpu] pub view_proj_03: f32,
+    #[gpu] pub view_proj_10: f32, #[gpu] pub view_proj_11: f32,
+    #[gpu] pub view_proj_12: f32, #[gpu] pub view_proj_13: f32,
+    #[gpu] pub view_proj_20: f32, #[gpu] pub view_proj_21: f32,
+    #[gpu] pub view_proj_22: f32, #[gpu] pub view_proj_23: f32,
+    #[gpu] pub view_proj_30: f32, #[gpu] pub view_proj_31: f32,
+    #[gpu] pub view_proj_32: f32, #[gpu] pub view_proj_33: f32,
+    #[gpu] pub prev_vp_00: f32, #[gpu] pub prev_vp_01: f32,
+    #[gpu] pub prev_vp_02: f32, #[gpu] pub prev_vp_03: f32,
+    #[gpu] pub prev_vp_10: f32, #[gpu] pub prev_vp_11: f32,
+    #[gpu] pub prev_vp_12: f32, #[gpu] pub prev_vp_13: f32,
+    #[gpu] pub prev_vp_20: f32, #[gpu] pub prev_vp_21: f32,
+    #[gpu] pub prev_vp_22: f32, #[gpu] pub prev_vp_23: f32,
+    #[gpu] pub prev_vp_30: f32, #[gpu] pub prev_vp_31: f32,
+    #[gpu] pub prev_vp_32: f32, #[gpu] pub prev_vp_33: f32,
+    #[gpu] pub pos_x: f32, #[gpu] pub pos_y: f32, #[gpu] pub pos_z: f32,
+    #[gpu] pub jitter_x: f32, #[gpu] pub jitter_y: f32,
+}
+
+/// GPU-facing decal data.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuDecal {
+    #[gpu] pub transform_00: f32, #[gpu] pub transform_01: f32,
+    #[gpu] pub transform_02: f32, #[gpu] pub transform_03: f32,
+    #[gpu] pub transform_10: f32, #[gpu] pub transform_11: f32,
+    #[gpu] pub transform_12: f32, #[gpu] pub transform_13: f32,
+    #[gpu] pub transform_20: f32, #[gpu] pub transform_21: f32,
+    #[gpu] pub transform_22: f32, #[gpu] pub transform_23: f32,
+    #[gpu] pub transform_30: f32, #[gpu] pub transform_31: f32,
+    #[gpu] pub transform_32: f32, #[gpu] pub transform_33: f32,
+    #[gpu] pub color_r: f32, #[gpu] pub color_g: f32, #[gpu] pub color_b: f32, #[gpu] pub color_a: f32,
+    #[gpu] pub uv_offset_x: f32, #[gpu] pub uv_offset_y: f32,
+    #[gpu] pub uv_scale_x: f32, #[gpu] pub uv_scale_y: f32,
+    #[gpu] pub angle: f32,
+    #[gpu] pub texture_index: u32,
+    #[gpu] pub flags: u32,
+}
+
+/// GPU-facing reflection capture data.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuReflectionCapture {
+    #[gpu] pub position_x: f32, #[gpu] pub position_y: f32,
+    #[gpu] pub position_z: f32, #[gpu] pub influence_radius: f32,
+    #[gpu] pub cubemap_index: i32,
+    #[gpu] pub blend_distance: f32,
+    #[gpu] pub intensity: f32,
+    #[gpu] pub flags: u32,
+}
+
+/// GPU-facing portal view data.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuPortalView {
+    #[gpu] pub view_00: f32, #[gpu] pub view_01: f32,
+    #[gpu] pub view_02: f32, #[gpu] pub view_03: f32,
+    #[gpu] pub view_10: f32, #[gpu] pub view_11: f32,
+    #[gpu] pub view_12: f32, #[gpu] pub view_13: f32,
+    #[gpu] pub view_20: f32, #[gpu] pub view_21: f32,
+    #[gpu] pub view_22: f32, #[gpu] pub view_23: f32,
+    #[gpu] pub view_30: f32, #[gpu] pub view_31: f32,
+    #[gpu] pub view_32: f32, #[gpu] pub view_33: f32,
+    #[gpu] pub proj_00: f32, #[gpu] pub proj_01: f32,
+    #[gpu] pub proj_02: f32, #[gpu] pub proj_03: f32,
+    #[gpu] pub proj_10: f32, #[gpu] pub proj_11: f32,
+    #[gpu] pub proj_12: f32, #[gpu] pub proj_13: f32,
+    #[gpu] pub proj_20: f32, #[gpu] pub proj_21: f32,
+    #[gpu] pub proj_22: f32, #[gpu] pub proj_23: f32,
+    #[gpu] pub proj_30: f32, #[gpu] pub proj_31: f32,
+    #[gpu] pub proj_32: f32, #[gpu] pub proj_33: f32,
+}
+
+/// GPU-facing portal chain data.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, SceneStore)]
+#[gpu(layout = packed)]
+pub(crate) struct HelioGpuPortalChain {
+    #[gpu] pub clip_plane_x: f32, #[gpu] pub clip_plane_y: f32,
+    #[gpu] pub clip_plane_z: f32, #[gpu] pub clip_plane_w: f32,
+    #[gpu] pub parent_index: u32,
+    #[gpu] pub view_count: u32,
+}
+
 /// Register every Helio component's GPU columns on the world-mirror store.
 pub(crate) fn register_gpu_columns(
     store: &mut pulsar_scenedb::gpu::SceneGpuStore,
@@ -120,4 +213,9 @@ pub(crate) fn register_gpu_columns(
 ) {
     HelioGpuInstance::register_gpu_columns_growable(store, 1024, device);
     HelioGpuLight::register_gpu_columns_growable(store, 256, device);
+    HelioGpuCamera::register_gpu_columns_growable(store, 1, device);
+    HelioGpuDecal::register_gpu_columns_growable(store, 256, device);
+    HelioGpuReflectionCapture::register_gpu_columns_growable(store, 64, device);
+    HelioGpuPortalView::register_gpu_columns_growable(store, 64, device);
+    HelioGpuPortalChain::register_gpu_columns_growable(store, 32, device);
 }

--- a/crates/helio/src/scene/stats.rs
+++ b/crates/helio/src/scene/stats.rs
@@ -6,6 +6,7 @@
 use libhelio::GpuLight;
 
 use crate::handles::LightId;
+use crate::scene::types::{LightRecord, ObjectRecord};
 use crate::scene::Scene;
 
 impl Scene {
@@ -22,14 +23,14 @@ impl Scene {
 
     /// Iterate over all live lights, yielding the handle, GPU light data, and user tag.
     pub fn iter_lights(&self) -> impl Iterator<Item = (LightId, &GpuLight, u64)> + '_ {
-        self.lights
-            .iter_with_handles()
-            .map(|(id, record)| (id, &record.gpu, record.user_tag))
+        self.world
+            .query::<&LightRecord>()
+            .map(|(entity, record)| (LightId::from_entity(entity), &record.gpu, record.user_tag))
     }
 
     /// Get the GPU light data for a single light by its handle.
     pub fn get_light(&self, id: LightId) -> Option<GpuLight> {
-        self.lights.get_with_index(id).map(|(_, record)| record.gpu)
+        self.world.get::<LightRecord>(id.entity()).map(|record| record.gpu)
     }
 
     /// Look up an object by the application-defined `user_tag` it was
@@ -76,8 +77,7 @@ impl Scene {
     pub fn drawn_mesh_stats(&self) -> (usize, usize) {
         let mut drawn_verts: usize = 0;
         let mut drawn_tris: usize = 0;
-        for i in 0..self.objects.dense_len() {
-            let Some(obj) = self.objects.get_dense(i) else { continue };
+        for (_, obj) in self.world.query::<&ObjectRecord>() {
             drawn_tris += (obj.draw.index_count / 3) as usize;
             if let Some(rec) = self.mesh_pool.get(obj.mesh) {
                 drawn_verts += rec.slice.vertex_count as usize;

--- a/crates/helio/src/scene/stats.rs
+++ b/crates/helio/src/scene/stats.rs
@@ -21,6 +21,10 @@ impl Scene {
         &self.gpu_scene
     }
 
+    pub(crate) fn gpu_scene_mut(&mut self) -> &mut helio_core::GpuScene {
+        &mut self.gpu_scene
+    }
+
     /// Iterate over all live lights, yielding the handle, GPU light data, and user tag.
     pub fn iter_lights(&self) -> impl Iterator<Item = (LightId, &GpuLight, u64)> + '_ {
         self.world

--- a/crates/helio/src/scene/stats.rs
+++ b/crates/helio/src/scene/stats.rs
@@ -11,18 +11,8 @@ use crate::scene::Scene;
 
 impl Scene {
     /// Get read-only access to the GPU scene resources.
-    ///
-    /// Returns a reference to the internal [`GpuScene`] containing all GPU buffers,
-    /// bind groups, and render state. Used by the renderer to access GPU resources.
-    ///
-    /// # Returns
-    /// A reference to the [`GpuScene`].
     pub fn gpu_scene(&self) -> &helio_core::GpuScene {
         &self.gpu_scene
-    }
-
-    pub(crate) fn gpu_scene_mut(&mut self) -> &mut helio_core::GpuScene {
-        &mut self.gpu_scene
     }
 
     /// Iterate over all live lights, yielding the handle, GPU light data, and user tag.

--- a/crates/helio/src/scene/sublevels.rs
+++ b/crates/helio/src/scene/sublevels.rs
@@ -21,6 +21,7 @@ use glam::Mat4;
 use crate::groups::GroupId;
 use crate::handles::SublevelId;
 use crate::scene::errors::{invalid, Result, SceneError};
+use crate::scene::types::ObjectRecord;
 use crate::scene::Scene;
 
 /// Configuration for [`Scene::add_sublevel`].
@@ -98,11 +99,7 @@ impl Scene {
     }
 
     fn tag_group_with_coordinate_space(&mut self, group: GroupId, slot: u32) {
-        let n = self.objects.dense_len();
-        for i in 0..n {
-            let Some(r) = self.objects.get_dense_mut(i) else {
-                continue;
-            };
+        for (_, r) in self.world.query::<&mut ObjectRecord>() {
             if !r.groups.contains(group) {
                 continue;
             }
@@ -164,11 +161,7 @@ impl Scene {
             .remove(sublevel)
             .ok_or_else(|| invalid("sublevel"))?;
 
-        let n = self.objects.dense_len();
-        for i in 0..n {
-            let Some(r) = self.objects.get_dense_mut(i) else {
-                continue;
-            };
+        for (_, r) in self.world.query::<&mut ObjectRecord>() {
             if !r.groups.contains(record.group) {
                 continue;
             }


### PR DESCRIPTION
Integrates pulsar_scenedb's world-mirror bridge into Helio's real frame loop.

## Foundation (b913e4e6)
- Two-store architecture: Arc<SceneGpuStore> for world-mirror flush, SceneGpuStore by value for phase-chain witness
- SceneGpuMirrorSubsystem flushes world-mirror at the boundary
- Scene::flush_scenedb_boundary() drives the full simulate→harvest→boundary→compact→sync chain
- Unit test proves insert-at-simulate reaches GPU via boundary flush

## Component types (4641207c)
- HelioGpuInstance: packed #[gpu] component for instance render data
- HelioGpuLight: packed #[gpu] component for light render data  
- CPU-only companions (HelioCpuInstance, HelioCpuLight)
- GPU columns registered on mirror_store in Scene::new

## CPU storage migration (354f0edc, 6428c3e1)
- ObjectId and LightId wrap pulsar_scenedb::Entity
- Scene::objects + Scene::lights DenseArena removed — all storage in World
- All call sites migrated to World queries (insert, remove, update, rebuild, groups, lifecycle, stats, etc.)
- 34 tests pass, workspace clean