### PR TITLE
Fix Radiance Cascades depth sampling on GLES

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,6 +1644,7 @@ dependencies = [
  "bytemuck",
  "helio-core",
  "libhelio",
+ "naga",
  "wgpu",
 ]
 

--- a/crates/passes/3d/helio-pass-radiance-cascades/Cargo.toml
+++ b/crates/passes/3d/helio-pass-radiance-cascades/Cargo.toml
@@ -10,3 +10,6 @@ helio-core  = { workspace = true }
 libhelio  = { workspace = true }
 wgpu      = { workspace = true }
 bytemuck  = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+naga = { version = "30.0.0", features = ["wgsl-in", "glsl-out"] }

--- a/crates/passes/3d/helio-pass-radiance-cascades/src/lib.rs
+++ b/crates/passes/3d/helio-pass-radiance-cascades/src/lib.rs
@@ -46,6 +46,7 @@ pub struct RadianceCascadesPass {
     rt_bgl: Option<wgpu::BindGroupLayout>,
     fb_bind_group: Option<wgpu::BindGroup>,
     fb_bg_key: Option<(usize, usize, usize)>,
+    fb_depth_sampler: wgpu::Sampler,
     uniform_buf: wgpu::Buffer,
     static_buf: Option<wgpu::Buffer>,
     use_rt: bool,
@@ -78,6 +79,7 @@ struct Camera {
 @group(0) @binding(2) var depth_tex:    texture_depth_2d;
 @group(0) @binding(3) var scene_color:  texture_2d<f32>;
 @group(0) @binding(4) var<storage, read> cameras: array<Camera, 2>;
+@group(0) @binding(5) var depth_sampler: sampler;
 
 const PROBE_DIM:   u32 = 8u;
 const DIR_DIM:     u32 = 4u;
@@ -148,8 +150,6 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
     let delta_depth = depth_end - depth_start;
 
     let scene_dims = vec2<f32>(textureDimensions(scene_color));
-    let depth_dims = vec2<f32>(textureDimensions(depth_tex));
-
     var radiance = vec3<f32>(0.0);
     var hit = false;
 
@@ -160,14 +160,20 @@ fn cs_main(@builtin(global_invocation_id) gid: vec3<u32>) {
 
         if any(uv < vec2<f32>(0.0)) || any(uv > vec2<f32>(1.0)) { break; }
 
-        let scene_d = textureLoad(depth_tex,
-            vec2<i32>(i32(uv.x * depth_dims.x), i32(uv.y * depth_dims.y)), 0);
+        // Depth texture loads cannot be translated by Naga's GLSL backend.
+        // Point sampling preserves the texel semantics while remaining valid
+        // on the Vulkan, Metal, D3D, GLES, and WebGPU paths.
+        let scene_d = textureSampleLevel(depth_tex, depth_sampler, uv, 0);
 
         if scene_d >= 1.0 { continue; }
 
         if d >= scene_d {
+            let scene_coord = min(
+                vec2<i32>(uv * scene_dims),
+                vec2<i32>(textureDimensions(scene_color)) - vec2<i32>(1),
+            );
             radiance = textureLoad(scene_color,
-                vec2<i32>(i32(uv.x * scene_dims.x), i32(uv.y * scene_dims.y)), 0).rgb;
+                scene_coord, 0).rgb;
             hit = true;
             break;
         }
@@ -205,6 +211,17 @@ impl RadianceCascadesPass {
                 usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
                 mapped_at_creation: false,
             })
+        });
+
+        let fb_depth_sampler = device.create_sampler(&wgpu::SamplerDescriptor {
+            label: Some("RC Fallback Depth Sampler"),
+            address_mode_u: wgpu::AddressMode::ClampToEdge,
+            address_mode_v: wgpu::AddressMode::ClampToEdge,
+            address_mode_w: wgpu::AddressMode::ClampToEdge,
+            mag_filter: wgpu::FilterMode::Nearest,
+            min_filter: wgpu::FilterMode::Nearest,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
+            ..Default::default()
         });
 
         // ── Fallback BGL & pipeline ────────────────────────────────────
@@ -259,6 +276,12 @@ impl RadianceCascadesPass {
                         has_dynamic_offset: false,
                         min_binding_size: None,
                     },
+                    count: None,
+                },
+                wgpu::BindGroupLayoutEntry {
+                    binding: 5,
+                    visibility: wgpu::ShaderStages::COMPUTE,
+                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::NonFiltering),
                     count: None,
                 },
             ],
@@ -402,6 +425,7 @@ impl RadianceCascadesPass {
             rt_bgl,
             fb_bind_group: None,
             fb_bg_key: None,
+            fb_depth_sampler,
             uniform_buf,
             static_buf,
             use_rt,
@@ -543,6 +567,10 @@ impl RadianceCascadesPass {
                             binding: 4,
                             resource: ctx.scene.camera.as_entire_binding(),
                         },
+                        wgpu::BindGroupEntry {
+                            binding: 5,
+                            resource: wgpu::BindingResource::Sampler(&self.fb_depth_sampler),
+                        },
                     ],
                 }));
             self.fb_bg_key = Some(key);
@@ -652,5 +680,44 @@ impl RadianceCascadesPass {
         pass.set_bind_group(0, &bind_group, &[]);
         pass.dispatch_workgroups(wg_x, wg_y, 1);
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FALLBACK_WGSL;
+    use naga::back::glsl;
+
+    #[test]
+    fn fallback_shader_translates_to_gles() {
+        let module = naga::front::wgsl::parse_str(FALLBACK_WGSL)
+            .expect("Radiance Cascades fallback WGSL must parse");
+        let info = naga::valid::Validator::new(
+            naga::valid::ValidationFlags::all(),
+            naga::valid::Capabilities::all(),
+        )
+        .subgroup_stages(naga::valid::ShaderStages::all())
+        .subgroup_operations(naga::valid::SubgroupOperationSet::all())
+        .validate(&module)
+        .expect("Radiance Cascades fallback WGSL must validate");
+
+        let mut output = String::new();
+        glsl::Writer::new(
+            &mut output,
+            &module,
+            &info,
+            &glsl::Options::default(),
+            &glsl::PipelineOptions {
+                shader_stage: naga::ShaderStage::Compute,
+                entry_point: "cs_main".into(),
+                multiview: None,
+            },
+            naga::proc::BoundsCheckPolicies::default(),
+        )
+        .expect("Radiance Cascades fallback must lower to GLES")
+        .write()
+        .expect("Radiance Cascades fallback must emit GLES");
+
+        assert!(output.contains("void main()"));
     }
 }


### PR DESCRIPTION
## Summary

- replace unsupported depth `textureLoad` in the non-RT Radiance Cascades fallback with nearest, clamped depth sampling
- preserve point-sampled depth semantics across Vulkan, Metal, D3D, OpenGL/GLES, and WebGPU
- clamp the color-buffer texel coordinate at the upper screen edge
- add a deterministic Naga regression test that parses, validates, and lowers the complete fallback shader to GLES

Fixes #221.

## Validation

- `cargo test -p helio-pass-radiance-cascades --locked` — 64 passed
- `cargo clippy -p helio-pass-radiance-cascades --lib --locked --no-deps -- -D warnings` — passed
- `cargo test -p helio-default-graphs --test planetary_extension --locked -- --test-threads=1` — passed
- `git diff --check` — passed

## Broader graph audit

`limited_native` now gets beyond Radiance Cascades but current Helio `main` independently fails when the portal-instance shader enables `wgpu_binding_array` on the deliberately non-bindless device tier. That existing portal-material capability bug is unrelated to this PR and will be tracked separately; this PR does not disable or bypass either pass.