### PR TITLE
Preserve render-graph attachment contracts across resize

### DIFF
--- a/crates/helio-core/src/graph/execution.rs
+++ b/crates/helio-core/src/graph/execution.rs
@@ -37,6 +37,11 @@ pub struct RenderGraph {
     pub(crate) xr_active: bool,
     pass_cache: Vec<Option<CachedPass>>,
     frame_count: u64,
+    /// Set by [`set_render_size`](Self::set_render_size) and consumed only
+    /// after the first successful frame at the new size. Passes use this
+    /// one-frame pulse through [`PrepareContext::resize`] to rebuild resources
+    /// that depend on graph-owned texture dimensions.
+    resize_pending: bool,
     /// Opaque storage for cross-crate data (e.g. a GraphRebuilder).
     /// Set by graph builders, consumed by the Renderer on construction.
     graph_data: Option<Box<dyn std::any::Any + Send + Sync>>,
@@ -69,6 +74,7 @@ impl RenderGraph {
             xr_active: false,
             pass_cache: Vec::new(),
             frame_count: 0,
+            resize_pending: false,
             graph_data: None,
         }
     }
@@ -122,6 +128,7 @@ impl RenderGraph {
         self.internal_h = height;
         self.output_w = width;
         self.output_h = height;
+        self.resize_pending = true;
 
         if self.locked {
             self.locked = false;
@@ -389,6 +396,7 @@ impl RenderGraph {
             });
 
         let mut visible_frame_resources = *frame_resources;
+        let resized_this_frame = self.resize_pending;
 
         let mut chain_rp: Option<std::mem::ManuallyDrop<wgpu::RenderPass<'_>>> = None;
         let mut chain_patch: Vec<Option<wgpu::RenderPassColorAttachment<'static>>> = Vec::new();
@@ -442,7 +450,7 @@ impl RenderGraph {
                     frame_num: scene.frame_count,
                     scene,
                     frame_resources: &visible_frame_resources,
-                    resize: false,
+                    resize: resized_this_frame,
                     width: self.internal_w,
                     height: self.internal_h,
                     delta_time: self.delta_time,
@@ -656,6 +664,7 @@ impl RenderGraph {
         );
 
         self.frame_count += 1;
+        self.resize_pending = false;
 
         Ok(submission_index)
     }

--- a/crates/helio-core/tests/render_graph_resize_contract.rs
+++ b/crates/helio-core/tests/render_graph_resize_contract.rs
@@ -1,0 +1,250 @@
+use helio_core::graph::{ResourceBuilder, ResourceFormat, ResourceSize};
+use helio_core::{
+    GpuScene, PassContext, PrepareContext, RenderGraph, RenderPass, Result as HelioResult,
+};
+use std::sync::{Arc, Mutex};
+
+struct ResizeProbePass {
+    observations: Arc<Mutex<Vec<(bool, u32, u32)>>>,
+}
+
+struct InternalAttachmentPass;
+
+impl RenderPass for InternalAttachmentPass {
+    fn name(&self) -> &'static str {
+        "InternalAttachment"
+    }
+
+    fn declare_resources(&self, builder: &mut ResourceBuilder) {
+        builder.write_color(
+            "pre_aa",
+            ResourceFormat::Rgba8Unorm,
+            ResourceSize::MatchSurface,
+        );
+    }
+
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _target: &'a wgpu::TextureView,
+        depth: &'a wgpu::TextureView,
+        resources: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        let pre_aa = resources
+            .pre_aa
+            .read(self.name())
+            .expect("graph must route its resized internal color attachment");
+        let color_attachments = Box::leak(Box::new([Some(wgpu::RenderPassColorAttachment {
+            view: pre_aa,
+            resolve_target: None,
+            depth_slice: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                store: wgpu::StoreOp::Store,
+            },
+        })]));
+        Some(wgpu::RenderPassDescriptor {
+            label: Some("Internal Attachment Resize Contract"),
+            color_attachments,
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: depth,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        })
+    }
+
+    fn execute(&mut self, _ctx: &mut PassContext) -> HelioResult<()> {
+        Ok(())
+    }
+}
+
+impl RenderPass for ResizeProbePass {
+    fn name(&self) -> &'static str {
+        "ResizeProbe"
+    }
+
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _target: &'a wgpu::TextureView,
+        _depth: &'a wgpu::TextureView,
+        _resources: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        None
+    }
+
+    fn prepare(&mut self, ctx: &PrepareContext) -> HelioResult<()> {
+        self.observations
+            .lock()
+            .expect("resize observations must not be poisoned")
+            .push((ctx.resize, ctx.width, ctx.height));
+        Ok(())
+    }
+
+    fn execute(&mut self, _ctx: &mut PassContext) -> HelioResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn prepare_receives_one_resize_pulse_after_graph_resize() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: render graph resize contract");
+            return;
+        };
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Render Graph Resize Contract Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a resize-contract device");
+        device.on_uncaptured_error(Arc::new(|error| {
+            panic!("render graph resize validation error: {error:?}");
+        }));
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let scene = GpuScene::new(Arc::clone(&device), Arc::clone(&queue));
+        let observations = Arc::new(Mutex::new(Vec::new()));
+        let mut graph = RenderGraph::new(&device, &queue);
+        graph.add_pass(Box::new(ResizeProbePass {
+            observations: Arc::clone(&observations),
+        }));
+        graph.lock(32, 24);
+
+        let (target, depth) = frame_views(&device, 32, 24);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("initial graph frame must execute");
+
+        graph.set_render_size(64, 48);
+        let (target, depth) = frame_views(&device, 64, 48);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("first resized graph frame must execute");
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("steady graph frame must execute");
+
+        assert_eq!(
+            observations
+                .lock()
+                .expect("resize observations must not be poisoned")
+                .as_slice(),
+            &[(false, 32, 24), (true, 64, 48), (false, 64, 48)]
+        );
+    });
+}
+
+#[test]
+fn graph_owned_internal_attachment_matches_depth_after_resize() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: render graph attachment resize contract");
+            return;
+        };
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Render Graph Attachment Resize Contract Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create an attachment resize-contract device");
+        device.on_uncaptured_error(Arc::new(|error| {
+            panic!("render graph attachment resize validation error: {error:?}");
+        }));
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let scene = GpuScene::new(Arc::clone(&device), Arc::clone(&queue));
+        let mut graph = RenderGraph::new(&device, &queue);
+        graph.add_pass(Box::new(InternalAttachmentPass));
+        graph.lock(32, 24);
+
+        let (target, depth) = frame_views(&device, 32, 24);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("initial graph attachment frame must execute");
+
+        graph.set_render_size(64, 48);
+        let (target, depth) = frame_views(&device, 64, 48);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("resized graph attachments must have matching extents");
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("attachment resize validation work must complete");
+    });
+}
+
+fn frame_views(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+) -> (wgpu::TextureView, wgpu::TextureView) {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Resize Contract Target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let depth = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Resize Contract Depth"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Depth32Float,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    (
+        target.create_view(&wgpu::TextureViewDescriptor::default()),
+        depth.create_view(&wgpu::TextureViewDescriptor::default()),
+    )
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}

--- a/crates/passes/3d/helio-pass-water-sim/src/lib.rs
+++ b/crates/passes/3d/helio-pass-water-sim/src/lib.rs
@@ -503,7 +503,9 @@ impl RenderPass for WaterSimPass {
         None
     }
 
-    fn on_resize(&mut self, _device: &wgpu::Device, _width: u32, _height: u32) {}
+    fn on_resize(&mut self, device: &wgpu::Device, width: u32, height: u32) {
+        self.resize_internal(device, width, height);
+    }
 
     fn declare_resources(&self, builder: &mut ResourceBuilder) {
         builder.read("pre_aa");

--- a/crates/passes/3d/helio-pass-water-sim/tests/resize_contract.rs
+++ b/crates/passes/3d/helio-pass-water-sim/tests/resize_contract.rs
@@ -1,0 +1,231 @@
+use helio_core::graph::{ResourceBuilder, ResourceFormat, ResourceSize};
+use helio_core::{GpuScene, PassContext, RenderGraph, RenderPass, Result as HelioResult};
+use helio_pass_water_sim::WaterSimPass;
+use std::sync::Arc;
+
+struct PreAaProducer;
+
+impl RenderPass for PreAaProducer {
+    fn name(&self) -> &'static str {
+        "PreAaProducer"
+    }
+
+    fn declare_resources(&self, builder: &mut ResourceBuilder) {
+        builder.write_color(
+            "pre_aa",
+            ResourceFormat::Rgba8Unorm,
+            ResourceSize::MatchSurface,
+        );
+    }
+
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _target: &'a wgpu::TextureView,
+        _depth: &'a wgpu::TextureView,
+        resources: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        color_only_descriptor(
+            "Pre-AA Producer",
+            resources
+                .pre_aa
+                .read(self.name())
+                .expect("pre_aa is routed"),
+        )
+    }
+
+    fn execute(&mut self, _ctx: &mut PassContext) -> HelioResult<()> {
+        Ok(())
+    }
+}
+
+struct PreAaDepthConsumer;
+
+impl RenderPass for PreAaDepthConsumer {
+    fn name(&self) -> &'static str {
+        "PreAaDepthConsumer"
+    }
+
+    fn declare_resources(&self, builder: &mut ResourceBuilder) {
+        builder.read("pre_aa");
+    }
+
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _target: &'a wgpu::TextureView,
+        depth: &'a wgpu::TextureView,
+        resources: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        let pre_aa = resources
+            .pre_aa
+            .read(self.name())
+            .expect("pre_aa is published");
+        let color_attachments = Box::leak(Box::new([Some(wgpu::RenderPassColorAttachment {
+            view: pre_aa,
+            resolve_target: None,
+            depth_slice: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Load,
+                store: wgpu::StoreOp::Store,
+            },
+        })]));
+        Some(wgpu::RenderPassDescriptor {
+            label: Some("Pre-AA Depth Consumer"),
+            color_attachments,
+            depth_stencil_attachment: Some(wgpu::RenderPassDepthStencilAttachment {
+                view: depth,
+                depth_ops: Some(wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(1.0),
+                    store: wgpu::StoreOp::Store,
+                }),
+                stencil_ops: None,
+            }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        })
+    }
+
+    fn execute(&mut self, _ctx: &mut PassContext) -> HelioResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn cached_water_output_is_reacquired_after_graph_resize() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let Some(adapter) = request_test_adapter(&instance).await else {
+            eprintln!("GPU_VALIDATION_SKIPPED_NO_ADAPTER: water resize contract");
+            return;
+        };
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Water Resize Contract Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: adapter.limits(),
+                ..Default::default()
+            })
+            .await
+            .expect("available adapter must create a water resize-contract device");
+        device.on_uncaptured_error(Arc::new(|error| {
+            panic!("water resize validation error: {error:?}");
+        }));
+
+        let device = Arc::new(device);
+        let queue = Arc::new(queue);
+        let scene = GpuScene::new(Arc::clone(&device), Arc::clone(&queue));
+        let camera = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("Water Resize Contract Camera"),
+            size: 256,
+            usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut graph = RenderGraph::new(&device, &queue);
+        graph.add_pass(Box::new(PreAaProducer));
+        graph.add_pass(Box::new(WaterSimPass::new(
+            &device,
+            &camera,
+            32,
+            24,
+            wgpu::TextureFormat::Rgba8Unorm,
+        )));
+        graph.add_pass(Box::new(PreAaDepthConsumer));
+        graph.lock(32, 24);
+
+        let (target, depth) = frame_views(&device, 32, 24);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("initial water graph frame must execute");
+
+        graph.set_render_size(64, 48);
+        let (target, depth) = frame_views(&device, 64, 48);
+        graph
+            .execute(&scene, &target, &depth)
+            .expect("water output and resized depth must have matching extents");
+        device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: None,
+            })
+            .expect("water resize validation work must complete");
+    });
+}
+
+fn color_only_descriptor<'a>(
+    label: &'static str,
+    view: &'a wgpu::TextureView,
+) -> Option<wgpu::RenderPassDescriptor<'a>> {
+    let color_attachments = Box::leak(Box::new([Some(wgpu::RenderPassColorAttachment {
+        view,
+        resolve_target: None,
+        depth_slice: None,
+        ops: wgpu::Operations {
+            load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+            store: wgpu::StoreOp::Store,
+        },
+    })]));
+    Some(wgpu::RenderPassDescriptor {
+        label: Some(label),
+        color_attachments,
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    })
+}
+
+fn frame_views(
+    device: &wgpu::Device,
+    width: u32,
+    height: u32,
+) -> (wgpu::TextureView, wgpu::TextureView) {
+    let target = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Water Resize Contract Target"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Rgba8Unorm,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    let depth = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("Water Resize Contract Depth"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format: wgpu::TextureFormat::Depth32Float,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+        view_formats: &[],
+    });
+    (
+        target.create_view(&wgpu::TextureViewDescriptor::default()),
+        depth.create_view(&wgpu::TextureViewDescriptor::default()),
+    )
+}
+
+async fn request_test_adapter(instance: &wgpu::Instance) -> Option<wgpu::Adapter> {
+    for force_fallback_adapter in [false, true] {
+        if let Ok(adapter) = instance
+            .request_adapter(&wgpu::RequestAdapterOptions {
+                power_preference: wgpu::PowerPreference::HighPerformance,
+                compatible_surface: None,
+                force_fallback_adapter,
+                apply_limit_buckets: false,
+            })
+            .await
+        {
+            return Some(adapter);
+        }
+    }
+    None
+}


### PR DESCRIPTION
## Outcome

Preserves render-graph attachment contracts across in-place resize, including fullscreen and windowed transitions.

## Root cause

`RenderGraph::set_render_size` recreated graph-owned textures but never exposed resize state through `PrepareContext`, while `WaterSimPass` retained a view into the previous graph-owned `pre_aa` texture. After fullscreen resize, the stale 960x540 color attachment was paired with the new 1920x1063 depth attachment.

## Changes

- Publish a one-frame `PrepareContext.resize` pulse after `set_render_size`, clearing it only after successful frame submission.
- Recreate WaterSim size-dependent resources and invalidate its cached graph-owned output view in `on_resize`.
- Add GPU regression coverage for resize signaling, graph-owned attachment dimensions, and the exact WaterSim stale-view failure.

## Validation

- `cargo test -q -p helio-core --test render_graph_resize_contract` — PASS (2 tests)
- `cargo test -q -p helio-pass-water-sim --test resize_contract` — PASS (1 test)
- `cargo build --release -p helio_component --example cubic_planet_demo` in the Pulsar integration worktree — PASS
- Visual/runtime: windowed -> fullscreen -> windowed — PASS, with no crash or wgpu validation error

Repository-wide formatting is already failing across unrelated existing examples and vendored Nebula sources. The broader Helio validation also retains unrelated pre-existing WGSL failures in `hlfs_toroidal_shift.wgsl` and `transparent_base.wgsl`; the default limited-native graph is separately blocked by the existing `PortalInstance`/`vt_record_demand` shader error.

Closes #241