### PR TITLE
Pin a published SceneDB revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3396,7 +3396,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=42dde7d#42dde7df974cca58edb37965a1400836d03e9a95"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=411ecd7707140765d99ba576e423d799e6869bbf#411ecd7707140765d99ba576e423d799e6869bbf"
 dependencies = [
  "ahash",
  "profiling 0.1.0",
@@ -3410,7 +3410,7 @@ dependencies = [
 [[package]]
 name = "pulsar_scenedb_derive"
 version = "0.1.0"
-source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=42dde7d#42dde7df974cca58edb37965a1400836d03e9a95"
+source = "git+https://github.com/Far-Beyond-Pulsar/SceneDB?rev=411ecd7707140765d99ba576e423d799e6869bbf#411ecd7707140765d99ba576e423d799e6869bbf"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/helio/Cargo.toml
+++ b/crates/helio/Cargo.toml
@@ -44,7 +44,7 @@ meshopt = "0.6.2"
 # `VarLenGpuPool<PackedVertex>` a DIFFERENT type than the one a
 # `#[gpu] Vec<PackedVertex>` component field resolves to elsewhere,
 # defeating the whole point of sharing one pool.
-pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "42dde7d", features = ["gpu"] }
+pulsar_scenedb = { git = "https://github.com/Far-Beyond-Pulsar/SceneDB", rev = "411ecd7707140765d99ba576e423d799e6869bbf", features = ["gpu"] }
 
 [features]
 default = ["profiling"]


### PR DESCRIPTION
Closes #232.

Replaces the nonexistent SceneDB revision with the exact published `411ecd7` commit and updates only the corresponding lockfile package identities. No renderer or SceneDB implementation changes are included.

Validation:
- Cargo dependency resolution succeeds.
- `cargo check -p helio-pass-planetary-voxel --all-targets` passes; only existing warnings remain.