### PR TITLE
Keep temporal sampling aligned with the rendered camera

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2049,6 +2049,7 @@ dependencies = [
  "bytemuck",
  "helio-core",
  "libhelio",
+ "pollster 0.4.0",
  "wgpu",
 ]
 

--- a/crates/helio/src/renderer/render.rs
+++ b/crates/helio/src/renderer/render.rs
@@ -12,14 +12,7 @@ use crate::scene::Camera;
 use super::renderer_impl::{CullStatsReadbackState, DebugCameraUniform, Renderer};
 
 /// R1/R2 low-discrepancy jitter — matches the sequence used by TSR passes.
-fn r1_r2_jitter(frame: u64) -> [f32; 2] {
-    const INV_R1: f64 = 0.7548776662466927;
-    const INV_R2: f64 = 0.5698402905980539;
-    const PHASE: f64 = 0.5;
-    let fx = frame as f64 * INV_R1 + PHASE;
-    let fy = frame as f64 * INV_R2 + PHASE;
-    [(fx.fract() - 0.5) as f32, (fy.fract() - 0.5) as f32]
-}
+use libhelio::temporal::r1_r2_jitter;
 
 /// Fullscreen-triangle shader for the PC mirror: samples the XR swapchain's
 /// 2-layer array texture and draws eye 0 on the left half, eye 1 on the right.
@@ -165,18 +158,20 @@ impl Renderer {
             .as_secs_f32()
             .min(0.1);
         self.last_render_time = now;
-        self.delta_time = dt;
+        self.delta_time = self.frame_delta_override.unwrap_or(dt);
         self.frame_times[self.frame_times_cursor] = dt;
         self.frame_times_cursor = (self.frame_times_cursor + 1) % self.frame_times.len();
-        self.graph.set_delta_time(dt);
+        self.graph.set_delta_time(self.delta_time);
 
         let internal_w = (((self.output_width as f32) * self.render_scale).ceil() as u32).max(1);
         let internal_h = (((self.output_height as f32) * self.render_scale).ceil() as u32).max(1);
 
         let frame_idx = self.scene.gpu_scene().frame_count;
-        let (jitter_mat, jx, jy) = if self.enable_jitter {
+        let (jitter_mat, jx, jy) = if self.enable_jitter || self.camera_jitter_override.is_some() {
             // Use R1/R2 plastic-ratio jitter to match TAA and TSR passes.
-            let jitter = r1_r2_jitter(frame_idx);
+            let jitter = self
+                .camera_jitter_override
+                .unwrap_or_else(|| r1_r2_jitter(frame_idx));
             let jx = jitter[0] * 2.0 / (internal_w as f32);
             let jy = jitter[1] * 2.0 / (internal_h as f32);
             let jitter_mat = glam::Mat4::from_translation(glam::Vec3::new(jx, jy, 0.0));

--- a/crates/helio/src/renderer/renderer_impl.rs
+++ b/crates/helio/src/renderer/renderer_impl.rs
@@ -132,6 +132,8 @@ pub struct Renderer {
     /// temporal accumulation pass (TaaPass, TsrPass) need this; non-temporal
     /// graphs (e.g. FXAA-only) disable it to avoid visible shimmer.
     pub(crate) enable_jitter: bool,
+    pub(crate) camera_jitter_override: Option<[f32; 2]>,
+    pub(crate) frame_delta_override: Option<f32>,
     pub(crate) gizmo_camera: Option<crate::scene::Camera>,
     pub(crate) gizmo_viewport_height: f32,
     #[cfg(feature = "bake")]
@@ -412,6 +414,22 @@ impl Renderer {
     /// the final image remains pixel-stable.
     pub fn set_jitter_enabled(&mut self, enabled: bool) {
         self.enable_jitter = enabled;
+    }
+
+    /// Set a deterministic projection offset in internal render-pixel units
+    /// for the standard, non-XR render path.
+    /// `None` restores the graph's normal temporal sampling sequence.
+    pub fn set_camera_jitter_override(&mut self, jitter: Option<[f32; 2]>) {
+        assert!(jitter.is_none_or(|v| v.iter().all(|x| x.is_finite())));
+        self.camera_jitter_override = jitter;
+    }
+
+    /// Fix temporal-filter time for offline captures in the standard, non-XR
+    /// render path so readback latency does not alter history weights.
+    /// `None` restores measured frame time.
+    pub fn set_frame_delta_override(&mut self, seconds: Option<f32>) {
+        assert!(seconds.is_none_or(|v| v.is_finite() && v > 0.0));
+        self.frame_delta_override = seconds;
     }
 
     pub fn set_debug_mode(&mut self, mode: u32) {

--- a/crates/helio/src/renderer/setup.rs
+++ b/crates/helio/src/renderer/setup.rs
@@ -262,6 +262,8 @@ impl Renderer {
             frame_times: vec![0.0; 200],
             frame_times_cursor: 0,
             enable_jitter,
+            camera_jitter_override: None,
+            frame_delta_override: None,
             #[cfg(feature = "bake")]
             bake_pending: None,
             #[cfg(feature = "bake")]

--- a/crates/helio/src/scene/camera.rs
+++ b/crates/helio/src/scene/camera.rs
@@ -37,7 +37,7 @@ pub struct Camera {
     /// View matrix (world-to-camera transform, right-handed).
     pub view: Mat4,
 
-    /// Projection matrix (camera-to-clip transform, reversed-Z).
+    /// Projection matrix. The default constructor uses forward [0,1] depth.
     pub proj: Mat4,
 
     /// Camera position in world space (used for distance calculations, skybox, etc.).
@@ -128,6 +128,15 @@ impl Camera {
 }
 
 impl Scene {
+    /// Re-express retained camera history after the host changes its floating
+    /// origin. Call once before rendering the next camera, with new minus old
+    /// origin. This does not move scene objects: the host must express their
+    /// current and previous transforms in the same new local coordinates.
+    pub fn rebase_camera_history(&mut self, origin_shift: glam::DVec3) {
+        self.prev_view_proj =
+            libhelio::temporal::rebase_previous_projection(self.prev_view_proj, origin_shift);
+    }
+
     /// Update the scene's camera for the current frame.
     ///
     /// Computes camera uniforms and uploads them to the GPU. Also stores the

--- a/crates/libhelio/src/camera.rs
+++ b/crates/libhelio/src/camera.rs
@@ -22,7 +22,8 @@ pub struct GpuCameraUniforms {
     pub position_near: [f32; 4],
     /// Camera forward direction (xyz) + far plane (w)
     pub forward_far: [f32; 4],
-    /// Jitter offset for TAA (xy) + frame index (z) + padding (w)
+    /// Projection translation in NDC (xy), frame index (z), padding (w).
+    /// Ray tracers convert xy with `temporal::ray_jitter_from_ndc`.
     pub jitter_frame: [f32; 4],
     /// Previous frame view-projection (for TAA motion vectors)
     pub prev_view_proj: [f32; 16],

--- a/crates/libhelio/src/lib.rs
+++ b/crates/libhelio/src/lib.rs
@@ -28,6 +28,7 @@ pub mod reflection;
 pub mod shader;
 pub mod shadow;
 pub mod sky;
+pub mod temporal;
 pub mod water;
 pub mod wind;
 

--- a/crates/libhelio/src/temporal.rs
+++ b/crates/libhelio/src/temporal.rs
@@ -1,0 +1,101 @@
+//! Shared temporal sampling conventions for raster passes and ray tracers.
+
+/// Express a previous view-projection in a new floating origin. `origin_shift`
+/// is new origin minus old origin; current local points therefore need this
+/// translation before the previous camera can project them. Compose in f64 so
+/// a large origin change does not discard the retained small camera offset.
+pub fn rebase_previous_projection(previous: glam::Mat4, origin_shift: glam::DVec3) -> glam::Mat4 {
+    assert!(
+        origin_shift.is_finite(),
+        "camera origin shift must be finite"
+    );
+    (previous.as_dmat4() * glam::DMat4::from_translation(origin_shift)).as_mat4()
+}
+
+/// R1/R2 projection jitter in render pixels, before the NDC conversion.
+/// Kept identical to Helio's existing renderer/TSR sequence.
+pub fn r1_r2_jitter(frame: u64) -> [f32; 2] {
+    const INV_R1: f64 = 0.7548776662466927;
+    const INV_R2: f64 = 0.5698402905980539;
+    let fx = frame as f64 * INV_R1 + 0.5;
+    let fy = frame as f64 * INV_R2 + 0.5;
+    [(fx.fract() - 0.5) as f32, (fy.fract() - 0.5) as f32]
+}
+
+/// Convert `GpuCameraUniforms::jitter_frame.xy` (NDC projection translation)
+/// to ray sample offsets in pixels, with image Y pointing down. Applying a
+/// positive projection translation moves geometry right/up, so its inverse
+/// ray offsets are left/down. Supply an unjittered ray basis with this offset.
+pub fn ray_jitter_from_ndc(jitter: [f32; 2], render_size: [u32; 2]) -> [f32; 4] {
+    [
+        -jitter[0] * render_size[0] as f32 * 0.5,
+        jitter[1] * render_size[1] as f32 * 0.5,
+        0.0,
+        0.0,
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use glam::{Mat4, Vec3, Vec4};
+    #[test]
+    fn origin_changes_preserve_previous_projection_without_inventing_motion() {
+        let projection = Mat4::perspective_rh(1.0, 16.0 / 9.0, 0.1, 30_000_000.0);
+        for shift in [
+            glam::DVec3::ZERO,
+            glam::DVec3::new(1024.0, -1024.0, 0.0),
+            glam::DVec3::new(0.0, 0.0, 8_000_000.0),
+        ] {
+            let old_camera = shift + glam::DVec3::new(0.031, 0.023, 0.047);
+            let previous = projection
+                * glam::DMat4::look_to_rh(old_camera, glam::DVec3::NEG_Z, glam::DVec3::Y).as_mat4();
+            let rebased = rebase_previous_projection(previous, shift);
+            for distance in [1.0, 32.0, 1024.0, 8_000_000.0] {
+                let new_point = glam::DVec3::new(0.25, -0.1, -distance);
+                let old_point = new_point + shift;
+                let reference = previous.as_dmat4() * old_point.extend(1.0);
+                // Evaluate f64 here to isolate matrix rebasing from a separate
+                // large-local-coordinate precision loss. The host bounds locals.
+                let actual = rebased.as_dmat4() * new_point.extend(1.0);
+                let a = actual.truncate() / actual.w;
+                let b = reference.truncate() / reference.w;
+                assert!(
+                    (a.x - b.x).abs() < 0.0001 && (a.y - b.y).abs() < 0.0001,
+                    "origin shift changed projected XY"
+                );
+            }
+        }
+    }
+    #[test]
+    fn ray_offsets_match_the_engines_jittered_projection() {
+        for size in [[960, 540], [1280, 720], [513, 701]] {
+            let projection =
+                Mat4::perspective_rh(1.0, size[0] as f32 / size[1] as f32, 0.1, 10000.0);
+            for frame in [0, 1, 2, 63, 127, 10000] {
+                let j = r1_r2_jitter(frame);
+                let ndc = [j[0] * 2.0 / size[0] as f32, j[1] * 2.0 / size[1] as f32];
+                let shifted = Mat4::from_translation(Vec3::new(ndc[0], ndc[1], 0.0)) * projection;
+                let ray = ray_jitter_from_ndc(ndc, size);
+                for uv in [[0.5, 0.5], [0.1, 0.8], [0.9, 0.2]] {
+                    let actual = shifted.inverse()
+                        * Vec4::new(uv[0] * 2.0 - 1.0, 1.0 - uv[1] * 2.0, 0.5, 1.0);
+                    let expected = projection.inverse()
+                        * Vec4::new(
+                            (uv[0] + ray[0] / size[0] as f32) * 2.0 - 1.0,
+                            1.0 - (uv[1] + ray[1] / size[1] as f32) * 2.0,
+                            0.5,
+                            1.0,
+                        );
+                    assert!(
+                        actual
+                            .truncate()
+                            .normalize()
+                            .distance(expected.truncate().normalize())
+                            < 0.000001
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/passes/3d/helio-pass-tsr/Cargo.toml
+++ b/crates/passes/3d/helio-pass-tsr/Cargo.toml
@@ -10,3 +10,6 @@ helio-core = { workspace = true }
 libhelio   = { workspace = true }
 wgpu       = { workspace = true }
 bytemuck   = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+pollster = { workspace = true }

--- a/crates/passes/3d/helio-pass-tsr/src/camera_sampling_tests.rs
+++ b/crates/passes/3d/helio-pass-tsr/src/camera_sampling_tests.rs
@@ -1,0 +1,122 @@
+use super::*;
+use std::sync::Arc;
+
+#[test]
+fn prepare_uploads_the_actual_camera_sample_and_supplied_frame_time() {
+    let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
+    let adapter = pollster::block_on(instance.request_adapter(&Default::default())).unwrap();
+    let (device, queue) = pollster::block_on(adapter.request_device(&Default::default())).unwrap();
+    let device = Arc::new(device);
+    let queue = Arc::new(queue);
+    let mut scene = helio_core::GpuScene::new(device.clone(), queue.clone());
+    let mut pass = TsrPass::new(
+        &device,
+        32,
+        16,
+        64,
+        32,
+        wgpu::TextureFormat::Rgba8Unorm,
+        TsrQuality::Quality,
+    );
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("read actual TSR uniform upload"),
+        source: wgpu::ShaderSource::Wgsl(
+            r#"
+@group(0) @binding(0) var<uniform> input_data: array<vec4<u32>, 2>;
+@group(0) @binding(1) var<storage, read_write> output_data: array<vec4<u32>, 2>;
+@compute @workgroup_size(1) fn read_uniform() {
+    output_data[0] = input_data[0]; output_data[1] = input_data[1];
+}
+"#
+            .into(),
+        ),
+    });
+    let pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: None,
+        layout: None,
+        module: &shader,
+        entry_point: Some("read_uniform"),
+        compilation_options: Default::default(),
+        cache: None,
+    });
+    let output = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 32,
+        usage: wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_SRC,
+        mapped_at_creation: false,
+    });
+    let staging = device.create_buffer(&wgpu::BufferDescriptor {
+        label: None,
+        size: 32,
+        usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+        mapped_at_creation: false,
+    });
+    let group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: None,
+        layout: &pipeline.get_bind_group_layout(0),
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: pass.uniform_buf.as_entire_binding(),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: output.as_entire_binding(),
+            },
+        ],
+    });
+    for (index, (size, expected, time, frame)) in [
+        ([32, 16], [0.0_f32, 0.0_f32], 1.0_f32 / 60.0, 17),
+        ([32, 16], [0.375, -0.25], 1.0 / 30.0, 991),
+        ([19, 27], [-0.125, 0.375], 1.0 / 120.0, 0),
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let mut camera = libhelio::GpuCameraUniforms::zeroed();
+        camera.jitter_frame = [
+            expected[0] * 2.0 / size[0] as f32,
+            expected[1] * 2.0 / size[1] as f32,
+            123.0,
+            0.0,
+        ];
+        scene.camera.update(camera);
+        pass.prepare(&PrepareContext {
+            device: &device,
+            queue: &queue,
+            scene: &scene,
+            frame_resources: &libhelio::FrameResources::empty(),
+            width: size[0],
+            height: size[1],
+            frame_num: frame,
+            resize: false,
+            delta_time: time,
+        })
+        .unwrap();
+        let mut encoder = device.create_command_encoder(&Default::default());
+        {
+            let mut compute = encoder.begin_compute_pass(&Default::default());
+            compute.set_pipeline(&pipeline);
+            compute.set_bind_group(0, &group, &[]);
+            compute.dispatch_workgroups(1, 1, 1);
+        }
+        encoder.copy_buffer_to_buffer(&output, 0, &staging, 0, 32);
+        queue.submit([encoder.finish()]);
+        let (send, receive) = std::sync::mpsc::channel();
+        staging
+            .slice(..)
+            .map_async(wgpu::MapMode::Read, move |result| {
+                send.send(result).unwrap();
+            });
+        device.poll(wgpu::PollType::wait_indefinitely()).unwrap();
+        receive.recv().unwrap().unwrap();
+        let data = staging.slice(..).get_mapped_range().unwrap();
+        let words: &[u32] = bytemuck::cast_slice(&data);
+        assert!((f32::from_bits(words[0]) - expected[0]).abs() < 1e-6);
+        assert!((f32::from_bits(words[1]) - expected[1]).abs() < 1e-6);
+        assert_eq!(words[3], u32::from(index == 0));
+        assert_eq!(words[4], time.to_bits());
+        drop(data);
+        staging.unmap();
+    }
+}

--- a/crates/passes/3d/helio-pass-tsr/src/lib.rs
+++ b/crates/passes/3d/helio-pass-tsr/src/lib.rs
@@ -54,18 +54,8 @@ struct VertexOut {
 }
 ";
 
-// ── R1/R2 low-discrepancy jitter ──────────────────────────────────────────────
-
-/// R1/R2 low-discrepancy jitter — same sub-pixel sequence as `TaaPass` so
-/// coverage is coherent between the two passes.
-fn r1_r2_jitter(frame: u64) -> [f32; 2] {
-    const INV_R1: f64 = 0.7548776662466927;
-    const INV_R2: f64 = 0.5698402905980539;
-    const PHASE: f64 = 0.5;
-    let fx = frame as f64 * INV_R1 + PHASE;
-    let fy = frame as f64 * INV_R2 + PHASE;
-    [(fx.fract() - 0.5) as f32, (fy.fract() - 0.5) as f32]
-}
+#[cfg(test)]
+mod camera_sampling_tests;
 
 // ── Quality presets ───────────────────────────────────────────────────────────
 
@@ -560,7 +550,13 @@ impl RenderPass for TsrPass {
     }
 
     fn prepare(&mut self, ctx: &PrepareContext) -> HelioResult<()> {
-        let jitter = r1_r2_jitter(ctx.frame_num);
+        // The camera is the sample authority. Reconstructing a separate
+        // sequence here breaks manual offsets and externally owned frame clocks.
+        let ndc = ctx.scene.camera.data().jitter_frame;
+        let jitter = [
+            ndc[0] * ctx.width as f32 * 0.5,
+            ndc[1] * ctx.height as f32 * 0.5,
+        ];
         let reset = if self.first_frame {
             self.first_frame = false;
             1u32


### PR DESCRIPTION
TSR currently regenerates jitter from the render graph's frame counter, which can disagree with the camera after a graph rebuild or when a host supplies its own sampling offset. TSR now reads the camera's actual NDC offset and converts it using the current internal render dimensions.

This also extracts the camera support used by deterministic offline captures: optional projection-jitter and frame-time overrides for the standard non-XR renderer, a shared unchanged R1/R2 sequence and ray-offset conversion, and an explicit helper to re-express retained camera history after a floating-origin change. Defaults preserve the existing renderer sampling and clock behavior. The host remains responsible for rebasing object transforms; the helper cannot recover precision already lost in input matrices.

Validation:
- All 18 `libhelio` unit tests and the TSR GPU upload regression passed.
- The new GPU regression fails against main's original TSR implementation and passes with this change. It reads the actual uploaded uniform for zero/custom jitter, a different graph frame counter, changed internal dimensions, and supplied frame time.
- `cargo check -p helio` and `git diff --check` passed.
- An expanded main-versus-combined-PR comparison (main `c3106597`, this PR plus #244 at `723aae48`, isolated candidate build) preserves all 86 existing passing tests and passes all seven added regressions: 93 passes total, with no reported GPU skips. Both native default-graph material configurations render before and after resize. `cargo check --workspace --all-targets --exclude examples --keep-going` passed.

The full suite still has baseline failures: the same standalone validation errors in unchanged HLFS/transparent shaders, and unchanged examples missing `VolumetricClouds::infinite_extent`. Different examples can be reported because Cargo stops early; their source and cloud type definition are unchanged. Initial shared-target candidate runs reused stale baseline libraries and were discarded in favor of the isolated rerun. GitHub's existing workflow checks only the placeholder root package, so its green result is not engine validation.

Based on current main `c3106597`, independent of the planet crate and PR #244. The small Scene method updates temporal camera history only; it does not alter the authored-object ownership/data-flow redesign in #231. No broader TSR reconstruction, shader-quality, or XR changes are included. End-to-end visual quality and rendering speed improvements are not claimed by these checks.
