### PR TITLE
Fix render-graph GPU totals and pass replacement state

### DIFF
--- a/crates/helio-core/src/graph/execution.rs
+++ b/crates/helio-core/src/graph/execution.rs
@@ -205,6 +205,28 @@ impl RenderGraph {
     pub fn replace_pass_at(&mut self, index: usize, pass: Box<dyn RenderPass>) {
         if index < self.passes.len() {
             self.passes[index] = pass;
+            // Replacing one type can also expose a later instance of the old
+            // type. Rebuild the first-instance map rather than patching one key.
+            self.pass_index_map.clear();
+            for (i, pass) in self.passes.iter().enumerate() {
+                self.pass_index_map
+                    .entry(pass.as_any().type_id())
+                    .or_insert(i);
+            }
+            // The replacement can publish different resources to later passes.
+            // Chain membership alone cannot detect stale dependent bundles.
+            self.gpu_render_bundles.clear();
+            self.pass_cache.clear();
+            if self.locked {
+                self.passes[index].on_resize(&self.device, self.output_w, self.output_h);
+                self.locked = false;
+                self.lock(self.output_w, self.output_h);
+                self.resize_pending = true;
+            } else if self.resources_allocated {
+                self.passes[index].on_resize(&self.device, self.output_w, self.output_h);
+                self.init_transients(self.output_w, self.output_h);
+                self.resize_pending = true;
+            }
         }
     }
 
@@ -430,6 +452,10 @@ impl RenderGraph {
                     label: Some("Compute Graph"),
                 });
 
+        // Compute is submitted first, graphics second. Span BOTH command
+        // buffers; per-pass markers on compute alone omit all graphics work.
+        self.profiler
+            .begin_gpu_pass(&mut compute_encoder, "__graph_frame");
         let mut visible_frame_resources = *frame_resources;
         let resized_this_frame = self.resize_pending;
 
@@ -720,8 +746,15 @@ impl RenderGraph {
             pass.publish(&mut visible_frame_resources);
         }
 
+        if let Some(mut rp) = chain_rp.take() {
+            unsafe {
+                std::mem::ManuallyDrop::drop(&mut rp);
+            }
+        }
+        self.profiler.end_gpu_pass(&mut encoder, "__graph_frame");
+        // Resolve after the final graphics timestamp, not before graphics runs.
         self.profiler
-            .resolve_gpu_queries(&mut compute_encoder, self.frame_count);
+            .resolve_gpu_queries(&mut encoder, self.frame_count);
         let submission_index = scene
             .queue
             .submit([compute_encoder.finish(), encoder.finish()]);

--- a/crates/helio-core/src/profiling/gpu.rs
+++ b/crates/helio-core/src/profiling/gpu.rs
@@ -218,7 +218,8 @@ impl GpuProfiler {
     ///
     /// # Performance
     ///
-    /// - **O(1)**: Writes a single GPU command (~10ns)
+    /// - Searches at most the fixed query capacity to match an unfinished scope,
+    ///   then writes one GPU timestamp command.
     ///
     /// # Example (Internal)
     ///
@@ -268,22 +269,25 @@ impl GpuProfiler {
     /// profiler.end_pass(&mut encoder, "ShadowPass");
     /// # }
     /// ```
-    pub fn end_pass(&mut self, encoder: &mut wgpu::CommandEncoder, _name: &'static str) {
+    pub fn end_pass(&mut self, encoder: &mut wgpu::CommandEncoder, name: &'static str) {
         if let Some(ref query_set) = self.query_set {
-            let Some((_, _, end_index)) = self.pending_queries.back() else {
-                return;
-            };
-            if *end_index != 0 || self.next_index >= QUERY_CAPACITY {
+            if self.next_index >= QUERY_CAPACITY {
                 return;
             }
+            // Match an unfinished scope by name so a whole-frame scope can
+            // surround individual passes across both command encoders.
+            let Some(scope) = self
+                .pending_queries
+                .iter_mut()
+                .rev()
+                .find(|(scope_name, _, end)| *scope_name == name && *end == 0)
+            else {
+                return;
+            };
             let end_index = self.next_index;
             self.next_index += 1;
             encoder.write_timestamp(query_set, end_index);
-
-            // Update the last pending query with end index
-            if let Some(last) = self.pending_queries.back_mut() {
-                last.2 = end_index;
-            }
+            scope.2 = end_index;
         }
     }
 

--- a/crates/helio-core/src/profiling/mod.rs
+++ b/crates/helio-core/src/profiling/mod.rs
@@ -358,7 +358,14 @@ impl Profiler {
             });
         }
         self.snapshot.total_cpu_ms = has_cpu.then_some(total_cpu_ms);
-        self.snapshot.total_gpu_ms = has_gpu.then_some(total_gpu_ms);
+        self.snapshot.gpu_frame_ms = gpu_timings
+            .iter()
+            .find(|t| t.name == "__graph_frame")
+            .map(|t| t.duration_ns as f32 / 1_000_000.0);
+        self.snapshot.total_gpu_ms = self
+            .snapshot
+            .gpu_frame_ms
+            .or_else(|| has_gpu.then_some(total_gpu_ms));
     }
 
     /// Returns the latest snapshot without allocation or synchronization.
@@ -527,7 +534,12 @@ pub struct RenderTimingSnapshot {
     pub gpu_lag_frames: Option<u64>,
     pub gpu_availability: GpuTimingAvailability,
     pub total_cpu_ms: Option<f32>,
+    /// Complete graph GPU span when available, otherwise legacy pass sum.
     pub total_gpu_ms: Option<f32>,
+    /// GPU elapsed time spanning compute and graphics command buffers. Excludes
+    /// CPU work, presentation and host capture readback. Individual legacy pass
+    /// markers still cover only compute-encoder commands.
+    pub gpu_frame_ms: Option<f32>,
     pub readback_drops: u64,
     pub query_overflows: u64,
     pub passes: Vec<RenderPassTiming>,

--- a/crates/helio-core/src/profiling/mod.rs
+++ b/crates/helio-core/src/profiling/mod.rs
@@ -153,6 +153,7 @@ pub struct Profiler {
     gpu: GpuProfiler,
     enabled: bool,
     snapshot: RenderTimingSnapshot,
+    gpu_frame_ms: Option<f32>,
 }
 
 impl Profiler {
@@ -174,6 +175,7 @@ impl Profiler {
             gpu: GpuProfiler::new(device, queue),
             enabled: cfg!(feature = "profiling"),
             snapshot: RenderTimingSnapshot::default(),
+            gpu_frame_ms: None,
         }
     }
 
@@ -358,12 +360,11 @@ impl Profiler {
             });
         }
         self.snapshot.total_cpu_ms = has_cpu.then_some(total_cpu_ms);
-        self.snapshot.gpu_frame_ms = gpu_timings
+        self.gpu_frame_ms = gpu_timings
             .iter()
             .find(|t| t.name == "__graph_frame")
             .map(|t| t.duration_ns as f32 / 1_000_000.0);
         self.snapshot.total_gpu_ms = self
-            .snapshot
             .gpu_frame_ms
             .or_else(|| has_gpu.then_some(total_gpu_ms));
     }
@@ -371,6 +372,14 @@ impl Profiler {
     /// Returns the latest snapshot without allocation or synchronization.
     pub const fn timing_snapshot(&self) -> &RenderTimingSnapshot {
         &self.snapshot
+    }
+
+    /// Complete compute-plus-graphics GPU span for the latest timing sample.
+    /// Excludes CPU work, presentation and host capture readback. `None` means
+    /// no completed whole-graph scope is available; the public snapshot's total
+    /// may still contain the legacy sum of per-pass compute timings.
+    pub const fn gpu_frame_ms(&self) -> Option<f32> {
+        self.gpu_frame_ms
     }
 
     /// Print profiling results to console (blocking - use for debugging only!)
@@ -536,10 +545,6 @@ pub struct RenderTimingSnapshot {
     pub total_cpu_ms: Option<f32>,
     /// Complete graph GPU span when available, otherwise legacy pass sum.
     pub total_gpu_ms: Option<f32>,
-    /// GPU elapsed time spanning compute and graphics command buffers. Excludes
-    /// CPU work, presentation and host capture readback. Individual legacy pass
-    /// markers still cover only compute-encoder commands.
-    pub gpu_frame_ms: Option<f32>,
     pub readback_drops: u64,
     pub query_overflows: u64,
     pub passes: Vec<RenderPassTiming>,

--- a/crates/helio-core/tests/gpu_frame_timing.rs
+++ b/crates/helio-core/tests/gpu_frame_timing.rs
@@ -1,0 +1,69 @@
+use helio_core::Profiler;
+
+/// An outer timing scope must include work submitted on the graphics encoder
+/// after the nested compute scope. This is a scope/ordering regression, not a
+/// benchmark or a hardware performance threshold.
+#[test]
+fn whole_frame_timestamp_spans_both_encoders_and_nested_scopes() {
+    pollster::block_on(async {
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+        let adapter = instance.request_adapter(&Default::default()).await.unwrap();
+        let features =
+            wgpu::Features::TIMESTAMP_QUERY | wgpu::Features::TIMESTAMP_QUERY_INSIDE_ENCODERS;
+        assert!(
+            adapter.features().contains(features),
+            "timestamp-capable GPU required"
+        );
+        let (device, queue) = adapter
+            .request_device(&wgpu::DeviceDescriptor {
+                required_features: features,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+        let mut profiler = Profiler::new(&device, &queue);
+        let scratch = device.create_buffer(&wgpu::BufferDescriptor {
+            label: Some("timed graphics-encoder work"),
+            size: 8 * 1024 * 1024,
+            usage: wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut compute = device.create_command_encoder(&Default::default());
+        let mut graphics = device.create_command_encoder(&Default::default());
+        profiler.begin_gpu_pass(&mut compute, "__graph_frame");
+        profiler.begin_gpu_pass(&mut compute, "inner");
+        profiler.end_gpu_pass(&mut compute, "inner");
+        graphics.clear_buffer(&scratch, 0, None);
+        profiler.end_gpu_pass(&mut graphics, "__graph_frame");
+        profiler.resolve_gpu_queries(&mut graphics, 17);
+        queue.submit([compute.finish(), graphics.finish()]);
+        let timings = profiler.read_gpu_timestamps_blocking(&device);
+        assert_eq!(timings.len(), 2, "both nested scopes must complete");
+        let outer = timings
+            .iter()
+            .find(|s| s.name == "__graph_frame")
+            .unwrap()
+            .duration_ns;
+        let inner = timings
+            .iter()
+            .find(|s| s.name == "inner")
+            .unwrap()
+            .duration_ns;
+        assert!(
+            outer > inner,
+            "outer scope must include graphics-encoder work: {outer} <= {inner}"
+        );
+        profiler.update_snapshot(17, ["inner"].into_iter());
+        let snapshot = profiler.timing_snapshot();
+        assert_eq!(snapshot.gpu_frame_index, Some(17));
+        assert_eq!(snapshot.query_overflows, 0);
+        assert_eq!(snapshot.gpu_frame_ms, Some(outer as f32 / 1_000_000.0));
+        assert_eq!(snapshot.total_gpu_ms, snapshot.gpu_frame_ms);
+        assert_eq!(
+            snapshot.passes.len(),
+            1,
+            "the outer scope is not a render pass"
+        );
+        assert_eq!(snapshot.passes[0].gpu_ms, Some(inner as f32 / 1_000_000.0));
+    });
+}

--- a/crates/helio-core/tests/gpu_frame_timing.rs
+++ b/crates/helio-core/tests/gpu_frame_timing.rs
@@ -57,8 +57,8 @@ fn whole_frame_timestamp_spans_both_encoders_and_nested_scopes() {
         let snapshot = profiler.timing_snapshot();
         assert_eq!(snapshot.gpu_frame_index, Some(17));
         assert_eq!(snapshot.query_overflows, 0);
-        assert_eq!(snapshot.gpu_frame_ms, Some(outer as f32 / 1_000_000.0));
-        assert_eq!(snapshot.total_gpu_ms, snapshot.gpu_frame_ms);
+        assert_eq!(profiler.gpu_frame_ms(), Some(outer as f32 / 1_000_000.0));
+        assert_eq!(snapshot.total_gpu_ms, profiler.gpu_frame_ms());
         assert_eq!(
             snapshot.passes.len(),
             1,

--- a/crates/helio-core/tests/render_graph_replacement.rs
+++ b/crates/helio-core/tests/render_graph_replacement.rs
@@ -1,0 +1,140 @@
+use helio_core::{PassContext, RenderGraph, RenderPass, Result};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+struct Original(u32);
+struct Replacement;
+impl RenderPass for Original {
+    fn name(&self) -> &'static str {
+        "original"
+    }
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _: &'a wgpu::TextureView,
+        _: &'a wgpu::TextureView,
+        _: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        None
+    }
+    fn execute(&mut self, _: &mut PassContext) -> Result<()> {
+        Ok(())
+    }
+}
+impl RenderPass for Replacement {
+    fn name(&self) -> &'static str {
+        "replacement"
+    }
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _: &'a wgpu::TextureView,
+        _: &'a wgpu::TextureView,
+        _: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        None
+    }
+    fn execute(&mut self, _: &mut PassContext) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn replacement_updates_first_instance_lookup_before_and_after_lock() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&Default::default())).unwrap();
+    let (device, queue) = pollster::block_on(adapter.request_device(&Default::default())).unwrap();
+    let mut graph = RenderGraph::new(&Arc::new(device), &queue);
+    graph.add_pass(Box::new(Original(1)));
+    graph.add_pass(Box::new(Original(2)));
+    graph.replace_pass_at(0, Box::new(Replacement));
+    assert!(graph.find_pass::<Replacement>().is_some());
+    assert_eq!(graph.find_pass::<Original>().unwrap().0, 2);
+    graph.lock(8, 8);
+    graph.replace_pass_at(1, Box::new(Replacement));
+    assert!(graph.find_pass::<Original>().is_none());
+    assert_eq!(graph.pass_index_of::<Replacement>(), Some(0));
+    assert!(graph.find_pass_mut::<Replacement>().is_some());
+}
+
+struct BundleObserver {
+    builds: Arc<AtomicUsize>,
+    expect_resize: bool,
+    size: Option<[u32; 2]>,
+}
+
+impl RenderPass for BundleObserver {
+    fn name(&self) -> &'static str {
+        "bundle observer"
+    }
+    fn render_pass_descriptor<'a>(
+        &'a self,
+        _: &'a wgpu::TextureView,
+        _: &'a wgpu::TextureView,
+        _: &'a libhelio::FrameResources<'a>,
+    ) -> Option<wgpu::RenderPassDescriptor<'a>> {
+        None
+    }
+    fn execute(&mut self, _: &mut PassContext) -> Result<()> {
+        Ok(())
+    }
+    fn on_resize(&mut self, _: &wgpu::Device, width: u32, height: u32) {
+        self.size = Some([width, height]);
+    }
+    fn build_gpu_render_bundle(
+        &mut self,
+        _: &wgpu::Device,
+        _: &libhelio::FrameResources<'_>,
+    ) -> Option<wgpu::RenderBundle> {
+        if self.expect_resize {
+            assert_eq!(
+                self.size,
+                Some([8, 16]),
+                "replacement must receive its size before bundles are built"
+            );
+        }
+        self.builds.fetch_add(1, Ordering::SeqCst);
+        None
+    }
+}
+
+#[test]
+fn replacement_rebuilds_dependent_bundles_even_when_chains_do_not_change() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&Default::default())).unwrap();
+    let (device, queue) = pollster::block_on(adapter.request_device(&Default::default())).unwrap();
+    let device = Arc::new(device);
+    for locked in [false, true] {
+        let mut graph = RenderGraph::new(&device, &queue);
+        graph.add_pass(Box::new(Original(1)));
+        let dependent_builds = Arc::new(AtomicUsize::new(0));
+        graph.add_pass(Box::new(BundleObserver {
+            builds: dependent_builds.clone(),
+            expect_resize: false,
+            size: None,
+        }));
+        if locked {
+            graph.lock(8, 16);
+        } else {
+            graph.init_transients(8, 16);
+        }
+        let prior_builds = dependent_builds.load(Ordering::SeqCst);
+        assert!(prior_builds > 0);
+        let replacement_builds = Arc::new(AtomicUsize::new(0));
+        graph.replace_pass_at(
+            0,
+            Box::new(BundleObserver {
+                builds: replacement_builds.clone(),
+                expect_resize: true,
+                size: None,
+            }),
+        );
+        assert!(replacement_builds.load(Ordering::SeqCst) > 0);
+        assert!(
+            dependent_builds.load(Ordering::SeqCst) > prior_builds,
+            "a later bundle must be rebuilt when an earlier resource publisher changes"
+        );
+        assert_eq!(
+            graph.find_pass::<BundleObserver>().unwrap().size,
+            Some([8, 16])
+        );
+    }
+}

--- a/crates/helio-core/tests/timing_snapshot_compatibility.rs
+++ b/crates/helio-core/tests/timing_snapshot_compatibility.rs
@@ -1,0 +1,25 @@
+use helio_core::{GpuTimingAvailability, RenderPassTiming, RenderTimingSnapshot};
+
+/// Pulsar-Native's timing bridge constructs this public struct exhaustively.
+/// Keep that caller compiling without requiring a synchronized host update.
+#[test]
+fn downstream_timing_snapshot_literal_remains_source_compatible() {
+    let snapshot = RenderTimingSnapshot {
+        generation: 4,
+        cpu_frame_index: 18,
+        gpu_frame_index: None,
+        gpu_lag_frames: None,
+        gpu_availability: GpuTimingAvailability::Unsupported,
+        total_cpu_ms: Some(7.0),
+        total_gpu_ms: None,
+        readback_drops: 0,
+        query_overflows: 1,
+        passes: vec![RenderPassTiming {
+            name: "Draw",
+            cpu_ms: Some(7.0),
+            gpu_ms: None,
+        }],
+    };
+    assert_eq!(snapshot.total_gpu_ms, None);
+    assert_eq!(snapshot.passes[0].name, "Draw");
+}

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -473,6 +473,13 @@ impl Renderer {
         self.graph.profiler().timing_snapshot()
     }
 
+    /// GPU time across the graph's compute and graphics work, excluding CPU
+    /// work and presentation. Unlike a legacy per-pass sum, this is `None`
+    /// until a completed whole-graph timing scope is available.
+    pub fn gpu_frame_ms(&self) -> Option<f32> {
+        self.graph.profiler().gpu_frame_ms()
+    }
+
     pub fn mesh_buffers(&self) -> MeshBuffers<'_> {
         self.scene.mesh_buffers()
     }


### PR DESCRIPTION
Render-graph GPU totals currently omit graphics-encoder work, and replacing a pass leaves type lookup and cached graph state referring to the old pass. This updates the general engine infrastructure used to measure and change rendering paths.

- Span both submitted command buffers with a frame timestamp and resolve it after graphics work. `Profiler::gpu_frame_ms()` and `Renderer::gpu_frame_ms()` expose that duration; `total_gpu_ms` uses it when available. Existing per-pass timings remain compute-encoder-only. CPU work and presentation are outside this measurement.
- Preserve the public `RenderTimingSnapshot` struct fields so existing exhaustive constructors in Pulsar-Native continue to compile. Whole-frame timing state is private to the profiler.
- Match unfinished timestamp scopes by name so the frame scope can surround pass scopes.
- Refresh first-instance type lookup after pass replacement, resize the replacement before graph preparation, and rebuild resource declarations and dependent bundles even when chain membership is unchanged.

Extracted onto current main (`c3106597`) without planet code. Related open PRs/issues and their ownership were checked; this does not modify the ongoing HLFS, Scene ownership, or virtual-geometry work.

Validation compared main `c3106597` with this commit (`24575e9a`) and #245 together (`723aae48`), using an isolated candidate build directory. All 86 existing passing tests kept their results; all seven added regressions passed, for 93 passes total. No GPU skips were reported in captured candidate output. The new core regressions cover nested timestamps/snapshot totals, pass replacement before and after graph lock, dependent bundle invalidation and the existing downstream snapshot constructor. Native default graphs also render before and after resizing in both material binding configurations. `cargo check --workspace --all-targets --exclude examples --keep-going` passed.

The full suite remains non-green: both variants reproduce the same standalone shader-validator errors in unchanged `hlfs_toroidal_shift.wgsl` and `transparent_base.wgsl`. Full workspace compilation encounters unchanged examples missing `VolumetricClouds::infinite_extent`; Cargo's early stopping exposes different examples, whose source and cloud type definition are identical in both variants. The separate check above verifies the remaining packages. Initial shared-target candidate runs reused baseline release libraries and were discarded; only the isolated rerun supports these results.

The existing GitHub workflow runs `cargo build` and `cargo test` at the placeholder root package, so its green status alone is not engine validation. The Pulsar-Native caller was inspected but its full application was not built. These tests do not establish populated-scene visual compatibility, XR behavior or rendering performance improvements.
