### PR TITLE
Compile HiZ GLES detection only where available

### DIFF
--- a/crates/passes/3d/helio-pass-hiz/src/lib.rs
+++ b/crates/passes/3d/helio-pass-hiz/src/lib.rs
@@ -419,14 +419,28 @@ fn mip_levels(w: u32, h: u32) -> u32 {
     (u32::BITS - max_dim.leading_zeros()).max(1)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    any(target_os = "windows", target_os = "linux", target_os = "android")
+))]
 fn depth_texture_buffer_copies_supported(device: &wgpu::Device) -> bool {
-    // Native Vulkan, Metal and DX12 implementations expose the WebGPU depth-copy
-    // contract. WGPU's GL compatibility backend may omit the corresponding
-    // downlevel flag, and Device does not retain the Adapter properties needed
-    // to query that flag directly. Backend identity is therefore the exact
-    // capability boundary available to an externally supplied Device.
+    // Native Vulkan and DX12 implementations expose the WebGPU depth-copy
+    // contract. WGPU's GL compatibility backend may omit it, and Device does
+    // not retain the Adapter properties needed to query the downlevel flag
+    // directly. Backend identity is therefore the exact capability boundary
+    // available to an externally supplied Device on GLES-capable targets.
     unsafe { device.as_hal::<wgpu::hal::api::Gles>() }.is_none()
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(any(target_os = "windows", target_os = "linux", target_os = "android"))
+))]
+fn depth_texture_buffer_copies_supported(_device: &wgpu::Device) -> bool {
+    // WGPU does not compile its GLES HAL on these native targets. Their native
+    // backends implement depth texture/buffer copies, so the exact copy path is
+    // available without a backend identity probe.
+    true
 }
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
Closes #219.

## What changed

- Restricts the direct GLES HAL identity probe to Windows, Linux, and Android, matching where wgpu 30 exposes that HAL.
- Uses the exact depth texture/buffer copy path on Apple and other native non-GLES targets.
- Keeps the conservative far-depth behavior only when the active device is actually backed by GLES.

This changes one production capability boundary. It adds no fallback renderer, legacy implementation, compatibility adapter, migration path, or new dependency.

## Validation

- cargo test -p helio-pass-hiz --locked: 46 passed, including the available-backend GPU portability test.
- cargo clippy -p helio-pass-hiz --locked --no-deps -- -A clippy::too-many-arguments -D warnings: clean for the changed crate; the allowance is for a pre-existing API outside this change.
- Helio CI: green.
- Pulsar consumer validation at this exact commit: macOS, Linux, and Windows full CI green in Pulsar#536.
- Pulsar cargo check --workspace --all-targets --locked: passed locally.
- git diff --check: clean.
- cargo fmt --package helio-pass-hiz -- --check reports pre-existing formatting drift elsewhere in the same source/test files; this PR does not rewrite unrelated code.

## Merge boundary

Validated and ready for engine review. Merge this before Pulsar#536;
